### PR TITLE
Allow to run multiple replicas

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,10 +27,10 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/K8sNetworkPlumbingWG/kubemacpool/pkg/controller"
+	"github.com/K8sNetworkPlumbingWG/kubemacpool/pkg/manager"
 	poolmanager "github.com/K8sNetworkPlumbingWG/kubemacpool/pkg/pool-manager"
 	"github.com/K8sNetworkPlumbingWG/kubemacpool/pkg/webhook"
 )

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -27,7 +27,7 @@ metadata:
     control-plane: mac-controller-manager
     controller-tools.k8s.io: "1.0"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       control-plane: mac-controller-manager
@@ -72,6 +72,13 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        readinessProbe:
+          exec:
+            command:
+              - cat
+              - /tmp/healthy
+          initialDelaySeconds: 15
+          periodSeconds: 5
         ports:
         - containerPort: 9876
           name: webhook-server

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -151,7 +151,7 @@ metadata:
   name: kubemacpool-mac-controller-manager
   namespace: kubemacpool-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       control-plane: mac-controller-manager
@@ -192,6 +192,13 @@ spec:
         - containerPort: 9876
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+          initialDelaySeconds: 15
+          periodSeconds: 5
         resources:
           limits:
             cpu: 100m

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -151,7 +151,7 @@ metadata:
   name: kubemacpool-mac-controller-manager
   namespace: kubemacpool-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       control-plane: mac-controller-manager
@@ -192,6 +192,13 @@ spec:
         - containerPort: 9876
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+          initialDelaySeconds: 15
+          periodSeconds: 5
         resources:
           limits:
             cpu: 100m

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ Same file as vendor/sigs.k8s.io/controller-runtime/pkg/manager/internal.go
+ The change is on the startLeaderElection function.
+ when we get the election lock we create a file.
+ This file is watch by the kubernetes readinessProbe.
+ When the pod because ready it will be added to the service for the webhook.
+ This way we have only one mutating webhook active.
+*/
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+var log = logf.KBLog.WithName("manager")
+
+type controllerManager struct {
+	// config is the rest.config used to talk to the apiserver.  Required.
+	config *rest.Config
+
+	// scheme is the scheme injected into Controllers, EventHandlers, Sources and Predicates.  Defaults
+	// to scheme.scheme.
+	scheme *runtime.Scheme
+	// admissionDecoder is used to decode an admission.Request.
+	admissionDecoder types.Decoder
+
+	// runnables is the set of Controllers that the controllerManager injects deps into and Starts.
+	runnables []manager.Runnable
+
+	cache cache.Cache
+
+	// TODO(directxman12): Provide an escape hatch to get individual indexers
+	// client is the client injected into Controllers (and EventHandlers, Sources and Predicates).
+	client client.Client
+
+	// fieldIndexes knows how to add field indexes over the Cache used by this controller,
+	// which can later be consumed via field selectors from the injected client.
+	fieldIndexes client.FieldIndexer
+
+	// recorderProvider is used to generate event recorders that will be injected into Controllers
+	// (and EventHandlers, Sources and Predicates).
+	recorderProvider recorder.Provider
+
+	// resourceLock forms the basis for leader election
+	resourceLock resourcelock.Interface
+
+	// mapper is used to map resources to kind, and map kind and version.
+	mapper meta.RESTMapper
+
+	// metricsListener is used to serve prometheus metrics
+	metricsListener net.Listener
+
+	mu      sync.Mutex
+	started bool
+	errChan chan error
+
+	// internalStop is the stop channel *actually* used by everything involved
+	// with the manager as a stop channel, so that we can pass a stop channel
+	// to things that need it off the bat (like the Channel source).  It can
+	// be closed via `internalStopper` (by being the same underlying channel).
+	internalStop <-chan struct{}
+
+	// internalStopper is the write side of the internal stop channel, allowing us to close it.
+	// It and `internalStop` should point to the same channel.
+	internalStopper chan<- struct{}
+
+	startCache func(stop <-chan struct{}) error
+}
+
+// Add sets dependencies on i, and adds it to the list of runnables to start.
+func (cm *controllerManager) Add(r manager.Runnable) error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	// Set dependencies on the object
+	if err := cm.SetFields(r); err != nil {
+		return err
+	}
+
+	// Add the runnable to the list
+	cm.runnables = append(cm.runnables, r)
+	if cm.started {
+		// If already started, start the controller
+		go func() {
+			cm.errChan <- r.Start(cm.internalStop)
+		}()
+	}
+
+	return nil
+}
+
+func (cm *controllerManager) SetFields(i interface{}) error {
+	if _, err := inject.ConfigInto(cm.config, i); err != nil {
+		return err
+	}
+	if _, err := inject.ClientInto(cm.client, i); err != nil {
+		return err
+	}
+	if _, err := inject.SchemeInto(cm.scheme, i); err != nil {
+		return err
+	}
+	if _, err := inject.CacheInto(cm.cache, i); err != nil {
+		return err
+	}
+	if _, err := inject.InjectorInto(cm.SetFields, i); err != nil {
+		return err
+	}
+	if _, err := inject.StopChannelInto(cm.internalStop, i); err != nil {
+		return err
+	}
+	if _, err := inject.DecoderInto(cm.admissionDecoder, i); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cm *controllerManager) GetConfig() *rest.Config {
+	return cm.config
+}
+
+func (cm *controllerManager) GetClient() client.Client {
+	return cm.client
+}
+
+func (cm *controllerManager) GetScheme() *runtime.Scheme {
+	return cm.scheme
+}
+
+func (cm *controllerManager) GetAdmissionDecoder() types.Decoder {
+	return cm.admissionDecoder
+}
+
+func (cm *controllerManager) GetFieldIndexer() client.FieldIndexer {
+	return cm.fieldIndexes
+}
+
+func (cm *controllerManager) GetCache() cache.Cache {
+	return cm.cache
+}
+
+func (cm *controllerManager) GetRecorder(name string) record.EventRecorder {
+	return cm.recorderProvider.GetEventRecorderFor(name)
+}
+
+func (cm *controllerManager) GetRESTMapper() meta.RESTMapper {
+	return cm.mapper
+}
+
+func (cm *controllerManager) serveMetrics(stop <-chan struct{}) {
+	handler := promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
+	})
+	// TODO(JoelSpeed): Use existing Kubernetes machinery for serving metrics
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", handler)
+	server := http.Server{
+		Handler: mux,
+	}
+	// Run the server
+	go func() {
+		if err := server.Serve(cm.metricsListener); err != nil && err != http.ErrServerClosed {
+			cm.errChan <- err
+		}
+	}()
+
+	// Shutdown the server when stop is closed
+	select {
+	case <-stop:
+		if err := server.Shutdown(context.Background()); err != nil {
+			cm.errChan <- err
+		}
+	}
+}
+
+func (cm *controllerManager) Start(stop <-chan struct{}) error {
+	// join the passed-in stop channel as an upstream feeding into cm.internalStopper
+	defer close(cm.internalStopper)
+
+	// Metrics should be served whether the controller is leader or not.
+	// (If we don't serve metrics for non-leaders, prometheus will still scrape
+	// the pod but will get a connection refused)
+	if cm.metricsListener != nil {
+		go cm.serveMetrics(cm.internalStop)
+	}
+
+	if cm.resourceLock != nil {
+		err := cm.startLeaderElection()
+		if err != nil {
+			return err
+		}
+	} else {
+		go cm.start()
+	}
+
+	select {
+	case <-stop:
+		// We are done
+		return nil
+	case err := <-cm.errChan:
+		// Error starting a controller
+		return err
+	}
+}
+
+func (cm *controllerManager) start() {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	// Start the Cache. Allow the function to start the cache to be mocked out for testing
+	if cm.startCache == nil {
+		cm.startCache = cm.cache.Start
+	}
+	go func() {
+		if err := cm.startCache(cm.internalStop); err != nil {
+			cm.errChan <- err
+		}
+	}()
+
+	// Wait for the caches to sync.
+	// TODO(community): Check the return value and write a test
+	cm.cache.WaitForCacheSync(cm.internalStop)
+
+	// Start the runnables after the cache has synced
+	for _, c := range cm.runnables {
+		// Controllers block, but we want to return an error if any have an error starting.
+		// Write any Start errors to a channel so we can return them
+		ctrl := c
+		go func() {
+			cm.errChan <- ctrl.Start(cm.internalStop)
+		}()
+	}
+
+	cm.started = true
+}
+
+func (cm *controllerManager) startLeaderElection() (err error) {
+	l, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock: cm.resourceLock,
+		// Values taken from: https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/v1alpha1/defaults.go
+		// TODO(joelspeed): These timings should be configurable
+		LeaseDuration: 15 * time.Second,
+		RenewDeadline: 10 * time.Second,
+		RetryPeriod:   2 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(_ context.Context) {
+				// **This function is the change from the original package**
+				log.V(1).Info("leader elected starting manager")
+				cm.start()
+				if !cm.started {
+					cm.errChan <- fmt.Errorf("manager failed to start")
+					return
+				}
+
+				log.V(1).Info("manager stated")
+				f, err := os.Create("/tmp/healthy")
+				if err != nil {
+					cm.errChan <- fmt.Errorf("failed to create healthy file")
+				} else {
+					defer f.Close()
+					_, err = f.Write([]byte("Leader"))
+					if err != nil {
+						cm.errChan <- fmt.Errorf("failed to write into the healthy file")
+					}
+				}
+			},
+			OnStoppedLeading: func() {
+				os.Remove("/tmp/healthy")
+				// Most implementations of leader election log.Fatal() here.
+				// Since Start is wrapped in log.Fatal when called, we can just return
+				// an error here which will cause the program to exit.
+				cm.errChan <- fmt.Errorf("leader election lost")
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Start the leader elector process
+	go l.Run(context.Background())
+	return nil
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ Same file as vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go
+*/
+
+package manager
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	internalrecorder "github.com/K8sNetworkPlumbingWG/kubemacpool/pkg/manager/recorder"
+)
+
+// Options are the arguments for creating a new Manager
+type Options struct {
+	// Scheme is the scheme used to resolve runtime.Objects to GroupVersionKinds / Resources
+	// Defaults to the kubernetes/client-go scheme.Scheme
+	Scheme *runtime.Scheme
+
+	// MapperProvider provides the rest mapper used to map go types to Kubernetes APIs
+	MapperProvider func(c *rest.Config) (meta.RESTMapper, error)
+
+	// SyncPeriod determines the minimum frequency at which watched resources are
+	// reconciled. A lower period will correct entropy more quickly, but reduce
+	// responsiveness to change if there are many watched resources. Change this
+	// value only if you know what you are doing. Defaults to 10 hours if unset.
+	SyncPeriod *time.Duration
+
+	// LeaderElection determines whether or not to use leader election when
+	// starting the manager.
+	LeaderElection bool
+
+	// LeaderElectionNamespace determines the namespace in which the leader
+	// election configmap will be created.
+	LeaderElectionNamespace string
+
+	// LeaderElectionID determines the name of the configmap that leader election
+	// will use for holding the leader lock.
+	LeaderElectionID string
+
+	// Namespace if specified restricts the manager's cache to watch objects in the desired namespace
+	// Defaults to all namespaces
+	// Note: If a namespace is specified then controllers can still Watch for a cluster-scoped resource e.g Node
+	// For namespaced resources the cache will only hold objects from the desired namespace.
+	Namespace string
+
+	// MetricsBindAddress is the TCP address that the controller should bind to
+	// for serving prometheus metrics
+	MetricsBindAddress string
+
+	// Functions to all for a user to customize the values that will be injected.
+
+	// NewCache is the function that will create the cache to be used
+	// by the manager. If not set this will use the default new cache function.
+	NewCache NewCacheFunc
+
+	// NewClient will create the client to be used by the manager.
+	// If not set this will create the default DelegatingClient that will
+	// use the cache for reads and the client for writes.
+	NewClient NewClientFunc
+
+	// Dependency injection for testing
+	newRecorderProvider func(config *rest.Config, scheme *runtime.Scheme, logger logr.Logger) (recorder.Provider, error)
+	newResourceLock     func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error)
+	newAdmissionDecoder func(scheme *runtime.Scheme) (types.Decoder, error)
+	newMetricsListener  func(addr string) (net.Listener, error)
+}
+
+// NewCacheFunc allows a user to define how to create a cache
+type NewCacheFunc func(config *rest.Config, opts cache.Options) (cache.Cache, error)
+
+// NewClientFunc allows a user to define how to create a client
+type NewClientFunc func(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error)
+
+// New returns a new Manager for creating Controllers.
+func New(config *rest.Config, options Options) (manager.Manager, error) {
+	// Initialize a rest.config if none was specified
+	if config == nil {
+		return nil, fmt.Errorf("must specify Config")
+	}
+
+	// Set default values for options fields
+	options = setOptionsDefaults(options)
+
+	// Create the mapper provider
+	mapper, err := options.MapperProvider(config)
+	if err != nil {
+		log.Error(err, "Failed to get API Group-Resources")
+		return nil, err
+	}
+
+	// Create the cache for the cached read client and registering informers
+	cache, err := options.NewCache(config, cache.Options{Scheme: options.Scheme, Mapper: mapper, Resync: options.SyncPeriod, Namespace: options.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	writeObj, err := options.NewClient(cache, config, client.Options{Scheme: options.Scheme, Mapper: mapper})
+	if err != nil {
+		return nil, err
+	}
+	// Create the recorder provider to inject event recorders for the components.
+	// TODO(directxman12): the log for the event provider should have a context (name, tags, etc) specific
+	// to the particular controller that it's being injected into, rather than a generic one like is here.
+	recorderProvider, err := options.newRecorderProvider(config, options.Scheme, log.WithName("events"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the resource lock to enable leader election)
+	resourceLock, err := options.newResourceLock(config, recorderProvider, leaderelection.Options{
+		LeaderElection:          options.LeaderElection,
+		LeaderElectionID:        options.LeaderElectionID,
+		LeaderElectionNamespace: options.LeaderElectionNamespace,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	admissionDecoder, err := options.newAdmissionDecoder(options.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the mertics listener. This will throw an error if the metrics bind
+	// address is invalid or already in use.
+	metricsListener, err := options.newMetricsListener(options.MetricsBindAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	stop := make(chan struct{})
+
+	return &controllerManager{
+		config:           config,
+		scheme:           options.Scheme,
+		admissionDecoder: admissionDecoder,
+		errChan:          make(chan error),
+		cache:            cache,
+		fieldIndexes:     cache,
+		client:           writeObj,
+		recorderProvider: recorderProvider,
+		resourceLock:     resourceLock,
+		mapper:           mapper,
+		metricsListener:  metricsListener,
+		internalStop:     stop,
+		internalStopper:  stop,
+	}, nil
+}
+
+// defaultNewClient creates the default caching client
+func defaultNewClient(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
+	// Create the Client for Write operations.
+	c, err := client.New(config, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client.DelegatingClient{
+		Reader: &client.DelegatingReader{
+			CacheReader:  cache,
+			ClientReader: c,
+		},
+		Writer:       c,
+		StatusClient: c,
+	}, nil
+}
+
+// setOptionsDefaults set default values for Options fields
+func setOptionsDefaults(options Options) Options {
+	// Use the Kubernetes client-go scheme if none is specified
+	if options.Scheme == nil {
+		options.Scheme = scheme.Scheme
+	}
+
+	if options.MapperProvider == nil {
+		options.MapperProvider = apiutil.NewDiscoveryRESTMapper
+	}
+
+	// Allow newClient to be mocked
+	if options.NewClient == nil {
+		options.NewClient = defaultNewClient
+	}
+
+	// Allow newCache to be mocked
+	if options.NewCache == nil {
+		options.NewCache = cache.New
+	}
+
+	// Allow newRecorderProvider to be mocked
+	if options.newRecorderProvider == nil {
+		options.newRecorderProvider = internalrecorder.NewProvider
+	}
+
+	// Allow newResourceLock to be mocked
+	if options.newResourceLock == nil {
+		options.newResourceLock = leaderelection.NewResourceLock
+	}
+
+	if options.newAdmissionDecoder == nil {
+		options.newAdmissionDecoder = admission.NewDecoder
+	}
+
+	if options.newMetricsListener == nil {
+		options.newMetricsListener = metrics.NewListener
+	}
+
+	return options
+}

--- a/pkg/manager/recorder/recorder.go
+++ b/pkg/manager/recorder/recorder.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ Same file as vendor/sigs.k8s.io/controller-runtime/pkg/manager/recorder/recorder.go
+*/
+
+package recorder
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
+)
+
+type provider struct {
+	// scheme to specify when creating a recorder
+	scheme *runtime.Scheme
+	// eventBroadcaster to create new recorder instance
+	eventBroadcaster record.EventBroadcaster
+	// logger is the logger to use when logging diagnostic event info
+	logger logr.Logger
+}
+
+// NewProvider create a new Provider instance.
+func NewProvider(config *rest.Config, scheme *runtime.Scheme, logger logr.Logger) (recorder.Provider, error) {
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init clientSet: %v", err)
+	}
+
+	p := &provider{scheme: scheme, logger: logger}
+	p.eventBroadcaster = record.NewBroadcaster()
+	p.eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
+	p.eventBroadcaster.StartEventWatcher(
+		func(e *corev1.Event) {
+			p.logger.V(1).Info(e.Type, "object", e.InvolvedObject, "reason", e.Reason, "message", e.Message)
+		})
+
+	return p, nil
+}
+
+func (p *provider) GetEventRecorderFor(name string) record.EventRecorder {
+	return p.eventBroadcaster.NewRecorder(p.scheme, corev1.EventSource{Component: name})
+}


### PR DESCRIPTION
Copy the manager code from controller runtime and change it.
With the new manager the controller will became ready only when it became leader.

most of the code is the same as the regular manager I just change the leader election function.
When a controller take the leader he also create a file under `/tmp/healthy` this way the pod will became ready.
When the pod became ready it will be added as an endpoint for the admission webhook service