### PR TITLE
Add owner reference for the mutating webhook

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -30,7 +30,6 @@ REGISTRY=$registry make docker-push
 make docker-generate
 
 ./cluster/kubectl.sh delete --ignore-not-found -f ./config/test/kubemacpool.yaml || true
-./cluster/kubectl.sh delete --ignore-not-found mutatingwebhookconfigurations mutating-webhook-configuration
 
 # Wait until all objects are deleted
 until [[ `./cluster/kubectl.sh get ns | grep "kubemacpool-system " | wc -l` -eq 0 ]]; do

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -111,6 +111,11 @@ func main() {
 	startPoolRange := loadMacAddressFromEnvVar(poolmanager.StartPoolRangeEnv)
 	endPoolRange := loadMacAddressFromEnvVar(poolmanager.EndPoolRangeEnv)
 
+	// create a owner ref on the mutating webhook
+	// this way when we remove the statefulset of the manager the webhook will be also removed from the cluster
+	err = webhook.CreateOwnerRefForMutatingWebhook(clientset)
+	ExitIfError(err, "unable to create owner reference for mutating webhook object")
+
 	isKubevirtInstalled := checkForKubevirt(clientset)
 	poolManager, err := poolmanager.NewPoolManager(clientset, startPoolRange, endPoolRange, isKubevirtInstalled)
 	ExitIfError(err, "unable to create pool manager")

--- a/config/default/rbac/rbac_role.yaml
+++ b/config/default/rbac/rbac_role.yaml
@@ -80,6 +80,17 @@ rules:
   - get
   - list
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - list
+  - watch
+- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachines

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -88,6 +88,17 @@ rules:
   - get
   - list
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - list
+  - watch
+- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachines

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -88,6 +88,17 @@ rules:
   - get
   - list
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - list
+  - watch
+- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachines


### PR DESCRIPTION
This way when we remove the statefulset the webhook will be removed as well.

This PR also change the name of the hook from `mutating-webhook-configuration` to `kubemacpool`

This should fix https://github.com/kubevirt/cluster-network-addons-operator/issues/33