### PR TITLE
Revert mac allocation

### DIFF
--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -121,6 +121,12 @@ func (p *PoolManager) InitMaps() error {
 	return nil
 }
 
+func (p *PoolManager) releaseAllocations(allocations []string) {
+	for _, macAddr := range allocations {
+		delete(p.macPoolMap, macAddr)
+	}
+}
+
 func checkRange(startMac, endMac net.HardwareAddr) error {
 	for idx := 0; idx <= 5; idx++ {
 		if startMac[idx] < endMac[idx] {


### PR DESCRIPTION
This PR allow to revert allocations if there was a problem allocating one of the interfaces.

The allocation could fail if there is not enough free mac addresses in the pool for all the interfaces, if the user request a mac that is already allocated or invalid.