### PR TITLE
Remove the readinessProbe

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -72,13 +72,6 @@ spec:
           requests:
             cpu: 500m
             memory: 500Mi
-        readinessProbe:
-          exec:
-            command:
-              - cat
-              - /tmp/healthy
-          initialDelaySeconds: 15
-          periodSeconds: 5
         ports:
         - containerPort: 9876
           name: webhook-server

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -192,13 +192,6 @@ spec:
         - containerPort: 9876
           name: webhook-server
           protocol: TCP
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
-          initialDelaySeconds: 15
-          periodSeconds: 5
         resources:
           limits:
             cpu: 800m

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -192,13 +192,6 @@ spec:
         - containerPort: 9876
           name: webhook-server
           protocol: TCP
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
-          initialDelaySeconds: 15
-          periodSeconds: 5
         resources:
           limits:
             cpu: 800m


### PR DESCRIPTION
We don't need this any more after chainging the manager to one replica