### PR TITLE
Test for unicast validation

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -17,7 +17,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
 data:
   RANGE_START: 02:00:00:00:00:00
-  RANGE_END: FD:FF:FF:FF:FF:FF
+  RANGE_END: 02:FF:FF:FF:FF:FF
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -127,7 +127,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  RANGE_END: FD:FF:FF:FF:FF:FF
+  RANGE_END: 02:FF:FF:FF:FF:FF
   RANGE_START: "02:00:00:00:00:00"
 kind: ConfigMap
 metadata:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -127,7 +127,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  RANGE_END: FD:FF:FF:FF:FF:FF
+  RANGE_END: 02:FF:FF:FF:FF:FF
   RANGE_START: "02:00:00:00:00:00"
 kind: ConfigMap
 metadata:

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -18,8 +18,9 @@ package pool_manager
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"net"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	kubevirt "kubevirt.io/kubevirt/pkg/api/v1"


### PR DESCRIPTION
A test for  the function checkCast(), which is used when creating
a new pool manager to verify that the first octet of the ranges
is 02,06,0A or 0E.