### PR TITLE
Add namespace to vm object if not exist

### DIFF
--- a/pkg/webhook/virtualmachine/virtualmachine.go
+++ b/pkg/webhook/virtualmachine/virtualmachine.go
@@ -78,6 +78,9 @@ func (a *virtualMachineAnnotator) Handle(ctx context.Context, req types.Request)
 		return admission.ErrorResponse(http.StatusBadRequest, err)
 	}
 	copyObject := virtualMachine.DeepCopy()
+	if copyObject.Namespace == "" {
+		copyObject.Namespace = req.AdmissionRequest.Namespace
+	}
 
 	err = a.mutateVirtualMachinesFn(ctx, copyObject)
 	if err != nil {


### PR DESCRIPTION
If the vm object doesn't have a namespace variable we take the namespace from the request and add it to the vm object.