### PR TITLE
Fix multiple yaml apply

### DIFF
--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -270,7 +270,9 @@ func (p *PoolManager) allocatedToCurrentPod(podname string, network *multus.Netw
 // Revert allocation if one of the requested mac addresses fails to be allocated
 func (p *PoolManager) revertAllocationOnPod(podName string, allocations []string) {
 	log.V(1).Info("Rever vm allocation", "podName", podName, "allocations", allocations)
-	p.releaseAllocations(allocations)
+	for _, value := range allocations {
+		delete(p.macPoolMap, value)
+	}
 	delete(p.podToMacPoolMap, podName)
 }
 

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -133,12 +133,6 @@ func (p *PoolManager) InitMaps() error {
 	return nil
 }
 
-func (p *PoolManager) releaseAllocations(allocations []string) {
-	for _, macAddr := range allocations {
-		delete(p.macPoolMap, macAddr)
-	}
-}
-
 func checkRange(startMac, endMac net.HardwareAddr) error {
 	for idx := 0; idx <= 5; idx++ {
 		if startMac[idx] < endMac[idx] {

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -41,7 +41,7 @@ type PoolManager struct {
 	currentMac      net.HardwareAddr             // last given mac
 	macPoolMap      map[string]AllocationStatus  // allocated mac map and status
 	podToMacPoolMap map[string]map[string]string // map allocated mac address by networkname and namespace/podname: {"namespace/podname: {"network name": "mac address"}}
-	vmToMacPoolMap  map[string][]string          // cap for namespace/vmname and a list of allocated mac addresses
+	vmToMacPoolMap  map[string]map[string]string // map for namespace/vmname and a map of interface name with allocated mac address
 	poolMutex       sync.Mutex                   // mutex for allocation an release
 	isLeader        bool                         // leader boolean
 	isKubevirt      bool                         // bool if kubevirt virtualmachine crd exist in the cluster
@@ -70,7 +70,7 @@ func NewPoolManager(kubeClient kubernetes.Interface, rangeStart, rangeEnd net.Ha
 		rangeStart:      rangeStart,
 		currentMac:      currentMac,
 		podToMacPoolMap: map[string]map[string]string{},
-		vmToMacPoolMap:  map[string][]string{},
+		vmToMacPoolMap:  map[string]map[string]string{},
 		macPoolMap:      map[string]AllocationStatus{},
 		poolMutex:       sync.Mutex{}}
 

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Pool", func() {
 			macAddress, exist := poolManager.vmToMacPoolMap[vmNamespaced(&newVM)]
 			Expect(exist).To(BeTrue())
 			Expect(len(macAddress)).To(Equal(1))
-			Expect(macAddress[0]).To(Equal("02:00:00:00:00:01"))
+			Expect(macAddress["pod"]).To(Equal("02:00:00:00:00:01"))
 
 			err = poolManager.ReleaseVirtualMachineMac(vmNamespaced(&newVM))
 			Expect(err).ToNot(HaveOccurred())
@@ -208,8 +208,8 @@ var _ = Describe("Pool", func() {
 			macAddress, exist := poolManager.vmToMacPoolMap[vmNamespaced(&newVM)]
 			Expect(exist).To(BeTrue())
 			Expect(len(macAddress)).To(Equal(2))
-			Expect(macAddress[0]).To(Equal("02:00:00:00:00:01"))
-			Expect(macAddress[1]).To(Equal("02:00:00:00:00:02"))
+			Expect(macAddress["pod"]).To(Equal("02:00:00:00:00:01"))
+			Expect(macAddress["multus"]).To(Equal("02:00:00:00:00:02"))
 
 			err = poolManager.ReleaseVirtualMachineMac(vmNamespaced(&newVM))
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -57,7 +57,7 @@ func (p *PoolManager) AllocateVirtualMachineMac(virtualMachine *kubevirt.Virtual
 		"interfaces", virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces)
 
 	copyVM := virtualMachine.DeepCopy()
-	allocations := []string{}
+	allocations := map[string]string{}
 	for idx, iface := range copyVM.Spec.Template.Spec.Domain.Devices.Interfaces {
 		if iface.Masquerade == nil && iface.Slirp == nil && networks[iface.Name].Multus == nil {
 			log.Info("mac address can be set only for interface of type masquerade and slirp on the pod network")
@@ -65,19 +65,19 @@ func (p *PoolManager) AllocateVirtualMachineMac(virtualMachine *kubevirt.Virtual
 		}
 
 		if iface.MacAddress != "" {
-			if err := p.allocateRequestedVirtualMachineInterfaceMac(iface.MacAddress, copyVM); err != nil {
+			if err := p.allocateRequestedVirtualMachineInterfaceMac(copyVM, iface); err != nil {
 				p.revertAllocationOnVm(vmNamespaced(copyVM), allocations)
 				return err
 			}
-			allocations = append(allocations, iface.MacAddress)
+			allocations[iface.Name] = iface.MacAddress
 		} else {
-			macAddr, err := p.allocateFromPoolForVirtualMachine(copyVM)
+			macAddr, err := p.allocateFromPoolForVirtualMachine(copyVM, iface)
 			if err != nil {
 				p.revertAllocationOnVm(vmNamespaced(copyVM), allocations)
 				return err
 			}
 			copyVM.Spec.Template.Spec.Domain.Devices.Interfaces[idx].MacAddress = macAddr
-			allocations = append(allocations, macAddr)
+			allocations[iface.Name] = iface.MacAddress
 		}
 	}
 
@@ -117,7 +117,7 @@ func (p *PoolManager) ReleaseVirtualMachineMac(virtualMachineName string) error 
 	return nil
 }
 
-func (p *PoolManager) allocateFromPoolForVirtualMachine(virtualMachine *kubevirt.VirtualMachine) (string, error) {
+func (p *PoolManager) allocateFromPoolForVirtualMachine(virtualMachine *kubevirt.VirtualMachine, iface kubevirt.Interface) (string, error) {
 	macAddr, err := p.getFreeMac()
 	if err != nil {
 		return "", err
@@ -125,9 +125,9 @@ func (p *PoolManager) allocateFromPoolForVirtualMachine(virtualMachine *kubevirt
 
 	p.macPoolMap[macAddr.String()] = AllocationStatusAllocated
 	if p.vmToMacPoolMap[vmNamespaced(virtualMachine)] == nil {
-		p.vmToMacPoolMap[vmNamespaced(virtualMachine)] = []string{}
+		p.vmToMacPoolMap[vmNamespaced(virtualMachine)] = make(map[string]string)
 	}
-	p.vmToMacPoolMap[vmNamespaced(virtualMachine)] = append(p.vmToMacPoolMap[vmNamespaced(virtualMachine)], macAddr.String())
+	p.vmToMacPoolMap[vmNamespaced(virtualMachine)][iface.Name] = macAddr.String()
 	log.Info("mac from pool was allocated for virtual machine",
 		"allocatedMac", macAddr.String(),
 		"virtualMachineName", virtualMachine.Name,
@@ -135,7 +135,8 @@ func (p *PoolManager) allocateFromPoolForVirtualMachine(virtualMachine *kubevirt
 	return macAddr.String(), nil
 }
 
-func (p *PoolManager) allocateRequestedVirtualMachineInterfaceMac(requestedMac string, virtualMachine *kubevirt.VirtualMachine) error {
+func (p *PoolManager) allocateRequestedVirtualMachineInterfaceMac(virtualMachine *kubevirt.VirtualMachine, iface kubevirt.Interface) error {
+	requestedMac := iface.MacAddress
 	if _, err := net.ParseMAC(requestedMac); err != nil {
 		return err
 	}
@@ -149,10 +150,10 @@ func (p *PoolManager) allocateRequestedVirtualMachineInterfaceMac(requestedMac s
 
 	p.macPoolMap[requestedMac] = AllocationStatusAllocated
 	if p.vmToMacPoolMap[vmNamespaced(virtualMachine)] == nil {
-		p.vmToMacPoolMap[vmNamespaced(virtualMachine)] = []string{}
+		p.vmToMacPoolMap[vmNamespaced(virtualMachine)] = make(map[string]string)
 	}
 
-	p.vmToMacPoolMap[vmNamespaced(virtualMachine)] = append(p.vmToMacPoolMap[vmNamespaced(virtualMachine)], requestedMac)
+	p.vmToMacPoolMap[vmNamespaced(virtualMachine)][iface.Name] = requestedMac
 	log.Info("requested mac was allocated for virtual machine",
 		"requestedMap", requestedMac,
 		"virtualMachineName", virtualMachine.Name,
@@ -207,7 +208,7 @@ func (p *PoolManager) initVirtualMachineMap() error {
 			}
 
 			if iface.MacAddress != "" {
-				if err := p.allocateRequestedVirtualMachineInterfaceMac(iface.MacAddress, &vm); err != nil {
+				if err := p.allocateRequestedVirtualMachineInterfaceMac(&vm, iface); err != nil {
 					// Dont return an error here if we can't allocate a mac for a configured vm
 					log.Error(fmt.Errorf("failed to parse mac address for virtual machine"),
 						"Invalid mac address for virtual machine",
@@ -253,9 +254,15 @@ func (p *PoolManager) isRelatedToKubevirt(pod *corev1.Pod) bool {
 }
 
 // Revert allocation if one of the requested mac addresses fails to be allocated
-func (p *PoolManager) revertAllocationOnVm(vmName string, allocations []string) {
+func (p *PoolManager) revertAllocationOnVm(vmName string, allocations map[string]string) {
 	log.V(1).Info("Rever vm allocation", "vmName", vmName, "allocations", allocations)
-	p.releaseAllocations(allocations)
+	allocationsList := make([]string, len(allocations))
+	idx := 0
+	for _, value := range allocations {
+		allocationsList[idx] = value
+		idx++
+	}
+	p.releaseAllocations(allocationsList)
 	delete(p.vmToMacPoolMap, vmName)
 }
 


### PR DESCRIPTION
Add virtual machine update webhook
    
Add update handler for virtual machines objects.

This PR fix an issue when the user try to apply the same vm again.

Before this PR if the issue apply the yaml file again the mac addresses allocated by the kubemacpool will disapear from the vm object.

We support now to apply the same yaml again and all the allocated addresses will be reserved but also add and remove interfaces.