### PR TITLE
Add a cleanup loop for failed vm

### DIFF
--- a/pkg/controller/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualmachine/virtualmachine_controller.go
@@ -96,5 +96,6 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, err
 	}
 
+	r.poolManager.MarkVMAsReady(fmt.Sprintf("%s/%s", request.Namespace, request.Name))
 	return reconcile.Result{}, nil
 }

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -364,6 +364,61 @@ var _ = Describe("Virtual Machines", func() {
 				}
 			})
 		})
+		Context("When we re-apply a failed VM yaml", func() {
+			It("should allow to assign to the VM the same MAC addresses, name as requested before and do not return an error", func() {
+				err := setRange(rangeStart, rangeEnd)
+				Expect(err).ToNot(HaveOccurred())
+
+				vm1 := CreateVmObject(TestNamespace, false,
+					[]kubevirtv1.Interface{newInterface("br1", "02:00:ff:ff:ff:ff")},
+					[]kubevirtv1.Network{newNetwork("br1"), newNetwork("br2")})
+
+				baseVM := vm1.DeepCopy()
+
+				Eventually(func() bool {
+					err := testClient.VirtClient.Create(context.TODO(), vm1)
+					if err != nil && strings.Contains(err.Error(), "every network must be mapped to an interface") {
+						return true
+					}
+					return false
+
+				}, 40*time.Second, 5*time.Second).Should(BeTrue(), "failed to apply the new vm object")
+
+				baseVM.Spec.Template.Spec.Domain.Devices.Interfaces = append(baseVM.Spec.Template.Spec.Domain.Devices.Interfaces, newInterface("br2", ""))
+
+				Eventually(func() error {
+					return testClient.VirtClient.Create(context.TODO(), baseVM)
+
+				}, 50*time.Second, 5*time.Second).Should(Not(HaveOccurred()), "failed to apply the new vm object error")
+			})
+			It("should allow to assign to the VM the same MAC addresses, different name as requested before and do not return an error", func() {
+				err := setRange(rangeStart, rangeEnd)
+				Expect(err).ToNot(HaveOccurred())
+
+				vm1 := CreateVmObject(TestNamespace, false,
+					[]kubevirtv1.Interface{newInterface("br1", "02:00:ff:ff:ff:ff")},
+					[]kubevirtv1.Network{newNetwork("br1"), newNetwork("br2")})
+
+				baseVM := vm1.DeepCopy()
+				baseVM.Name = "new-vm"
+
+				Eventually(func() bool {
+					err := testClient.VirtClient.Create(context.TODO(), vm1)
+					if err != nil && strings.Contains(err.Error(), "every network must be mapped to an interface") {
+						return true
+					}
+					return false
+
+				}, 40*time.Second, 5*time.Second).Should(BeTrue(), "failed to apply the new vm object")
+
+				baseVM.Spec.Template.Spec.Domain.Devices.Interfaces = append(baseVM.Spec.Template.Spec.Domain.Devices.Interfaces, newInterface("br2", ""))
+
+				Eventually(func() error {
+					return testClient.VirtClient.Create(context.TODO(), baseVM)
+
+				}, 50*time.Second, 5*time.Second).Should(Not(HaveOccurred()), "failed to apply the new vm object error")
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
Before this PR we have an issue if the vm creation fails because there
is an validation error from the virt-api we didn't clean the allocation.

This PR introduce a cleanup loop into the system.
When we hit the create vm mutating webhook we create the regular
allocation but we also configure the vm in a wait map.
We have a waiting look the will check if the object is removed from the
map and if is not after 3-6 second we assume the object wasn't saved
into the etcd (no controller event) so we release the object.