### PR TITLE
Change Cert to file system mode

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -38,12 +38,5 @@ resources:
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
 
-vars:
-- fieldref: {}
-  name: WEBHOOK_SECRET_NAME
-  objref:
-    apiVersion: v1
-    kind: Secret
-    name: webhook-secret
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -53,8 +53,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SECRET_NAME
-            value: $(WEBHOOK_SECRET_NAME)
           - name: RANGE_START
             valueFrom:
               configMapKeyRef:
@@ -76,19 +74,4 @@ spec:
         - containerPort: 9876
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/cert
-          name: cert
-          readOnly: true
       terminationGracePeriodSeconds: 5
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: webhook-secret
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: webhook-secret
-  namespace: system

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -137,12 +137,6 @@ metadata:
   name: kubemacpool-mac-range-config
   namespace: kubemacpool-system
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kubemacpool-webhook-secret
-  namespace: kubemacpool-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -173,8 +167,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: SECRET_NAME
-          value: kubemacpool-webhook-secret
         - name: RANGE_START
           valueFrom:
             configMapKeyRef:
@@ -199,14 +191,5 @@ spec:
           requests:
             cpu: 500m
             memory: 500Mi
-        volumeMounts:
-        - mountPath: /tmp/cert
-          name: cert
-          readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: kubemacpool-webhook-secret

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -137,12 +137,6 @@ metadata:
   name: kubemacpool-mac-range-config
   namespace: kubemacpool-system
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kubemacpool-webhook-secret
-  namespace: kubemacpool-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -173,8 +167,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: SECRET_NAME
-          value: kubemacpool-webhook-secret
         - name: RANGE_START
           valueFrom:
             configMapKeyRef:
@@ -199,14 +191,5 @@ spec:
           requests:
             cpu: 500m
             memory: 500Mi
-        volumeMounts:
-        - mountPath: /tmp/cert
-          name: cert
-          readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: kubemacpool-webhook-secret

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -22,7 +22,6 @@ import (
 	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -51,10 +50,6 @@ func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) er
 		Port:    8000,
 		BootstrapOptions: &runtimewebhook.BootstrapOptions{
 			MutatingWebhookConfigName: "kubemacpool",
-			Secret: &apitypes.NamespacedName{
-				Namespace: "kubemacpool-system",
-				Name:      "kubemacpool-webhook-secret",
-			},
 			Service: &runtimewebhook.Service{
 				Namespace: "kubemacpool-system",
 				Name:      "kubemacpool-service",


### PR DESCRIPTION
This PR change the cert creation mode from secret to file system.

This way the pod will not make a restart in the first time.