### PR TITLE
add finalizers to allow deep delete of VMs

### DIFF
--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -26,10 +26,11 @@ import (
 )
 
 const (
-	RangeStartEnv            = "RANGE_START"
-	RangeEndEnv              = "RANGE_END"
-	networksAnnotation       = "k8s.v1.cni.cncf.io/networks"
-	networksStatusAnnotation = "k8s.v1.cni.cncf.io/networks-status"
+	RangeStartEnv              = "RANGE_START"
+	RangeEndEnv                = "RANGE_END"
+	RuntimeObjectFinalizerName = "k8s.v1.cni.cncf.io/kubeMacPool"
+	networksAnnotation         = "k8s.v1.cni.cncf.io/networks"
+	networksStatusAnnotation   = "k8s.v1.cni.cncf.io/networks-status"
 )
 
 var log = logf.Log.WithName("PoolManager")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+func ContainsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func RemoveString(slice []string, s string) (result []string) {
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}


### PR DESCRIPTION
In this PR we added a feature of finalizers ,which allow us a more safe way of deleting VMs
and releasing their mac.

The finalizers do not allow the object to be deleted until some necessary actions occur. in our
case- the release of the mac address.

Before this PR, the release of the mac and the deletion of the VM were not dependent,
so in order to keep track with the allocated mac addresses and safely release them,
we mapped each mac address to the name of the object it was allocated for (pod or VM).
That implementation could lead to safety issues. For example, if the controller collapses for some reason,we lose track of the allocated macs.

With the finalizers, we can be sure that before any deletion of a VM it's mac will be released, and tracking the allocated mac addresses is done through the VM itself.