### PR TITLE
Allow mutiple replicas for manager

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -68,7 +68,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	kubemacpoolManager := manager.NewKubeMacPoolManager(metricsAddr)
+	podNamespace, ok := os.LookupEnv("POD_NAMESPACE")
+	if !ok {
+		log.Error(err, "Failed to load pod namespace from environment variable")
+		os.Exit(1)
+	}
+
+	podName, ok := os.LookupEnv("POD_NAME")
+	if !ok {
+		log.Error(err, "Failed to load pod name from environment variable")
+		os.Exit(1)
+	}
+
+	kubemacpoolManager := manager.NewKubeMacPoolManager(podNamespace, podName, metricsAddr)
 
 	err = kubemacpoolManager.Run(rangeStart, rangeEnd)
 	if err != nil {

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -28,7 +28,7 @@ metadata:
     control-plane: mac-controller-manager
     controller-tools.k8s.io: "1.0"
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       control-plane: mac-controller-manager
@@ -53,6 +53,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: RANGE_START
             valueFrom:
               configMapKeyRef:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -146,7 +146,7 @@ metadata:
   name: kubemacpool-mac-controller-manager
   namespace: kubemacpool-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       control-plane: mac-controller-manager
@@ -167,6 +167,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: RANGE_START
           valueFrom:
             configMapKeyRef:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -146,7 +146,7 @@ metadata:
   name: kubemacpool-mac-controller-manager
   namespace: kubemacpool-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       control-plane: mac-controller-manager
@@ -167,6 +167,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: RANGE_START
           valueFrom:
             configMapKeyRef:

--- a/pkg/manager/leaderelection.go
+++ b/pkg/manager/leaderelection.go
@@ -1,0 +1,64 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	manager_leaderelection "sigs.k8s.io/controller-runtime/pkg/leaderelection"
+)
+
+func (k *KubeMacPoolManager) newLeaderElection(config *rest.Config, scheme *runtime.Scheme) error {
+	recorderProvider, err := NewProvider(config, scheme, log.WithName("events"))
+	if err != nil {
+		return err
+	}
+
+	// Create the resource lock to enable leader election)
+	resourceLock, err := manager_leaderelection.NewResourceLock(config, recorderProvider, manager_leaderelection.Options{
+		LeaderElection:          true,
+		LeaderElectionID:        "kubemacpool-election",
+		LeaderElectionNamespace: "kubemacpool-system",
+	})
+	if err != nil {
+		return err
+	}
+
+	k.resourceLock = resourceLock
+
+	return nil
+}
+
+func (k *KubeMacPoolManager) waitToStartLeading() error {
+	messageChan := make(chan error, 1)
+
+	l, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock: k.resourceLock,
+		// Values taken from: https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/v1alpha1/defaults.go
+		LeaseDuration: 15 * time.Second,
+		RenewDeadline: 10 * time.Second,
+		RetryPeriod:   2 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(_ context.Context) {
+				messageChan <- nil
+			},
+			OnStoppedLeading: func() {
+				// Most implementations of leader election log.Fatal() here.
+				// Since Start is wrapped in log.Fatal when called, we can just return
+				// an error here which will cause the program to exit.
+				messageChan <- fmt.Errorf("leader election lost")
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Start the leader elector process
+	go l.Run(context.Background())
+
+	return <-messageChan
+}

--- a/pkg/manager/recorder.go
+++ b/pkg/manager/recorder.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
+)
+
+type provider struct {
+	// scheme to specify when creating a recorder
+	scheme *runtime.Scheme
+	// eventBroadcaster to create new recorder instance
+	eventBroadcaster record.EventBroadcaster
+	// logger is the logger to use when logging diagnostic event info
+	logger logr.Logger
+}
+
+// NewProvider create a new Provider instance.
+func NewProvider(config *rest.Config, scheme *runtime.Scheme, logger logr.Logger) (recorder.Provider, error) {
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init clientSet: %v", err)
+	}
+
+	p := &provider{scheme: scheme, logger: logger}
+	p.eventBroadcaster = record.NewBroadcaster()
+	p.eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
+	p.eventBroadcaster.StartEventWatcher(
+		func(e *corev1.Event) {
+			p.logger.V(1).Info(e.Type, "object", e.InvolvedObject, "reason", e.Reason, "message", e.Message)
+		})
+
+	return p, nil
+}
+
+func (p *provider) GetEventRecorderFor(name string) record.EventRecorder {
+	return p.eventBroadcaster.NewRecorder(p.scheme, corev1.EventSource{Component: name})
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -31,6 +31,10 @@ import (
 	"github.com/K8sNetworkPlumbingWG/kubemacpool/pkg/pool-manager"
 )
 
+const (
+	LeaderLabel = "kubemacpool-leader"
+)
+
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager, *pool_manager.PoolManager, *metav1.LabelSelector) (*admission.Webhook, error)
 
@@ -55,7 +59,7 @@ func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) er
 				Name:      "kubemacpool-service",
 				// Selectors should select the pods that runs this webhook server.
 				Selectors: map[string]string{
-					"control-plane": "mac-controller-manager",
+					LeaderLabel: "true",
 				},
 			},
 		},

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -421,6 +421,35 @@ var _ = Describe("Virtual Machines", func() {
 				}, 50*time.Second, 5*time.Second).Should(Not(HaveOccurred()), "failed to apply the new vm object error")
 			})
 		})
+		Context("When the leader is changed", func() {
+			It("should be able to create a new virtual machine", func() {
+				err := setRange(rangeStart, rangeEnd)
+				Expect(err).ToNot(HaveOccurred())
+
+				vm := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br", "")},
+					[]kubevirtv1.Network{newNetwork("br")})
+
+				anotherVm := vm.DeepCopy()
+				anotherVm.Name = "another-vm"
+
+				Eventually(func() error {
+					return testClient.VirtClient.Create(context.TODO(), vm)
+
+				}, 40*time.Second, 5*time.Second).Should(Not(HaveOccurred()), "failed to apply the new vm object")
+				_, err = net.ParseMAC(vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("deleting leader manager")
+				DeleteLeaderManager()
+
+				Eventually(func() error {
+					return testClient.VirtClient.Create(context.TODO(), anotherVm)
+
+				}, 40*time.Second, 5*time.Second).Should(Not(HaveOccurred()), "failed to apply the new vm object")
+				_, err = net.ParseMAC(anotherVm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
This PR allow to run the kubemacpool manager with multiple replicas

When a manager become leader it updates is pod label to a leader.
This label is the selector of the webhook service.
This way the service will always point only to the leader manager.