### PR TITLE
add affinty to constrain kubemacpool pods

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -39,6 +39,18 @@ spec:
         control-plane: mac-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: control-plane
+                  operator: In
+                  values:
+                  - mac-controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 1
       restartPolicy: Always
       containers:
       - command:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -157,6 +157,18 @@ spec:
         control-plane: mac-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: control-plane
+                  operator: In
+                  values:
+                  - mac-controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 1
       containers:
       - args:
         - --v=production

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -157,6 +157,18 @@ spec:
         control-plane: mac-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: control-plane
+                  operator: In
+                  values:
+                  - mac-controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 1
       containers:
       - args:
         - --v=debug


### PR DESCRIPTION
we added a pod-anti-affinity to the kubemacpool pod spec which constrain
(in a *soft way) the scheduling of the pod so that
no more than one kubemacpool-pod will be scheduled on a single node.

*if there is no other choice, it will bypass the constraint,
and will create more than one kubemacpool pods on a single node.