### PR TITLE
add pod disruption budget to kubemacapool

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -91,3 +91,13 @@ spec:
           name: webhook-server
           protocol: TCP
       terminationGracePeriodSeconds: 5
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: mac-controller-manager
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: mac-controller-manager

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -209,3 +209,14 @@ spec:
             memory: 500Mi
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kubemacpool-mac-controller-manager
+  namespace: kubemacpool-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: mac-controller-manager

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -209,3 +209,14 @@ spec:
             memory: 500Mi
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kubemacpool-mac-controller-manager
+  namespace: kubemacpool-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: mac-controller-manager


### PR DESCRIPTION
add pod disruption budjet to kubemacpool to set
the minimum number of available kubemacpool pods
on one node to 1 (on volentary distruption)