### PR TITLE
Allow to run kubemacpool in different namespace

### DIFF
--- a/pkg/manager/leaderelection.go
+++ b/pkg/manager/leaderelection.go
@@ -21,7 +21,7 @@ func (k *KubeMacPoolManager) newLeaderElection(config *rest.Config, scheme *runt
 	resourceLock, err := manager_leaderelection.NewResourceLock(config, recorderProvider, manager_leaderelection.Options{
 		LeaderElection:          true,
 		LeaderElectionID:        "kubemacpool-election",
-		LeaderElectionNamespace: "kubemacpool-system",
+		LeaderElectionNamespace: k.podNamespace,
 	})
 	if err != nil {
 		return err

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -116,13 +116,13 @@ func (k *KubeMacPoolManager) Run(rangeStart, rangeEnd net.HardwareAddr) error {
 
 		// create a owner ref on the mutating webhook
 		// this way when we remove the statefulset of the manager the webhook will be also removed from the cluster
-		err = webhook.CreateOwnerRefForMutatingWebhook(k.clientset)
+		err = webhook.CreateOwnerRefForMutatingWebhook(k.clientset, k.podNamespace)
 		if err != nil {
 			return fmt.Errorf("unable to create owner reference for mutating webhook object error %v", err)
 		}
 
 		isKubevirtInstalled := checkForKubevirt(k.clientset)
-		poolManager, err := poolmanager.NewPoolManager(k.clientset, rangeStart, rangeEnd, isKubevirtInstalled, k.waitingTime)
+		poolManager, err := poolmanager.NewPoolManager(k.clientset, rangeStart, rangeEnd, k.podNamespace, isKubevirtInstalled, k.waitingTime)
 		if err != nil {
 			return fmt.Errorf("unable to create pool manager error %v", err)
 		}
@@ -139,7 +139,7 @@ func (k *KubeMacPoolManager) Run(rangeStart, rangeEnd net.HardwareAddr) error {
 			return fmt.Errorf("unable to register controllers to the manager error %v", err)
 		}
 
-		err = webhook.AddToManager(mgr, poolManager)
+		err = webhook.AddToManager(mgr, poolManager, k.podNamespace)
 		if err != nil {
 			return fmt.Errorf("unable to register webhooks to the manager error %v", err)
 		}

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Pool", func() {
 		Expect(err).ToNot(HaveOccurred())
 		endPoolRangeEnv, err := net.ParseMAC(endMacAddr)
 		Expect(err).ToNot(HaveOccurred())
-		poolManager, err := NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, false, 10)
+		poolManager, err := NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, names.MANAGER_NAMESPACE, false, 10)
 		Expect(err).ToNot(HaveOccurred())
 
 		return poolManager
@@ -112,7 +112,7 @@ var _ = Describe("Pool", func() {
 			Expect(err).ToNot(HaveOccurred())
 			endPoolRangeEnv, err := net.ParseMAC("02:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, false, 10)
+			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, names.MANAGER_NAMESPACE, false, 10)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Invalid range. rangeStart: 0a:00:00:00:00:00 rangeEnd: 02:00:00:00:00:00"))
 
@@ -124,7 +124,7 @@ var _ = Describe("Pool", func() {
 			Expect(err).ToNot(HaveOccurred())
 			endPoolRangeEnv, err := net.ParseMAC("06:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, false, 10)
+			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, names.MANAGER_NAMESPACE, false, 10)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("RangeStart is invalid: invalid mac address. Multicast addressing is not supported. Unicast addressing must be used. The first octet is 0X3"))
 
@@ -136,7 +136,7 @@ var _ = Describe("Pool", func() {
 			Expect(err).ToNot(HaveOccurred())
 			endPoolRangeEnv, err := net.ParseMAC("05:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, false, 10)
+			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, names.MANAGER_NAMESPACE, false, 10)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("RangeEnd is invalid: invalid mac address. Multicast addressing is not supported. Unicast addressing must be used. The first octet is 0X5"))
 		})

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -45,14 +45,14 @@ var AddToManagerFuncs []func(manager.Manager, *pool_manager.PoolManager, *metav1
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;create;update;patch;list;watch
 // +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachines,verbs=get;list;watch;create;update;patch
-func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) error {
+func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager, managerNamespace string) error {
 	svr, err := runtimewebhook.NewServer(names.MUTATE_WEBHOOK, mgr, runtimewebhook.ServerOptions{
 		CertDir: "/tmp/cert",
 		Port:    8000,
 		BootstrapOptions: &runtimewebhook.BootstrapOptions{
 			MutatingWebhookConfigName: names.MUTATE_WEBHOOK_CONFIG,
 			Service: &runtimewebhook.Service{
-				Namespace: names.MANAGER_NAMESPACE,
+				Namespace: managerNamespace,
 				Name:      names.WEBHOOK_SERVICE,
 				// Selectors should select the pods that runs this webhook server.
 				Selectors: map[string]string{
@@ -90,8 +90,8 @@ func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) er
 // of new pods and virtual machines objects.
 // We choose this solution because the sigs.k8s.io/controller-runtime package doesn't allow to customize
 // the ServerOptions object
-func CreateOwnerRefForMutatingWebhook(kubeClient *kubernetes.Clientset) error {
-	managerDeployment, err := kubeClient.AppsV1().Deployments(names.MANAGER_NAMESPACE).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
+func CreateOwnerRefForMutatingWebhook(kubeClient *kubernetes.Clientset, managerNamespace string) error {
+	managerDeployment, err := kubeClient.AppsV1().Deployments(managerNamespace).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -27,7 +27,7 @@ import (
 const (
 	TestNamespace      = "kubemacpool-test"
 	OtherTestNamespace = "kubemacpool-test-alternative"
-	ManagerNamespce    = "kubemacpool-system"
+	ManagerNamespce    = names.MANAGER_NAMESPACE
 	nadPostUrl         = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s"
 	linuxBridgeConfCRD = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"type\": \"bridge\", \"bridge\": \"br1\"}"}}`
 )


### PR DESCRIPTION
This PR allow to run the kubemacpool in a different namespace
not hard coded one.

The manager reads the pod namespace and use it to create the
webhook and service.