### PR TITLE
Fix mutiple replica code

### DIFF
--- a/pkg/controller/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualmachine/virtualmachine_controller.go
@@ -131,9 +131,7 @@ func (r *ReconcilePolicy) addFinalizerAndUpdate(virtualMachine *kubevirt.Virtual
 		"virtualMachineName", request.Name,
 		"virtualMachineNamespace", request.Namespace)
 
-	r.poolManager.MarkVMAsReady(virtualMachine)
-
-	return nil
+	return r.poolManager.MarkVMAsReady(virtualMachine)
 }
 
 func (r *ReconcilePolicy) removeFinalizerAndReleaseMac(virtualMachine *kubevirt.VirtualMachine, request *reconcile.Request) error {

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -12,4 +12,6 @@ const MUTATE_WEBHOOK_CONFIG = "kubemacpool"
 
 const LEADER_LABEL = "kubemacpool-leader"
 
+const LEADER_ID = "kubemacpool-election"
+
 const ADMISSION_IGNORE_LABEL = "kubemacpool/ignoreAdmission"

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -89,7 +89,9 @@ func NewPoolManager(kubeClient kubernetes.Interface, rangeStart, rangeEnd net.Ha
 		return nil, err
 	}
 
-	go poolManger.vmWaitingCleanupLook(waitTime)
+	if kubevirtExist {
+		go poolManger.vmWaitingCleanupLook(waitTime)
+	}
 
 	return poolManger, nil
 }

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"github.com/K8sNetworkPlumbingWG/kubemacpool/pkg/names"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -38,6 +39,8 @@ func KubemacPoolFailedFunction(message string, callerSkip ...int) {
 	}
 
 	for _, pod := range podList.Items {
+		podYaml, err := testClient.KubeClient.CoreV1().Pods(ManagerNamespce).Get(pod.Name, metav1.GetOptions{})
+
 		req := testClient.KubeClient.CoreV1().Pods(ManagerNamespce).GetLogs(pod.Name, &corev1.PodLogOptions{})
 		output, err := req.DoRaw()
 		if err != nil {
@@ -46,8 +49,25 @@ func KubemacPoolFailedFunction(message string, callerSkip ...int) {
 		}
 
 		fmt.Printf("Pod Name: %s \n", pod.Name)
+		fmt.Printf("%v \n", *podYaml)
 		fmt.Println(string(output))
 	}
+
+	service, err := testClient.KubeClient.CoreV1().Services(ManagerNamespce).Get(names.WEBHOOK_SERVICE, metav1.GetOptions{})
+	if err != nil {
+		fmt.Println(err)
+		Fail(message, callerSkip...)
+	}
+
+	fmt.Printf("Service: %v", service)
+
+	endpoint, err := testClient.KubeClient.CoreV1().Endpoints(ManagerNamespce).Get(names.WEBHOOK_SERVICE, metav1.GetOptions{})
+	if err != nil {
+		fmt.Println(err)
+		Fail(message, callerSkip...)
+	}
+
+	fmt.Printf("Endpoint: %v", endpoint)
 
 	Fail(message, callerSkip...)
 }


### PR DESCRIPTION
This PR fix an issue we have when we create the kubemacpool before
kubevirt was installed and then we try to restart the manager after
we find kubevirt in the cluster.

The manager was stuck waiting to be the leader (but it's already
the leader)

/cc @alonSadan 