### PR TITLE
set webhooks failure policy to Ignore

### DIFF
--- a/pkg/webhook/pod/pod.go
+++ b/pkg/webhook/pod/pod.go
@@ -42,7 +42,7 @@ func Add(mgr manager.Manager, poolManager *pool_manager.PoolManager, namespaceSe
 
 	wh, err := builder.NewWebhookBuilder().
 		Mutating().
-		FailurePolicy(admissionregistrationv1beta1.Fail).
+		FailurePolicy(admissionregistrationv1beta1.Ignore).
 		Operations(admissionregistrationv1beta1.Create).
 		ForType(&corev1.Pod{}).
 		Handlers(podAnnotator).

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -18,7 +18,7 @@ import (
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 )
 
-const timeout = 60 * time.Second
+const timeout = 2 * time.Minute
 const pollingInterval = 5 * time.Second
 
 var _ = Describe("Virtual Machines", func() {


### PR DESCRIPTION
We are still facing many issues with inaccessible webhook blocking
creation of VMs and especially pods. Let's make our failure policy
ignore for now and investigate mentioned issues only in test
environments for now.