### PR TITLE
Create a ownerRef for the service

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -86,6 +86,7 @@ func main() {
 
 	err = kubemacpoolManager.Run(rangeStart, rangeEnd)
 	if err != nil {
+		log.Error(err, "Failed to run the manager")
 		os.Exit(1)
 	}
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -115,10 +115,15 @@ func (k *KubeMacPoolManager) Run(rangeStart, rangeEnd net.HardwareAddr) error {
 		}
 
 		// create a owner ref on the mutating webhook
-		// this way when we remove the statefulset of the manager the webhook will be also removed from the cluster
+		// this way when we remove the deployment of the manager the webhook will be also removed from the cluster
 		err = webhook.CreateOwnerRefForMutatingWebhook(k.clientset, k.podNamespace)
 		if err != nil {
 			return fmt.Errorf("unable to create owner reference for mutating webhook object error %v", err)
+		}
+
+		err = webhook.CreateOwnerRefForService(k.clientset, k.podNamespace)
+		if err != nil {
+			return fmt.Errorf("unable to create owner reference for service object error %v", err)
 		}
 
 		isKubevirtInstalled := checkForKubevirt(k.clientset)


### PR DESCRIPTION
This PR creates a OwnerRef for the manager service.
When the manager deployment will be removed it will also remove the service.

Before this PR if we remove the deployment it will not remove the service
related to him.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/k8snetworkplumbingwg/kubemacpool/71)
<!-- Reviewable:end -->
