### PR TITLE
Skip pods in critical namespaces

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -4,7 +4,8 @@ metadata:
   labels:
     control-plane: mac-controller-manager
     controller-tools.k8s.io: "1.0"
-    kubemacpool/ignoreAdmission: "true"
+    runlevel: "0"
+    openshift.io/run-level: "0"
   name: system
 ---
 apiVersion: v1

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -4,7 +4,8 @@ metadata:
   labels:
     control-plane: mac-controller-manager
     controller-tools.k8s.io: "1.0"
-    kubemacpool/ignoreAdmission: "true"
+    openshift.io/run-level: "0"
+    runlevel: "0"
   name: kubemacpool-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -4,7 +4,8 @@ metadata:
   labels:
     control-plane: mac-controller-manager
     controller-tools.k8s.io: "1.0"
-    kubemacpool/ignoreAdmission: "true"
+    openshift.io/run-level: "0"
+    runlevel: "0"
   name: kubemacpool-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -14,4 +14,8 @@ const LEADER_LABEL = "kubemacpool-leader"
 
 const LEADER_ID = "kubemacpool-election"
 
-const ADMISSION_IGNORE_LABEL = "kubemacpool/ignoreAdmission"
+const K8S_RUNLABEL = "runlevel"
+
+const OPENSHIFT_RUNLABEL = "openshift.io/run-level"
+
+var CRITICAL_RUNLABELS = []string{"0", "1"}

--- a/pkg/webhook/pod/pod.go
+++ b/pkg/webhook/pod/pod.go
@@ -42,7 +42,7 @@ func Add(mgr manager.Manager, poolManager *pool_manager.PoolManager, namespaceSe
 
 	wh, err := builder.NewWebhookBuilder().
 		Mutating().
-		FailurePolicy(admissionregistrationv1beta1.Ignore).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
 		Operations(admissionregistrationv1beta1.Create).
 		ForType(&corev1.Pod{}).
 		Handlers(podAnnotator).

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -67,8 +67,12 @@ func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager, ma
 		return err
 	}
 
-	namespaceSelector := &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: names.ADMISSION_IGNORE_LABEL,
-		Operator: metav1.LabelSelectorOpDoesNotExist}}}
+	namespaceSelector := &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+		{Key: names.K8S_RUNLABEL,
+			Operator: metav1.LabelSelectorOpNotIn, Values: names.CRITICAL_RUNLABELS},
+		{Key: names.OPENSHIFT_RUNLABEL,
+			Operator: metav1.LabelSelectorOpNotIn, Values: names.CRITICAL_RUNLABELS,
+		}}}
 
 	webhooks := []runtimewebhook.Webhook{}
 	for _, f := range AddToManagerFuncs {

--- a/tests/pods_test.go
+++ b/tests/pods_test.go
@@ -1,16 +1,97 @@
 package tests
 
 import (
+	"context"
+	"fmt"
+	"github.com/onsi/gomega/types"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 )
 
+const defaultNumberOfReplicas = 2
+
 var _ = Describe("Pods", func() {
-	Context("Check the client", func() {
-		It("should not fail", func() {
-			_, err := testClient.KubeClient.CoreV1().Pods("").List(v1.ListOptions{})
+	Context("Check the pod mutating webhook", func() {
+		AfterEach(func() {
+			// Clean pods from our test namespaces after every test to start clean
+			for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
+				podList := &corev1.PodList{}
+				err := testClient.VirtClient.List(context.TODO(), &client.ListOptions{Namespace: namespace}, podList)
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, podObject := range podList.Items {
+					err = testClient.VirtClient.Delete(context.TODO(), &podObject)
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				Eventually(func() int {
+					podList := &corev1.PodList{}
+					err := testClient.VirtClient.List(context.TODO(), &client.ListOptions{Namespace: namespace}, podList)
+					Expect(err).ToNot(HaveOccurred())
+					return len(podList.Items)
+
+				}, timeout, pollingInterval).Should(Equal(0), fmt.Sprintf("failed to remove all pod objects from namespace %s", namespace))
+
+				// This function remove all the labels from the namespace
+				err = cleanNamespaceLabels(namespace)
+			}
+
+			// Restore the default number of managers
+			err := changeManagerReplicas(defaultNumberOfReplicas)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		testCriticalNamespace := func(namespace, label string, matcher types.GomegaMatcher) {
+			err := changeManagerReplicas(0)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = addLabelsToNamespace(OtherTestNamespace, map[string]string{label: "0"})
+
+			podObject := createPodObject()
+
+			Eventually(func() bool {
+				_, err := testClient.KubeClient.CoreV1().Pods(OtherTestNamespace).Create(podObject)
+				if err != nil && strings.Contains(err.Error(), "connection refused") {
+					return false
+				}
+
+				return true
+			}, timeout, pollingInterval).Should(matcher, "failed to apply the new pod object")
+		}
+
+		It("should create a pod when mac pool is running in a regular namespace", func() {
+			err := setRange(rangeStart, rangeEnd)
+			Expect(err).ToNot(HaveOccurred())
+
+			podObject := createPodObject()
+
+			Eventually(func() bool {
+				_, err := testClient.KubeClient.CoreV1().Pods(TestNamespace).Create(podObject)
+				if err != nil && strings.Contains(err.Error(), "connection refused") {
+					return false
+				}
+
+				return true
+			}, timeout, pollingInterval).Should(BeTrue(), "failed to apply the new pod object")
+		})
+
+		It("should fail to create a pod on a regular namespace when mac pool is down", func() {
+			testCriticalNamespace(OtherTestNamespace, "not-critical", BeFalse())
+		})
+
+		It("should create a pod on a critical k8s namespaces when mac pool is down", func() {
+			testCriticalNamespace(OtherTestNamespace, names.K8S_RUNLABEL, BeTrue())
+		})
+
+		It("should create a pod on a critical openshift namespaces when mac pool is down", func() {
+			testCriticalNamespace(OtherTestNamespace, names.OPENSHIFT_RUNLABEL, BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
This PR fix the issue when a Critical pod like the sdn provider
need to be recreated.

change the mutating webhook to skip namespaces to contains

1. runlevel=[0,1] for kubernetes environments
2. openshift.io/run-level=[0,1] for openshift environments

With this change we can change the FailurePolicy from ignore to fail.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/k8snetworkplumbingwg/kubemacpool/74)
<!-- Reviewable:end -->
