### PR TITLE
Update the port number in the manager deployment

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -89,7 +89,7 @@ spec:
             cpu: 100m
             memory: 300Mi
         ports:
-        - containerPort: 9876
+        - containerPort: 8000
           name: webhook-server
           protocol: TCP
       terminationGracePeriodSeconds: 5

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -199,7 +199,7 @@ spec:
         imagePullPolicy: Always
         name: manager
         ports:
-        - containerPort: 9876
+        - containerPort: 8000
           name: webhook-server
           protocol: TCP
         resources:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -199,7 +199,7 @@ spec:
         imagePullPolicy: Always
         name: manager
         ports:
-        - containerPort: 9876
+        - containerPort: 8000
           name: webhook-server
           protocol: TCP
         resources:


### PR DESCRIPTION
This PR fix the port in the manager yaml.

Change from 9876 to 8000

Signed-off-by: Sebastian Sch <sebassch@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/k8snetworkplumbingwg/kubemacpool/76)
<!-- Reviewable:end -->
