### PR TITLE
BZ1779513: make webhook ignoring

### DIFF
--- a/pkg/webhook/virtualmachine/virtualmachine.go
+++ b/pkg/webhook/virtualmachine/virtualmachine.go
@@ -50,7 +50,7 @@ func Add(mgr manager.Manager, poolManager *pool_manager.PoolManager, namespaceSe
 
 	wh, err := builder.NewWebhookBuilder().
 		Mutating().
-		FailurePolicy(admissionregistrationv1beta1.Fail).
+		FailurePolicy(admissionregistrationv1beta1.Ignore).
 		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
 		ForType(&kubevirt.VirtualMachine{}).
 		Handlers(virtualMachineAnnotator).


### PR DESCRIPTION
With https://github.com/k8snetworkplumbingwg/kubemacpool/pull/74
we set webhook failing policy to failing in belief the kubemacpool
became stable. Unfortunatelly, we still see some certificate issues
as listed in https://bugzilla.redhat.com/1779513 (most probably due to
ca rotation).

The policy is moved back to failing till the issues are fixed.
The fixes will be tracked in - https://bugzilla.redhat.com/1787213

Signed-off-by: Alona Kaplan <alkaplan@redhat.com>