### PR TITLE
Update the port number in the manager deployment

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -88,7 +88,7 @@ spec:
             cpu: 100m
             memory: 300Mi
         ports:
-        - containerPort: 9876
+        - containerPort: 8000
           name: webhook-server
           protocol: TCP
       terminationGracePeriodSeconds: 5

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -198,7 +198,7 @@ spec:
         imagePullPolicy: Always
         name: manager
         ports:
-        - containerPort: 9876
+        - containerPort: 8000
           name: webhook-server
           protocol: TCP
         resources:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -198,7 +198,7 @@ spec:
         imagePullPolicy: Always
         name: manager
         ports:
-        - containerPort: 9876
+        - containerPort: 8000
           name: webhook-server
           protocol: TCP
         resources:


### PR DESCRIPTION
The port written in our manifests is not matching the one used by webserver. Since the port in service is only for documentation purposes, it should not be a big deal, but let's be on the safe side.