### PR TITLE
tests: wait for new managers to become available

### DIFF
--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -478,7 +478,7 @@ var _ = Describe("Virtual Machines", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("deleting leader manager")
-				DeleteLeaderManager()
+				deleteLeaderManager()
 
 				Eventually(func() error {
 					return testClient.VirtClient.Create(context.TODO(), anotherVm)


### PR DESCRIPTION
In the current code, setRange and deleteLeaderManager functions
are not waiting for the old pods to disappear and new ones to become
available. Due to that, tests using this functions don't have any
webhook available or worse, they are being served by the old one.

This issue was not exposed due to Eventually we have around all the
Create calls.