### PR TITLE
add automation scripts

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -xe
+
+teardown() {
+    make cluster-down
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
+}
+
+main() {
+    export KUBEVIRT_PROVIDER='k8s-1.17.0'
+    source automation/check-patch.setup.sh
+    cd ${TMP_PROJECT_PATH}
+
+    # Let's fail fast if it's not compiling
+    make docker-build
+
+    make cluster-down
+    make cluster-up
+    trap teardown EXIT SIGINT SIGTERM SIGSTOP
+    make cluster-sync
+    make functest
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -1,0 +1,14 @@
+# Prepare environment for kubemacpool end to end testing. This includes
+# temporary Go paths and binaries.
+#
+# source automation/check-patch.e2e.setup.sh
+# cd ${TMP_PROJECT_PATH}
+
+tmp_dir=/tmp/kubemacpool/
+
+rm -rf $tmp_dir
+mkdir -p $tmp_dir
+
+export TMP_PROJECT_PATH=$tmp_dir/kubemacpool
+
+rsync -rt --links --filter=':- .gitignore' $(pwd)/ $TMP_PROJECT_PATH

--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+teardown() {
+    cp $(find . -name "*junit*.xml") $ARTIFACTS
+}
+
+main() {
+    source automation/check-patch.setup.sh
+    cd ${TMP_PROJECT_PATH}
+
+    trap teardown EXIT SIGINT SIGTERM SIGSTOP
+
+    make all
+    make test
+}
+
+[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"


### PR DESCRIPTION
These can be used to run unit/functional tests on an arbitrary host
with docker and rsync installed. They will be later used for CI triggered
by prow.

Signed-off-by: Petr Horacek <phoracek@redhat.com>