### PR TITLE
drop dockerized test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: required
 dist: trusty
-go: "1.11"
+go: "1.12"
 
 services:
 - docker
@@ -11,7 +11,7 @@ script:
   - sudo cp ./cluster/dind-cluster/kubectl /usr/bin/kubectl
   - make docker-generate
   - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run make. Please run it and commit the changes"; git status --porcelain; false; fi
-  - make docker-test
+  - make test
   - make deploy-test-cluster
   - KUBECONFIG="`pwd`/cluster/dind-cluster/config" go test -timeout 30m -v -race ./tests/...
 

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,6 @@ docker-goveralls: docker-test
 docker-generate:
 	./hack/run.sh 
 
-# Test Inside a docker
-docker-test:
-	./hack/run.sh test
-
 # Build the docker image
 docker-build:
 	docker build . -t ${REGISTRY}/${IMG}:${IMAGE_TAG}

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker run --rm -t --volume `pwd`:/go/src/github.com/k8s-nativelb  --volume $HOME/.kube/:/root/.kube/ --volume $HOME/.minikube:/home/travis/.minikube --env KUBECONFIG=/root/.kube/config --workdir /go/src/github.com/k8s-nativelb/ golang:1.11.0 make test


### PR DESCRIPTION
We can run the tests with Go alone, there is no need to containerize them.

Signed-off-by: Petr Horacek <phoracek@redhat.com>