### PR TITLE
add label to kubemacpool yamls

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -37,6 +37,7 @@ spec:
   template:
     metadata:
       labels:
+        app: kubemacpool
         control-plane: mac-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -228,6 +228,7 @@ spec:
   template:
     metadata:
       labels:
+        app: kubemacpool
         control-plane: mac-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -228,6 +228,7 @@ spec:
   template:
     metadata:
       labels:
+        app: kubemacpool
         control-plane: mac-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:


### PR DESCRIPTION
There is a label missing from kubemacpool yamls: app: kubemacpool

This label is used in various places like rotate_cert script in [HCO](https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/tools/rotate-certs.sh#L39).

Signed-off-by: Ram Lavi <ralavi@redhat.com>