### PR TITLE
Deploy kubemacpool-mac-controller-manager with StatefulSet

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -21,7 +21,7 @@ data:
   RANGE_END: 02:FF:FF:FF:FF:FF
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: mac-controller-manager
   namespace: system
@@ -29,6 +29,7 @@ metadata:
     control-plane: mac-controller-manager
     controller-tools.k8s.io: "1.0"
 spec:
+  serviceName: kubemacpool-service
   replicas: 2
   selector:
     matchLabels:

--- a/config/default/rbac/rbac_role.yaml
+++ b/config/default/rbac/rbac_role.yaml
@@ -78,7 +78,7 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
+  - statefulsets
   verbs:
   - get
   - create

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -212,7 +212,7 @@ spec:
     kubemacpool-leader: "true"
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   labels:
     control-plane: mac-controller-manager
@@ -225,6 +225,7 @@ spec:
     matchLabels:
       control-plane: mac-controller-manager
       controller-tools.k8s.io: "1.0"
+  serviceName: kubemacpool-service
   template:
     metadata:
       labels:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -152,7 +152,7 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
+  - statefulsets
   verbs:
   - get
   - create

--- a/config/release/manager_image_patch.yaml
+++ b/config/release/manager_image_patch.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: kubemacpool-mac-controller-manager
   namespace: kubemacpool-system

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -152,7 +152,7 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
+  - statefulsets
   verbs:
   - get
   - create
@@ -212,7 +212,7 @@ spec:
     kubemacpool-leader: "true"
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   labels:
     control-plane: mac-controller-manager
@@ -225,6 +225,7 @@ spec:
     matchLabels:
       control-plane: mac-controller-manager
       controller-tools.k8s.io: "1.0"
+  serviceName: kubemacpool-service
   template:
     metadata:
       labels:

--- a/config/test/manager_image_patch.yaml
+++ b/config/test/manager_image_patch.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: kubemacpool-mac-controller-manager
   namespace: kubemacpool-system

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -2,7 +2,7 @@ package names
 
 const MANAGER_NAMESPACE = "kubemacpool-system"
 
-const MANAGER_DEPLOYMENT = "kubemacpool-mac-controller-manager"
+const MANAGER_STATEFULSET = "kubemacpool-mac-controller-manager"
 
 const WEBHOOK_SERVICE = "kubemacpool-service"
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -133,7 +133,7 @@ func CreateOwnerRefForService(kubeClient *kubernetes.Clientset, managerNamespace
 }
 
 func createStatefulSetOwnerRef(kubeClient *kubernetes.Clientset, managerNamespace string) ([]metav1.OwnerReference, error) {
-	managerStatefulset, err := kubeClient.AppsV1().StatefulSets(managerNamespace).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
+	managerStatefulset, err := kubeClient.AppsV1().StatefulSets(managerNamespace).Get(names.MANAGER_STATEFULSET, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -45,7 +45,7 @@ const (
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;create;update;patch;list;watch
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;create;update;patch;list;watch
 // +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachines,verbs=get;list;watch;create;update;patch
 var AddToWebhookFuncs []func(*webhookserver.Server, *pool_manager.PoolManager) error
 
@@ -70,7 +70,7 @@ func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) er
 // We choose this solution because the sigs.k8s.io/controller-runtime package doesn't allow to customize
 // the ServerOptions object
 func CreateOwnerRefForMutatingWebhook(kubeClient *kubernetes.Clientset, managerNamespace string) error {
-	ownerRefList, err := createDeploymentOwnerRef(kubeClient, managerNamespace)
+	ownerRefList, err := createStatefulSetOwnerRef(kubeClient, managerNamespace)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func CreateOwnerRefForMutatingWebhook(kubeClient *kubernetes.Clientset, managerN
 }
 
 func CreateOwnerRefForService(kubeClient *kubernetes.Clientset, managerNamespace string) error {
-	ownerRefList, err := createDeploymentOwnerRef(kubeClient, managerNamespace)
+	ownerRefList, err := createStatefulSetOwnerRef(kubeClient, managerNamespace)
 	if err != nil {
 		return err
 	}
@@ -132,12 +132,12 @@ func CreateOwnerRefForService(kubeClient *kubernetes.Clientset, managerNamespace
 	return err
 }
 
-func createDeploymentOwnerRef(kubeClient *kubernetes.Clientset, managerNamespace string) ([]metav1.OwnerReference, error) {
-	managerDeployment, err := kubeClient.AppsV1().Deployments(managerNamespace).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
+func createStatefulSetOwnerRef(kubeClient *kubernetes.Clientset, managerNamespace string) ([]metav1.OwnerReference, error) {
+	managerStatefulset, err := kubeClient.AppsV1().StatefulSets(managerNamespace).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	ownerRefList := []metav1.OwnerReference{{Name: managerDeployment.Name, Kind: "Deployment", APIVersion: "apps/v1", UID: managerDeployment.UID}}
+	ownerRefList := []metav1.OwnerReference{{Name: managerStatefulset.Name, Kind: "StatefulSet", APIVersion: "apps/v1", UID: managerStatefulset.UID}}
 
 	return ownerRefList, nil
 }

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -232,14 +232,14 @@ func DeleteLeaderManager() {
 
 func changeManagerReplicas(numOfReplica int32) error {
 	Eventually(func() error {
-		managerDeployment, err := testClient.KubeClient.AppsV1().Deployments(ManagerNamespce).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
+		managerStatefulset, err := testClient.KubeClient.AppsV1().StatefulSets(ManagerNamespce).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
-		managerDeployment.Spec.Replicas = &numOfReplica
+		managerStatefulset.Spec.Replicas = &numOfReplica
 
-		_, err = testClient.KubeClient.AppsV1().Deployments(ManagerNamespce).Update(managerDeployment)
+		_, err = testClient.KubeClient.AppsV1().StatefulSets(ManagerNamespce).Update(managerStatefulset)
 		if err != nil {
 			return err
 		}
@@ -248,16 +248,16 @@ func changeManagerReplicas(numOfReplica int32) error {
 	}, 30*time.Second, 3*time.Second).ShouldNot(HaveOccurred(), "failed to update number of replicas on manager")
 
 	Eventually(func() bool {
-		managerDeployment, err := testClient.KubeClient.AppsV1().Deployments(ManagerNamespce).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
+		managerStatefulset, err := testClient.KubeClient.AppsV1().StatefulSets(ManagerNamespce).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
 
-		if managerDeployment.Status.Replicas != numOfReplica {
+		if managerStatefulset.Status.Replicas != numOfReplica {
 			return false
 		}
 		//due to readiness probe only 1 (the leader) pod will be ready (if any)
-		if float64(managerDeployment.Status.ReadyReplicas) != math.Min(float64(1), float64(numOfReplica)) {
+		if float64(managerStatefulset.Status.ReadyReplicas) != math.Min(float64(1), float64(numOfReplica)) {
 			return false
 		}
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"math"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -235,7 +235,7 @@ func DeleteLeaderManager() {
 
 func changeManagerReplicas(numOfReplica int32) error {
 	Eventually(func() error {
-		managerStatefulset, err := testClient.KubeClient.AppsV1().StatefulSets(ManagerNamespce).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
+		managerStatefulset, err := testClient.KubeClient.AppsV1().StatefulSets(ManagerNamespce).Get(names.MANAGER_STATEFULSET, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func changeManagerReplicas(numOfReplica int32) error {
 	}, 30*time.Second, 3*time.Second).ShouldNot(HaveOccurred(), "failed to update number of replicas on manager")
 
 	Eventually(func() bool {
-		managerStatefulset, err := testClient.KubeClient.AppsV1().StatefulSets(ManagerNamespce).Get(names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
+		managerStatefulset, err := testClient.KubeClient.AppsV1().StatefulSets(ManagerNamespce).Get(names.MANAGER_STATEFULSET, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
This PR change the deployment strategy from deploying kubemacpool-mac-controller-manager pod with Deployment to StatufSet.
As part of removing the leader-election mechanism effort #109 , it is necessary to enumerate the `kubemacpool-mac-controller-manager` pod names, with StatfulSet it is out-of-the-box functionality.

Signed-off-by: Or Mergi <ormergi@redhat.com>