### PR TITLE
[release-v0.8] disable pod handling

### DIFF
--- a/pkg/controller/add_pod.go
+++ b/pkg/controller/add_pod.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package controller
 
-import (
-	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/pod"
-)
-
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, pod.Add)
+	//AddToManagerFuncs = append(AddToManagerFuncs, pod.Add)
 }

--- a/pkg/webhook/add_pod.go
+++ b/pkg/webhook/add_pod.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package webhook
 
-import (
-	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/webhook/pod"
-)
-
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, pod.Add)
+	//AddToManagerFuncs = append(AddToManagerFuncs, pod.Add)
 }

--- a/tests/pods_test.go
+++ b/tests/pods_test.go
@@ -17,7 +17,7 @@ import (
 
 const defaultNumberOfReplicas = 2
 
-var _ = Describe("Pods", func() {
+var _ = PDescribe("Pods [PENDING since due to an issue with outdated Multus]", func() {
 	Context("Check the pod mutating webhook", func() {
 		AfterEach(func() {
 			// Clean pods from our test namespaces after every test to start clean


### PR DESCRIPTION
There is a bug related to outdated multus dependency. Let's just disable
Pod handling completely.

Signed-off-by: Petr Horacek <phoracek@redhat.com>