### PR TITLE
Add opt in functionality

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -168,6 +168,8 @@ webhooks:
         values:
           - "0"
           - "1"
+      matchLabels:
+        mutatepods.kubemacpool.io: allocateForAll
     rules:
       - operations: ["CREATE"]
         apiGroups: [""]
@@ -193,6 +195,8 @@ webhooks:
         values:
           - "0"
           - "1"
+      matchLabels:
+        mutatevirtualmachines.kubemacpool.io: allocateForAll
     rules:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["kubevirt.io"]

--- a/config/default/rbac/rbac_role.yaml
+++ b/config/default/rbac/rbac_role.yaml
@@ -97,3 +97,9 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+    - ""
+  resources:
+    - namespaces
+  verbs:
+    - get

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -33,6 +33,8 @@ webhooks:
       values:
       - "0"
       - "1"
+    matchLabels:
+      mutatepods.kubemacpool.io: allocateForAll
   rules:
   - apiGroups:
     - ""
@@ -61,6 +63,8 @@ webhooks:
       values:
       - "0"
       - "1"
+    matchLabels:
+      mutatevirtualmachines.kubemacpool.io: allocateForAll
   rules:
   - apiGroups:
     - kubevirt.io

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -33,6 +33,8 @@ webhooks:
       values:
       - "0"
       - "1"
+    matchLabels:
+      mutatepods.kubemacpool.io: allocateForAll
   rules:
   - apiGroups:
     - ""
@@ -61,6 +63,8 @@ webhooks:
       values:
       - "0"
       - "1"
+    matchLabels:
+      mutatevirtualmachines.kubemacpool.io: allocateForAll
   rules:
   - apiGroups:
     - kubevirt.io

--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -19,8 +19,8 @@ package pod
 import (
 	"context"
 	"fmt"
+
 	"github.com/intel/multus-cni/logging"
-	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,17 +77,17 @@ type ReconcilePolicy struct {
 // Reconcile reads that state of the cluster for a Pod object and makes changes based on the state
 func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.V(1).Info("got a pod event in the controller")
-	instanceOptedIn, err := r.poolManager.IsInstanceOptedIn(request.Namespace, names.NAMESPACE_OPT_IN_LABEL_PODS, "allocateForAll")
-	if !instanceOptedIn {
-		log.V(1).Info("pod is opted-out from kubemacpool",
-			"pod", request.Name,
-			"podNamespace", request.Namespace)
-		return reconcile.Result{}, err
-	}
+	instanceOptedIn, err := r.poolManager.IsPodInstanceOptedIn(request.Namespace)
 	if err != nil {
 		// Error reading the object - requeue the request.
 		log.Error(err, "failed to check opt-in selection",
 			"podName", request.Name,
+			"podNamespace", request.Namespace)
+		return reconcile.Result{}, err
+	}
+	if !instanceOptedIn {
+		log.V(1).Info("pod is opted-out from kubemacpool",
+			"pod", request.Name,
 			"podNamespace", request.Namespace)
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/intel/multus-cni/logging"
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,8 +77,23 @@ type ReconcilePolicy struct {
 // Reconcile reads that state of the cluster for a Pod object and makes changes based on the state
 func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.V(1).Info("got a pod event in the controller")
+	instanceOptedIn, err := r.poolManager.IsInstanceOptedIn(request.Namespace, names.NAMESPACE_OPT_IN_LABEL_PODS, "allocateForAll")
+	if !instanceOptedIn {
+		log.V(1).Info("pod is opted-out from kubemacpool",
+			"pod", request.Name,
+			"podNamespace", request.Namespace)
+		return reconcile.Result{}, err
+	}
+	if err != nil {
+		// Error reading the object - requeue the request.
+		log.Error(err, "failed to check opt-in selection",
+			"podName", request.Name,
+			"podNamespace", request.Namespace)
+		return reconcile.Result{}, err
+	}
+
 	instance := &corev1.Pod{}
-	err := r.Get(context.TODO(), request.NamespacedName, instance)
+	err = r.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			err := r.poolManager.ReleasePodMac(fmt.Sprintf("%s/%s", request.Namespace, request.Name))

--- a/pkg/controller/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualmachine/virtualmachine_controller.go
@@ -19,7 +19,6 @@ package virtualmachine
 import (
 	"context"
 
-	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirt "kubevirt.io/client-go/api/v1"
@@ -84,16 +83,16 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 		"virtualMachineName", request.Name,
 		"virtualMachineNamespace", request.Namespace)
 
-	instanceOptedIn, err := r.poolManager.IsInstanceOptedIn(request.Namespace, names.NAMESPACE_OPT_IN_LABEL_VMS, "allocateForAll")
-	if !instanceOptedIn {
-		log.V(1).Info("vm is opted-out from kubemacpool",
+	instanceOptedIn, err := r.poolManager.IsVmInstanceOptedIn(request.Namespace)
+	if err != nil {
+		// Error reading the object - requeue the request.
+		log.Error(err, "failed to check opt-in selection",
 			"virtualMachineName", request.Name,
 			"virtualMachineNamespace", request.Namespace)
 		return reconcile.Result{}, err
 	}
-	if err != nil {
-		// Error reading the object - requeue the request.
-		log.Error(err, "failed to check opt-in selection",
+	if !instanceOptedIn {
+		log.V(1).Info("vm is opted-out from kubemacpool",
 			"virtualMachineName", request.Name,
 			"virtualMachineNamespace", request.Namespace)
 		return reconcile.Result{}, err

--- a/pkg/controller/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualmachine/virtualmachine_controller.go
@@ -19,6 +19,7 @@ package virtualmachine
 import (
 	"context"
 
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirt "kubevirt.io/client-go/api/v1"
@@ -82,8 +83,24 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 	log.V(1).Info("got a virtual machine event in the controller",
 		"virtualMachineName", request.Name,
 		"virtualMachineNamespace", request.Namespace)
+
+	instanceOptedIn, err := r.poolManager.IsInstanceOptedIn(request.Namespace, names.NAMESPACE_OPT_IN_LABEL_VMS, "allocateForAll")
+	if !instanceOptedIn {
+		log.V(1).Info("vm is opted-out from kubemacpool",
+			"virtualMachineName", request.Name,
+			"virtualMachineNamespace", request.Namespace)
+		return reconcile.Result{}, err
+	}
+	if err != nil {
+		// Error reading the object - requeue the request.
+		log.Error(err, "failed to check opt-in selection",
+			"virtualMachineName", request.Name,
+			"virtualMachineNamespace", request.Namespace)
+		return reconcile.Result{}, err
+	}
+
 	instance := &kubevirt.VirtualMachine{}
-	err := r.Get(context.TODO(), request.NamespacedName, instance)
+	err = r.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return reconcile.Result{}, nil

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -19,3 +19,7 @@ const K8S_RUNLABEL = "runlevel"
 const OPENSHIFT_RUNLABEL = "openshift.io/run-level"
 
 const WAITING_VMS_CONFIGMAP = "kubemacpool-vm-configmap"
+
+const NAMESPACE_OPT_IN_LABEL_PODS = "mutatepods.kubemacpool.io"
+
+const NAMESPACE_OPT_IN_LABEL_VMS = "mutatevirtualmachines.kubemacpool.io"

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -19,7 +19,3 @@ const K8S_RUNLABEL = "runlevel"
 const OPENSHIFT_RUNLABEL = "openshift.io/run-level"
 
 const WAITING_VMS_CONFIGMAP = "kubemacpool-vm-configmap"
-
-const NAMESPACE_OPT_IN_LABEL_PODS = "mutatepods.kubemacpool.io"
-
-const NAMESPACE_OPT_IN_LABEL_VMS = "mutatevirtualmachines.kubemacpool.io"

--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -274,6 +274,11 @@ func (p *PoolManager) revertAllocationOnPod(podName string, allocations []string
 	delete(p.podToMacPoolMap, podName)
 }
 
+// Checks if the namespace of a pod instance is opted in for kubemacpool
+func (p *PoolManager) IsPodInstanceOptedIn(namespaceName string) (bool, error) {
+	return p.isInstanceOptedIn(namespaceName, "kubemacpool-mutator", "mutatepods.kubemacpool.io")
+}
+
 func podNamespaced(pod *corev1.Pod) string {
 	return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 }

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
@@ -175,4 +176,21 @@ func getNextMac(currentMac net.HardwareAddr) net.HardwareAddr {
 	}
 
 	return currentMac
+}
+
+// Checks if the namespace of an instance is opted in for kubemacpool
+func (p *PoolManager) IsInstanceOptedIn(namespaceName, labelSelector, labelValue string) (bool, error) {
+	isNamespaceOptedIn := false
+
+	ns, err := p.kubeClient.CoreV1().Namespaces().Get(namespaceName, metav1.GetOptions{})
+	if err != nil {
+		return isNamespaceOptedIn, err
+	}
+
+	log.V(1).Info("namespaceName Labels", "Labels", ns.GetLabels())
+	if value := ns.GetLabels()[labelSelector]; labelValue == value {
+		isNamespaceOptedIn = true
+	}
+
+	return isNamespaceOptedIn, err
 }

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -184,14 +184,14 @@ func getNextMac(currentMac net.HardwareAddr) net.HardwareAddr {
 func (p *PoolManager) isInstanceOptedIn(namespaceName, mutatingWebhookConfigName, webhookName string) (bool, error) {
 	ns, err := p.kubeClient.CoreV1().Namespaces().Get(namespaceName, metav1.GetOptions{})
 	if err != nil {
-		return false, errors.Wrap(err, fmt.Sprintf("Failed to get Namespace %s", namespaceName))
+		return false, errors.Wrapf(err, "Failed to get Namespace %s", namespaceName)
 	}
 	namespaceLabelMap := ns.GetLabels()
 	log.V(3).Info("namespaceName Labels", "namespaceName", namespaceName, "Labels", namespaceLabelMap)
 
 	mutatingWebhookConfiguration, err := p.kubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(mutatingWebhookConfigName, metav1.GetOptions{})
 	if err != nil {
-		return false, errors.Wrap(err, fmt.Sprintf("Failed to get mutatingWebhookConfig %s", mutatingWebhookConfigName))
+		return false, errors.Wrapf(err, "Failed to get mutatingWebhookConfig %s", mutatingWebhookConfigName)
 	}
 
 	for _, webhook := range mutatingWebhookConfiguration.Webhooks {

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -477,6 +477,11 @@ func (p *PoolManager) vmWaitingCleanupLook(waitTime int) {
 	}
 }
 
+// Checks if the namespace of a vm instance is opted in for kubemacpool
+func (p *PoolManager) IsVmInstanceOptedIn(namespaceName string) (bool, error) {
+	return p.isInstanceOptedIn(namespaceName, "kubemacpool-mutator", "mutatevirtualmachines.kubemacpool.io")
+}
+
 func vmNamespaced(machine *kubevirt.VirtualMachine) string {
 	return fmt.Sprintf("%s/%s", machine.Namespace, machine.Name)
 }

--- a/tests/pods_test.go
+++ b/tests/pods_test.go
@@ -19,6 +19,14 @@ const defaultNumberOfReplicas = 2
 
 var _ = Describe("Pods", func() {
 	Context("Check the pod mutating webhook", func() {
+		BeforeEach(func() {
+			// update namespaces opt in labels before every test
+			for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
+				err := addLabelsToNamespace(namespace, map[string]string{names.NAMESPACE_OPT_IN_LABEL_PODS: "allocateForAll"})
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
 		AfterEach(func() {
 			// Clean pods from our test namespaces after every test to start clean
 			for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
@@ -41,6 +49,7 @@ var _ = Describe("Pods", func() {
 
 				// This function remove all the labels from the namespace
 				err = cleanNamespaceLabels(namespace)
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			// Restore the default number of managers
@@ -48,11 +57,12 @@ var _ = Describe("Pods", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		testCriticalNamespace := func(namespace, label string, matcher types.GomegaMatcher) {
+		testCriticalNamespace := func(namespace string, namespaceLabelMap map[string]string, matcher types.GomegaMatcher) {
 			err := changeManagerReplicas(0)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = addLabelsToNamespace(OtherTestNamespace, map[string]string{label: "0"})
+			err = addLabelsToNamespace(OtherTestNamespace, namespaceLabelMap)
+			Expect(err).ToNot(HaveOccurred())
 
 			podObject := createPodObject()
 
@@ -66,8 +76,8 @@ var _ = Describe("Pods", func() {
 			}, timeout, pollingInterval).Should(matcher, "failed to apply the new pod object")
 		}
 
-		It("should create a pod when mac pool is running in a regular namespace", func() {
-			err := setRange(rangeStart, rangeEnd)
+		It("should create a pod when mac pool is running in a regular opted-in namespace", func() {
+			err := initKubemacpoolParams(rangeStart, rangeEnd)
 			Expect(err).ToNot(HaveOccurred())
 
 			podObject := createPodObject()
@@ -82,16 +92,58 @@ var _ = Describe("Pods", func() {
 			}, timeout, pollingInterval).Should(BeTrue(), "failed to apply the new pod object")
 		})
 
-		It("should fail to create a pod on a regular namespace when mac pool is down", func() {
-			testCriticalNamespace(OtherTestNamespace, "not-critical", BeFalse())
+		It("should create a pod when mac pool is running in a regular opted-out namespace (disabled label)", func() {
+			err := initKubemacpoolParams(rangeStart, rangeEnd)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("updating the namespace opt-in label to disabled")
+			err = cleanNamespaceLabels(TestNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			err = addLabelsToNamespace(TestNamespace, map[string]string{names.NAMESPACE_OPT_IN_LABEL_PODS: "disable"})
+			Expect(err).ToNot(HaveOccurred())
+
+			podObject := createPodObject()
+
+			Eventually(func() bool {
+				_, err := testClient.KubeClient.CoreV1().Pods(TestNamespace).Create(podObject)
+				if err != nil && strings.Contains(err.Error(), "connection refused") {
+					return false
+				}
+
+				return true
+			}, timeout, pollingInterval).Should(BeTrue(), "failed to apply the new pod object")
+		})
+
+		It("should create a pod when mac pool is running in a regular opted-out namespace (no label)", func() {
+			err := initKubemacpoolParams(rangeStart, rangeEnd)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("removing the namespace opt-in label")
+			err = cleanNamespaceLabels(TestNamespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			podObject := createPodObject()
+
+			Eventually(func() bool {
+				_, err := testClient.KubeClient.CoreV1().Pods(TestNamespace).Create(podObject)
+				if err != nil && strings.Contains(err.Error(), "connection refused") {
+					return false
+				}
+
+				return true
+			}, timeout, pollingInterval).Should(BeTrue(), "failed to apply the new pod object")
+		})
+
+		It("should fail to create a pod on a regular opted-in namespace when mac pool is down", func() {
+			testCriticalNamespace(OtherTestNamespace, map[string]string{"not-critical": "0"}, BeFalse())
 		})
 
 		It("should create a pod on a critical k8s namespaces when mac pool is down", func() {
-			testCriticalNamespace(OtherTestNamespace, names.K8S_RUNLABEL, BeTrue())
+			testCriticalNamespace(OtherTestNamespace, map[string]string{names.K8S_RUNLABEL: "0"}, BeTrue())
 		})
 
 		It("should create a pod on a critical openshift namespaces when mac pool is down", func() {
-			testCriticalNamespace(OtherTestNamespace, names.OPENSHIFT_RUNLABEL, BeTrue())
+			testCriticalNamespace(OtherTestNamespace, map[string]string{names.OPENSHIFT_RUNLABEL: "0"}, BeTrue())
 		})
 	})
 })

--- a/tests/pods_test.go
+++ b/tests/pods_test.go
@@ -22,8 +22,8 @@ var _ = Describe("Pods", func() {
 		BeforeEach(func() {
 			// update namespaces opt in labels before every test
 			for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
-				err := addLabelsToNamespace(namespace, map[string]string{names.NAMESPACE_OPT_IN_LABEL_PODS: "allocateForAll"})
-				Expect(err).ToNot(HaveOccurred())
+				err := addLabelsToNamespace(namespace, map[string]string{podNamespaceOptInLabel: "allocateForAll"})
+				Expect(err).ToNot(HaveOccurred(), "should be able to add the namespace labels")
 			}
 		})
 
@@ -62,7 +62,7 @@ var _ = Describe("Pods", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			err = addLabelsToNamespace(OtherTestNamespace, namespaceLabelMap)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "should be able to add the namespace labels")
 
 			podObject := createPodObject()
 
@@ -98,9 +98,9 @@ var _ = Describe("Pods", func() {
 
 			By("updating the namespace opt-in label to disabled")
 			err = cleanNamespaceLabels(TestNamespace)
-			Expect(err).ToNot(HaveOccurred())
-			err = addLabelsToNamespace(TestNamespace, map[string]string{names.NAMESPACE_OPT_IN_LABEL_PODS: "disable"})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
+			err = addLabelsToNamespace(TestNamespace, map[string]string{podNamespaceOptInLabel: "disable"})
+			Expect(err).ToNot(HaveOccurred(), "should be able to add the namespace labels")
 
 			podObject := createPodObject()
 
@@ -120,7 +120,7 @@ var _ = Describe("Pods", func() {
 
 			By("removing the namespace opt-in label")
 			err = cleanNamespaceLabels(TestNamespace)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
 
 			podObject := createPodObject()
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -26,11 +26,13 @@ import (
 )
 
 const (
-	TestNamespace      = "kubemacpool-test"
-	OtherTestNamespace = "kubemacpool-test-alternative"
-	ManagerNamespce    = names.MANAGER_NAMESPACE
-	nadPostUrl         = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s"
-	linuxBridgeConfCRD = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"type\": \"bridge\", \"bridge\": \"br1\"}"}}`
+	TestNamespace          = "kubemacpool-test"
+	OtherTestNamespace     = "kubemacpool-test-alternative"
+	ManagerNamespce        = names.MANAGER_NAMESPACE
+	nadPostUrl             = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s"
+	linuxBridgeConfCRD     = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"type\": \"bridge\", \"bridge\": \"br1\"}"}}`
+	podNamespaceOptInLabel = "mutatepods.kubemacpool.io"
+	vmNamespaceOptInLabel  = "mutatevirtualmachines.kubemacpool.io"
 )
 
 var (
@@ -90,7 +92,6 @@ func deleteTestNamespaces(namespace string) error {
 }
 
 func removeTestNamespaces() {
-
 	By(fmt.Sprintf("Waiting for namespace %s to be removed, this can take a while ...\n", TestNamespace))
 	EventuallyWithOffset(1, func() bool { return errors.IsNotFound(deleteTestNamespaces(TestNamespace)) }, 120*time.Second, 5*time.Second).
 		Should(BeTrue(), "Namespace %s haven't been deleted within the given timeout", TestNamespace)
@@ -194,10 +195,10 @@ func setRangeInRangeConfigMap(rangeStart, rangeEnd string) error {
 
 func initKubemacpoolParams(rangeStart, rangeEnd string) error {
 	err := setRangeInRangeConfigMap(rangeStart, rangeEnd)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "Should succeed setting range in the range config map")
 
 	err = restartKubemacpoolManagerPods()
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "Should succeed resetting the kubemacpool pods")
 
 	return nil
 }

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Virtual Machines", func() {
 
 		// add vm opt-in label to the test namespaces
 		for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
-			err := addLabelsToNamespace(namespace, map[string]string{names.NAMESPACE_OPT_IN_LABEL_VMS: "allocateForAll"})
-			Expect(err).ToNot(HaveOccurred())
+			err := addLabelsToNamespace(namespace, map[string]string{vmNamespaceOptInLabel: "allocateForAll"})
+			Expect(err).ToNot(HaveOccurred(), "should be able to add the namespace labels")
 		}
 	})
 
@@ -79,7 +79,7 @@ var _ = Describe("Virtual Machines", func() {
 			// remove all the labels from the test namespaces
 			for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
 				err = cleanNamespaceLabels(namespace)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
 			}
 		})
 
@@ -91,7 +91,7 @@ var _ = Describe("Virtual Machines", func() {
 				//remove namespace opt-in labels
 				By("removing the namespace opt-in label")
 				err = cleanNamespaceLabels(TestNamespace)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
 
 				vm := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br", "")},
 					[]kubevirtv1.Network{newNetwork("br")})
@@ -110,9 +110,9 @@ var _ = Describe("Virtual Machines", func() {
 				//change namespace opt-in label to disable
 				By("updating the namespace opt-in label to disabled")
 				err = cleanNamespaceLabels(TestNamespace)
-				Expect(err).ToNot(HaveOccurred())
-				err = addLabelsToNamespace(TestNamespace, map[string]string{names.NAMESPACE_OPT_IN_LABEL_VMS: "disabled"})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
+				err = addLabelsToNamespace(TestNamespace, map[string]string{vmNamespaceOptInLabel: "disabled"})
+				Expect(err).ToNot(HaveOccurred(), "should be able to add the namespace labels")
 
 				vm := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br", "")},
 					[]kubevirtv1.Network{newNetwork("br")})


### PR DESCRIPTION
Currently the kubemacpool operate on all non-critical namespaces by default.

We want to invert this behavior to opt-in: only namespaces that state the kubemacpool label would be served by the kmp.
In this PR we will add namespace selector to the mutating webhook manifest, and also to the controller reconcile logic. Additionally, the necessary changes will be made to tests, and other tests are added.