### PR TITLE
Enable cluster-sync with external provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ cluster/k8s-1.13.3/.kubectl
 hack/config-provider-*
 
 _kubevirtci/
+
+# config/external is something generated when KUBEVIRT_PROVIDER=external
+# it's a modified copy of config/test
+config/external

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This project allow to allocate mac addresses from a pool to secondary interfaces using 
+This project allow to allocate mac addresses from a pool to secondary interfaces using
 [Network Plumbing Working Group de-facto standard](https://github.com/k8snetworkplumbingwg/multi-net-spec).
 
 ## Usage
@@ -34,7 +34,7 @@ Download the project yaml and apply it.
 ```bash
 wget https://raw.githubusercontent.com/k8snetworkplumbingwg/kubemacpool/master/config/release/kubemacpool.yaml
 kubectl apply -f ./kubemacpool.yaml
-``` 
+```
 
 ### Opting-in to kubemacpool service
 
@@ -45,7 +45,7 @@ On releases v0.8.4 and above, kubemacpool is set to apply on pods/vms that resid
 #### Opt-in Example
 
 ```bash
-# Add the opt-in labels to namespace using kubectl 
+# Add the opt-in labels to namespace using kubectl
 kubectl label namespace user-namespace-opting-in-pods-vms mutatepods.kubemacpool.io=allocateForAll mutatevirtualmachines.kubemacpool.io=allocateForAll
 namespace/user-namespace-opting-in-pods-vms labeled
 
@@ -75,7 +75,7 @@ RANGE_START:
 
 pods:
 ```bash
-kubectl -n kubemacpool-system get po                
+kubectl -n kubemacpool-system get po
 NAME                                                  READY   STATUS    RESTARTS   AGE
 kubemacpool-mac-controller-manager-6894f7785d-t6hf4   1/1     Running   0          107s
 ```
@@ -85,8 +85,8 @@ kubemacpool-mac-controller-manager-6894f7785d-t6hf4   1/1     Running   0       
 Create a network-attachment-definition:
 
 The 'NetworkAttachmentDefinition' is used to setup the network attachment, i.e. secondary interface for the pod.
-This is follows the [Kubernetes Network Custom Resource Definition De-facto Standard](https://docs.google.com/document/d/1Ny03h6IDVy_e_vmElOqR7UdTPAG_RNydhVE1Kx54kFQ/edit) 
-to provide a standardized method by which to specify the configurations for additional network interfaces. 
+This is follows the [Kubernetes Network Custom Resource Definition De-facto Standard](https://docs.google.com/document/d/1Ny03h6IDVy_e_vmElOqR7UdTPAG_RNydhVE1Kx54kFQ/edit)
+to provide a standardized method by which to specify the configurations for additional network interfaces.
 This standard is put forward by the Kubernetes [Network Plumbing Working Group](https://docs.google.com/document/d/1oE93V3SgOGWJ4O1zeD1UmpeToa0ZiiO6LqRAmZBPFWM/edit).
 
 ```yaml
@@ -115,7 +115,7 @@ spec:
 
 This example used [ovs-cni](https://github.com/kubevirt/ovs-cni/).
 
-**note** the tuning plugin change the mac address after the main plugin was executed so 
+**note** the tuning plugin change the mac address after the main plugin was executed so
 network connectivity will not work if the main plugin configure mac filter on the interface.
 
 **note** make sure that the  pod's namespace is opted in for pods.
@@ -182,7 +182,7 @@ k8s.v1.cni.cncf.io/networks: [{"name":"ovs-conf","namespace":"default","mac":"02
 
 MAC address can be also set manually by the user using the MAC field in the annotation.
 If the mac is already in used the system will reject it even if the MAC address is outside of the range.
- 
+
 
 ## Develop
 
@@ -191,19 +191,20 @@ deploy local cluster.
 
 ### Dockerized Kubernetes Provider
 
-Refer to the [kubernetes 1.13.3 with multus document](cluster/k8s-multus-1.13.3/README.md)
+Refer to the [kubernetes 1.17](https://github.com/kubevirt/kubevirtci/blob/master/cluster-up/cluster/k8s-1.17/README.md)
 
 ### Usage
 
 Use following commands to control it.
 
-*note:* Default Provider is one node (master + worker) of kubernetes 1.13.3
+*note:* Default Provider is one master + one worker of kubernetes 1.17 nodes
 with multus cni plugin.
+
+#### Ephemeral cluster
 
 ```shell
 # Deploy local Kubernetes cluster
-export MACPOOL_PROVIDER=k8s-multus-1.13.3 # choose this provider
-export MACPOOL_NUM_NODES=3 # master + two nodes
+export KUBEVIRT_NUM_NODES=3 # one master + two workers
 make cluster-up
 
 # SSH to node01 and open interactive shell
@@ -220,4 +221,36 @@ make cluster-sync
 
 # Destroy the cluster
 make cluster-down
+
+# Run function test
+make functest
+```
+#### External cluster
+
+To deploy at an external cluster not provided by kubevirtci we can to do
+the following steps
+
+```bash
+# Set env variables
+export KUBEVIRT_PROVIDER=external
+export KUBECONFIG=[path to the cluster's kubeconfig]
+
+# Intermediate registry to deploy kubemacpool
+export DEV_REGISTRY=docker.io # can be different
+
+# Intermediate repo to deploy kubemacpool
+export REPO=$USER # Usually there is a docker.io/$USER this can use
+
+# Deploy kubevirt and multus
+make cluster-up
+
+# Build project, build images, push them to $DEV_REGISTRY/$REPO/kubemacpool and
+# install it
+make cluster-sync
+
+# Destroy the cluster, it will not install kubevirt or multus
+make cluster-down
+
+# Run function test
+make functest
 ```

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright 2018-2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+source ./cluster/kubevirtci.sh
+kubevirtci::install
+
+./cluster/kubectl.sh delete --ignore-not-found -f ./config/test/kubemacpool.yaml || true
+
+# Wait until all objects are deleted
+until [[ `./cluster/kubectl.sh get ns | grep "kubemacpool-system " | wc -l` -eq 0 ]]; do
+    sleep 5
+done

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -21,7 +21,9 @@ CNAO_VERSIOV=0.35.0
 KUBEVIRT_VERSION=v0.20.4
 kubevirtci::install
 
-$(kubevirtci::path)/cluster-up/up.sh
+if [[ "$KUBEVIRT_PROVIDER" != external ]]; then
+    $(kubevirtci::path)/cluster-up/up.sh
+fi
 
 # Deploy CNA
 ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/namespace.yaml

--- a/config/test/kustomization.yaml
+++ b/config/test/kustomization.yaml
@@ -1,7 +1,9 @@
-bases:
-- ../default
-
-patchesStrategicMerge:
-- manager_image_patch.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+patchesStrategicMerge:
+- manager_image_patch.yaml
+resources:
+- ../default
+images:
+- name: quay.io/kubevirt/kubemacpool
+  newName: registry:5000/kubevirt/kubemacpool

--- a/config/test/manager_image_patch.yaml
+++ b/config/test/manager_image_patch.yaml
@@ -7,8 +7,7 @@ spec:
   template:
     spec:
       containers:
-      - image: registry:5000/kubevirt/kubemacpool:latest
-        name: manager
+      - name: manager
         args:
           - "--v=debug"
           - "--wait-time=10"

--- a/hack/clean-ns-finalizers.sh
+++ b/hack/clean-ns-finalizers.sh
@@ -1,0 +1,9 @@
+#!/bin/env bash
+
+set -xe
+
+kubectl=./cluster/kubectl.sh
+
+$kubectl get namespace kubemacpool-system -o json \
+    | jq '.spec.finalizers = []' | \
+    $kubectl replace --raw "/api/v1/namespaces/kubemacpool-system/finalize" -f -

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+set -xe
 
 source ./cluster/kubevirtci.sh
 
-KUBECONFIG=$(kubevirtci::kubeconfig) go test -timeout 20m -v -race ./tests/...
+KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test -timeout 20m -v -race ./tests/...

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -13,4 +13,6 @@ docker run --rm -t --user $(id -u):$(id -g) \
            --env RANGE_END=02:FF:FF:FF:FF:FF \
            --env POD_NAMESPACE=default \
            --env POD_NAME=kubemacpool-pod \
+           --env REGISTRY=${REGISTRY} \
+           --env REPO=${REPO} \
             ${DOCKER_BASE_IMAGE} make $@


### PR DESCRIPTION
**What this PR does / why we need it**:
Running latest kubemacpool at external cluster like openshift helps on iterating for defects, this PR add support for `KUBEVIRT_PROVIDER=external` and it will deploy and run functest on an external cluster pointed at with `KUBECONFIG`

Doing the following steps will will deploy kubemacpool + kubevirt + multus and wil
run functest towards it at an external cluster.

```
export KUBEVIRT_PROVIDER=external
export KUBECONFIG=[]/kubeconfig
export DEV_REGISTRY=docker.io
export REPO=$USER
export make cluster-up cluster-sync functest
```

**Special notes for your reviewer**:
The installed kubevirt and CNAO/multus is not cleaned up it can be put something in place at a follow up.

**Release note**:

```release-note
Support for KUBEVIRT_PROVIDER=external
```

