### PR TITLE
Remove 1.17.0 provider reference

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -6,7 +6,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.17.0'
+    export KUBEVIRT_PROVIDER='k8s-1.17'
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER='k8s-1.17'
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.17'}
 
 KUBEVIRTCI_VERSION='c7dccd19872a2e4f5f34932912ea7d79be0eecbb'
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"


### PR DESCRIPTION
It also make possible to specify different KUBEVIRT_PROVIDER

Signed-off-by: Quique Llorente <ellorent@redhat.com>