### PR TITLE
adding check that all genereated files are commited before performing automation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 install: true
 script:
-  - make container
+  - make check
 
 deploy:
 - provider: script

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,16 @@ generate-go: $(DEEPCOPY_GEN) fmt vet manifests
 
 generate: generate-go generate-deploy generate-test
 
-goveralls: $(GOVERALLS)
-	GOVERALLS=$(GOVERALLS) ./hack/goveralls.sh
+docker-goveralls: docker-builder docker-test
+	DOCKER_BASE_IMAGE=${REGISTRY}/${IMG}:kubemacpool_builder ./hack/run.sh goveralls
 
-manager: generate-go
+docker-generate: docker-builder
+	DOCKER_BASE_IMAGE=${REGISTRY}/${IMG}:kubemacpool_builder ./hack/run.sh
+
+check: $(KUSTOMIZE)
+	./hack/check.sh
+
+manager: $(GO)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -o $(BIN_DIR)/manager github.com/k8snetworkplumbingwg/kubemacpool/cmd/manager
 
 # Build the docker image
@@ -124,6 +130,7 @@ tools: $(GO)
 	fmt \
 	vet \
 	goveralls \
+	check \
 	manager \
 	container \
 	push \

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -xe
+
+make container generate generate-deploy generate-test
+if [[ -n "$(git status --porcelain)" ]] ; then
+    echo "It seems like you need to run `make generate`. Please run it and commit the changes"
+    git status --porcelain
+    exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
currently there is no check that makes sure that all generated manifests are committed.
In order to fix this we will add it in travis test like they do in [kubevirt](https://github.com/kubevirt/kubevirt/blob/6e87ec791e03fdb9899bbe85bbdd441a72c534ab/.travis.yml#L19).
 
**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
