### PR TITLE
Remove Pending flag from skipped tests

### DIFF
--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -266,8 +266,8 @@ var _ = Describe("Virtual Machines", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
-		//2162 test postponed due to issue: https://github.com/k8snetworkplumbingwg/kubemacpool/issues/104
-		PContext("When trying to create a VM after all MAC addresses in range have been occupied", func() {
+		//2162
+		Context("When trying to create a VM after all MAC addresses in range have been occupied", func() {
 			It("should return an error because no MAC address is available", func() {
 				err := initKubemacpoolParams("02:00:00:00:00:00", "02:00:00:00:00:01")
 				Expect(err).ToNot(HaveOccurred())
@@ -289,8 +289,8 @@ var _ = Describe("Virtual Machines", func() {
 				Expect(err).To(HaveOccurred())
 			})
 		})
-		//2165 test postponed due to issue: https://github.com/k8snetworkplumbingwg/kubemacpool/issues/105
-		PContext("when trying to create a VM after a MAC address has just been released duo to a VM deletion", func() {
+		//2165
+		Context("when trying to create a VM after a MAC address has just been released duo to a VM deletion", func() {
 			It("should re-use the released MAC address for the creation of the new VM and not return an error", func() {
 				err := initKubemacpoolParams("02:00:00:00:00:00", "02:00:00:00:00:02")
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR remove Pending flag form 2162 and 2165 tests.

These tests were flaky due to an issue with how the manager pods
reported readiness, this caused the manager-pods to raise
`connection refused` errors right after deletion.

We deploy the manager pods with Deployment thus after deletion the pods 
will be be created again right away, and so are the certs by the cert-manager used
in KubeMacPollManager.
The manager-pods will report readiness before the certs are ready,
and eventually cause connection refused error (due to absent cert).

Now that #124 is merged we can continue to use these tests.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
