### PR TITLE
Drop 'Eventually' from 2633 test

### DIFF
--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -419,14 +419,8 @@ var _ = Describe("Virtual Machines", func() {
 
 				baseVM.Spec.Template.Spec.Domain.Devices.Interfaces = append(baseVM.Spec.Template.Spec.Domain.Devices.Interfaces, newInterface("br2", ""))
 
-				Eventually(func() error {
-					err = testClient.VirtClient.Create(context.TODO(), baseVM)
-					if err != nil {
-						Expect(strings.Contains(err.Error(), "failed to allocate requested mac address")).To(Equal(true))
-					}
-					return err
-
-				}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+				err = testClient.VirtClient.Create(context.TODO(), baseVM)
+				Expect(err).ToNot(HaveOccurred(), "should successfully create VM after yaml is fixed")
 			})
 			It("should allow to assign to the VM the same MAC addresses, different name as requested before and do not return an error", func() {
 				err := initKubemacpoolParams(rangeStart, rangeEnd)
@@ -445,14 +439,8 @@ var _ = Describe("Virtual Machines", func() {
 
 				baseVM.Spec.Template.Spec.Domain.Devices.Interfaces = append(baseVM.Spec.Template.Spec.Domain.Devices.Interfaces, newInterface("br2", ""))
 
-				Eventually(func() error {
-					err = testClient.VirtClient.Create(context.TODO(), baseVM)
-					if err != nil {
-						Expect(strings.Contains(err.Error(), "failed to allocate requested mac address")).To(Equal(true))
-					}
-					return err
-
-				}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+				err = testClient.VirtClient.Create(context.TODO(), baseVM)
+				Expect(err).ToNot(HaveOccurred(), "should successfully create VM after yaml is fixed")
 			})
 		})
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR Drops the  'Eventually' usage in test 2633 and refactors the test to use DescribeTable.
This PR is necessary in order to merge #139
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
