### PR TITLE
Bump kube-admission-webhook 0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190401220125-3a6077f1f910+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/procfs v0.0.8 // indirect
-	github.com/qinqon/kube-admission-webhook v0.6.0
+	github.com/qinqon/kube-admission-webhook v0.7.0
 	go.uber.org/atomic v1.4.0 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	k8s.io/api v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -598,8 +598,8 @@ github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN
 github.com/prometheus/prometheus v2.9.2+incompatible/go.mod h1:vdLuLLM0uqhLSofrQ7Nev2b/rQUyZ+pkT3zF7LB/i1g=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
-github.com/qinqon/kube-admission-webhook v0.6.0 h1:FTOT19QXmXZeYec1tBirdfarrD9BXNJz6e2xW3DsDl0=
-github.com/qinqon/kube-admission-webhook v0.6.0/go.mod h1:90v/WxuBhHI+xxm1qPhvAy3jc337cvqxXUuXb9V+7qw=
+github.com/qinqon/kube-admission-webhook v0.7.0 h1:8dHYwhxHfmWtSkVm82jF3aYbCPBNmyfPPKiwIvZcMq8=
+github.com/qinqon/kube-admission-webhook v0.7.0/go.mod h1:90v/WxuBhHI+xxm1qPhvAy3jc337cvqxXUuXb9V+7qw=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rlmcpherson/s3gof3r v0.5.0/go.mod h1:s7vv7SMDPInkitQMuZzH615G7yWHdrU2r/Go7Bo71Rs=

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/webhook/server/certificate/secret.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/webhook/server/certificate/secret.go
@@ -3,6 +3,8 @@ package certificate
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,33 +14,53 @@ import (
 	"github.com/qinqon/kube-admission-webhook/pkg/webhook/server/certificate/triple"
 )
 
-func tlsSecret(service types.NamespacedName, keyPair *triple.KeyPair) corev1.Secret {
+func updateTLSSecret(secret corev1.Secret, keyPair *triple.KeyPair) *corev1.Secret {
+	secret.Data = map[string][]byte{
+		corev1.TLSCertKey:       triple.EncodeCertPEM(keyPair.Cert),
+		corev1.TLSPrivateKeyKey: triple.EncodePrivateKeyPEM(keyPair.Key),
+	}
+	secret.Type = corev1.SecretTypeTLS
+	return &secret
+}
+
+func (m *Manager) newTLSSecret(serviceKey types.NamespacedName, keyPair *triple.KeyPair) (*corev1.Secret, error) {
+	service := corev1.Service{}
+	err := m.get(serviceKey, &service)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting service %s to set secret owner", serviceKey)
+	}
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      service.Name,
 			Namespace: service.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name:       service.Name,
+					Kind:       service.TypeMeta.Kind,
+					APIVersion: service.TypeMeta.APIVersion,
+					UID:        service.UID},
+			},
 		},
-		Data: map[string][]byte{
-			corev1.TLSCertKey:       triple.EncodeCertPEM(keyPair.Cert),
-			corev1.TLSPrivateKeyKey: triple.EncodePrivateKeyPEM(keyPair.Key),
-		},
-		Type: corev1.SecretTypeTLS,
 	}
-	return secret
+	return updateTLSSecret(secret, keyPair), nil
 }
 
 func (m *Manager) applyTLSSecret(service types.NamespacedName, keyPair *triple.KeyPair) error {
-	tlsSecret := tlsSecret(service, keyPair)
+	secret := corev1.Secret{}
 
-	err := m.get(service, &corev1.Secret{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return m.client.Create(context.TODO(), &tlsSecret)
-		} else {
-			return err
-		}
-	}
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		return m.client.Update(context.TODO(), &tlsSecret)
+		err := m.get(service, &secret)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				tlsSecret, err := m.newTLSSecret(service, keyPair)
+				if err != nil {
+					return errors.Wrapf(err, "failed initailizing secret %s", service)
+				}
+				return m.client.Create(context.TODO(), tlsSecret)
+			} else {
+				return err
+			}
+		}
+		return m.client.Update(context.TODO(), updateTLSSecret(secret, keyPair))
 	})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/qinqon/kube-admission-webhook v0.6.0
+# github.com/qinqon/kube-admission-webhook v0.7.0
 github.com/qinqon/kube-admission-webhook/pkg/webhook/server
 github.com/qinqon/kube-admission-webhook/pkg/webhook/server/certificate
 github.com/qinqon/kube-admission-webhook/pkg/webhook/server/certificate/triple


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bumps the webhook's library to deal with secrets ownership correctly so we can integrate with CNAO.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
kube-admission-webhook 0.7.0
```
