### PR TITLE
Paramtereize manager namespaces used by functest

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ On releases v0.8.4 and above, kubemacpool is set to apply on pods/vms that resid
 - `mutatepods.kubemacpool.io=allocateForAll` - to opt in pods mac allocation in your namespace
 - `mutatevirtualmachines.kubemacpool.io=allocateForAll` - to opt in vms mac allocation in your namespace
 
-#### How to enable/disable kubemacpool for a namespace 
+#### How to enable/disable kubemacpool for a namespace
 
 Kubemacpool is disabled by default on a new namespace.
 To enable kubemacpool on a specific namespace:
@@ -86,7 +86,7 @@ webhooks:
     matchLabels:
       mutatevirtualmachines.kubemacpool.io: allocateForAll
  ...
-``` 
+```
 
 **note:** if the kubemacpool's mutatingwebhookconfiguration `kubemacpool-mutator` namespace-selector value per vm/pod is set to `allocateForAll`, then you can also opt-out your namespace by setting the label value to `disable` in your namespace:
 ```bash
@@ -305,4 +305,15 @@ make cluster-down
 
 # Run function test
 make functest
+```
+
+In just the functest want to be deployed at pre-deployed external cluster
+the namespace where kubemacpool is living can be parameterize at functest
+
+```bash
+# If kubemacpool is living at HCO
+MANAGER_NAMESPACE=kubevirt-hyperconverged make functest
+
+# If kubemacpool is living at CNAO
+MANAGER_NAMESPACE=cluster-network-addons make functest
 ```

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -32,16 +32,16 @@ var _ = AfterSuite(func() {
 })
 
 func KubemacPoolFailedFunction(message string, callerSkip ...int) {
-	podList, err := testClient.KubeClient.CoreV1().Pods(ManagerNamespce).List(metav1.ListOptions{})
+	podList, err := testClient.KubeClient.CoreV1().Pods(managerNamespace).List(metav1.ListOptions{})
 	if err != nil {
 		fmt.Println(err)
 		Fail(message, callerSkip...)
 	}
 
 	for _, pod := range podList.Items {
-		podYaml, err := testClient.KubeClient.CoreV1().Pods(ManagerNamespce).Get(pod.Name, metav1.GetOptions{})
+		podYaml, err := testClient.KubeClient.CoreV1().Pods(managerNamespace).Get(pod.Name, metav1.GetOptions{})
 
-		req := testClient.KubeClient.CoreV1().Pods(ManagerNamespce).GetLogs(pod.Name, &corev1.PodLogOptions{})
+		req := testClient.KubeClient.CoreV1().Pods(managerNamespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
 		output, err := req.DoRaw()
 		if err != nil {
 			fmt.Println(err)
@@ -53,7 +53,7 @@ func KubemacPoolFailedFunction(message string, callerSkip ...int) {
 		fmt.Println(string(output))
 	}
 
-	service, err := testClient.KubeClient.CoreV1().Services(ManagerNamespce).Get(names.WEBHOOK_SERVICE, metav1.GetOptions{})
+	service, err := testClient.KubeClient.CoreV1().Services(managerNamespace).Get(names.WEBHOOK_SERVICE, metav1.GetOptions{})
 	if err != nil {
 		fmt.Println(err)
 		Fail(message, callerSkip...)
@@ -61,7 +61,7 @@ func KubemacPoolFailedFunction(message string, callerSkip ...int) {
 
 	fmt.Printf("Service: %v", service)
 
-	endpoint, err := testClient.KubeClient.CoreV1().Endpoints(ManagerNamespce).Get(names.WEBHOOK_SERVICE, metav1.GetOptions{})
+	endpoint, err := testClient.KubeClient.CoreV1().Endpoints(managerNamespace).Get(names.WEBHOOK_SERVICE, metav1.GetOptions{})
 	if err != nil {
 		fmt.Println(err)
 		Fail(message, callerSkip...)

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -41,12 +41,12 @@ var _ = Describe("Virtual Machines", func() {
 		Expect(err).ToNot(HaveOccurred(), "Should successfully list add VMs")
 		Expect(len(currentVMList.Items)).To(BeZero(), "There should be no VM's in the cluster before a test")
 
-		vmWaitConfigMap, err := testClient.KubeClient.CoreV1().ConfigMaps(names.MANAGER_NAMESPACE).Get(names.WAITING_VMS_CONFIGMAP, meta_v1.GetOptions{})
+		vmWaitConfigMap, err := testClient.KubeClient.CoreV1().ConfigMaps(managerNamespace).Get(names.WAITING_VMS_CONFIGMAP, meta_v1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Should successfully get %s ConfigMap", names.WAITING_VMS_CONFIGMAP))
 
 		By(fmt.Sprintf("Clearing the map inside %s configMap in-place instead of waiting to garbage-collector", names.WAITING_VMS_CONFIGMAP))
 		clearMap(vmWaitConfigMap.Data)
-		vmWaitConfigMap, err = testClient.KubeClient.CoreV1().ConfigMaps(names.MANAGER_NAMESPACE).Update(vmWaitConfigMap)
+		vmWaitConfigMap, err = testClient.KubeClient.CoreV1().ConfigMaps(managerNamespace).Update(vmWaitConfigMap)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Should successfully update %s ConfigMap", names.WAITING_VMS_CONFIGMAP))
 		Expect(vmWaitConfigMap.Data).To(BeEmpty(), fmt.Sprintf("%s Data map should be empty", names.WAITING_VMS_CONFIGMAP))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To run functest at HCO provided cluster we need to be able to change the namespace to map with clustern-network-addons-operator one and also filter pods by app=kubemacpool they don't mess with not kubemacpool pods

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
