### PR TITLE
Parameterize manager namespace at tests from pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,14 +306,3 @@ make cluster-down
 # Run function test
 make functest
 ```
-
-In just the functest want to be deployed at pre-deployed external cluster
-the namespace where kubemacpool is living can be parameterize at functest
-
-```bash
-# If kubemacpool is living at HCO
-MANAGER_NAMESPACE=kubevirt-hyperconverged make functest
-
-# If kubemacpool is living at CNAO
-MANAGER_NAMESPACE=cluster-network-addons make functest
-```

--- a/hack/clean-ns-finalizers.sh
+++ b/hack/clean-ns-finalizers.sh
@@ -2,8 +2,10 @@
 
 set -xe
 
+namespace=$1
+
 kubectl=./cluster/kubectl.sh
 
-$kubectl get namespace kubemacpool-system -o json \
+$kubectl get namespace $namespace -o json \
     | jq '.spec.finalizers = []' | \
-    $kubectl replace --raw "/api/v1/namespaces/kubemacpool-system/finalize" -f -
+    $kubectl replace --raw "/api/v1/namespaces/$namespace/finalize" -f -

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -25,6 +25,8 @@ var _ = BeforeSuite(func() {
 	removeTestNamespaces()
 	err = createTestNamespaces()
 	Expect(err).ToNot(HaveOccurred())
+
+	managerNamespace = findManagerNamespace()
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Instead of using MANAGER_NAMESPACE env var this search for pods with label `app=kubemacpool` and
use the namespace there.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```