### PR TITLE
Check manager pod readyness changing leadership at test

### DIFF
--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -497,8 +497,7 @@ var _ = Describe("Virtual Machines", func() {
 				_, err = net.ParseMAC(vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress)
 				Expect(err).ToNot(HaveOccurred())
 
-				By("deleting leader manager")
-				DeleteLeaderManager()
+				ChangeManagerLeadership()
 
 				err = testClient.VirtClient.Create(context.TODO(), anotherVm)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Test were failing at CNAO looks like it takes more time to reach ready
state at manager pods after changing leardership, with this change
the test check not only that there is at pod with leadership  but also
that that pod is Ready.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
