### PR TITLE
add additional wait time in tests that check failed vm creation scenarios

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -25,6 +25,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/manager"
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	poolmanager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
 )
 
@@ -47,7 +48,7 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&logType, "v", "production", "Log type (debug/production).")
-	flag.IntVar(&waitingTime, "wait-time", 600, "waiting time to release the mac if object was not created")
+	flag.IntVar(&waitingTime, names.WAIT_TIME_ARG, 600, "waiting time to release the mac if object was not created")
 	flag.Parse()
 
 	if logType == "debug" {

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -19,3 +19,5 @@ const K8S_RUNLABEL = "runlevel"
 const OPENSHIFT_RUNLABEL = "openshift.io/run-level"
 
 const WAITING_VMS_CONFIGMAP = "kubemacpool-vm-configmap"
+
+const WAIT_TIME_ARG = "wait-time"

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -403,6 +403,13 @@ var _ = Describe("Virtual Machines", func() {
 		})
 		//2633
 		Context("When we re-apply a failed VM yaml", func() {
+			totalTimeout := time.Duration(0)
+			BeforeAll(func() {
+				vmFailCleanupWaitTime := getVmFailCleanupWaitTime()
+				// since this test checks vmWaitingCleanupLook routine, we nned to adjust the total timeout with the wait-time argument.
+				// we also add some extra timeout apart form wait-time to be sure that we catch the vm mac release.
+				totalTimeout = timeout + vmFailCleanupWaitTime
+			})
 			It("should allow to assign to the VM the same MAC addresses, with name as requested before and do not return an error", func() {
 				err := initKubemacpoolParams(rangeStart, rangeEnd)
 				Expect(err).ToNot(HaveOccurred())
@@ -425,7 +432,7 @@ var _ = Describe("Virtual Machines", func() {
 					}
 					return err
 
-				}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+				}, totalTimeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
 			})
 			It("should allow to assign to the VM the same MAC addresses, different name as requested before and do not return an error", func() {
 				err := initKubemacpoolParams(rangeStart, rangeEnd)
@@ -450,7 +457,7 @@ var _ = Describe("Virtual Machines", func() {
 					}
 					return err
 
-				}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+				}, totalTimeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
 			})
 		})
 


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
When a vm creation fails, the allocated mac stays in the configmap until a set wait-time - and then released in [vmWaitingCleanupLook() routine](https://github.com/k8snetworkplumbingwg/kubemacpool/blob/2982d1a7646a75eab32fa0e831a7f81b643d8c6e/pkg/pool-manager/virtualmachine_pool.go#L436).
This wait-time is given as an argument to the kubemacpool container in the deployment manifest.
Specifically, the wait-time in production manifests is bigger than the time we wait for the vm to be released in tests.
In order to fix that, we now read the wait-time from kubemacpool deployment and consider it during the relevant tests.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
