### PR TITLE
aligning wait-time of test to those of production

### DIFF
--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -260,7 +260,7 @@ spec:
       containers:
       - args:
         - --v=debug
-        - --wait-time=10
+        - --wait-time=600
         command:
         - /manager
         env:

--- a/config/test/kustomization.yaml
+++ b/config/test/kustomization.yaml
@@ -1,9 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patchesStrategicMerge:
-- manager_image_patch.yaml
 resources:
 - ../default
 images:
 - name: quay.io/kubevirt/kubemacpool
   newName: registry:5000/kubevirt/kubemacpool
+patches:
+  - path: manager_image_patch.yaml
+    target:
+      kind: Deployment
+      name: kubemacpool-mac-controller-manager
+      namespace: kubemacpool-system

--- a/config/test/manager_image_patch.yaml
+++ b/config/test/manager_image_patch.yaml
@@ -1,13 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: kubemacpool-mac-controller-manager
-  namespace: kubemacpool-system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-          - "--v=debug"
-          - "--wait-time=10"
+[
+{"op": "replace",
+ "path": "/spec/template/spec/containers/0/args/0",
+ "value": "--v=debug"}
+]

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -4,4 +4,4 @@ set -xe
 
 source ./cluster/kubevirtci.sh
 
-KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test ./tests/... $E2E_TEST_ARGS -timeout=20m -ginkgo.v -test.v -race
+KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test ./tests/... $E2E_TEST_ARGS -timeout=40m -ginkgo.v -test.v -race


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
wait-time is an argument passed by deployment to the kubemacpool manager pod.
When a vm is created but fails on a webhook that is not kubemacpool, then the mac should be retruned to the pool.
Since the kubemacpool controller cannot catch this cases, we use a goroutine thread that collects failed vms after the wait-time.

Currently we run on tests in a separate wait-time (10 seconds) than the one configured in production (10 min)
This can mask potential issues where the controller fails to do it's job from some reason, but the goroutine releases the mac and makes it look like all is good.

in order to run exactly as production, we want to change the wait-time to 10 mins - like in production.
This will cause tests to run +20min time (since the goroutine is chcked in 2 tests), so we change the test timeout accordingly

**Special notes for your reviewer**:

```release-note
NONE
```
