### PR TITLE
moving finalizer addition to webhook

### DIFF
--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -433,6 +433,12 @@ func (p *PoolManager) MarkVMAsReady(vm *kubevirt.VirtualMachine, parentLogger lo
 			return nil
 		}
 
+		if len(vm.Spec.Template.Spec.Domain.Devices.Interfaces) == 0 {
+			logger.Info("interface list is empty")
+			return nil
+		}
+
+		logger.V(1).Info("set vm's mac to status allocated", "vm interfaces", vm.Spec.Template.Spec.Domain.Devices.Interfaces)
 		for _, vmInterface := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
 			if vmInterface.MacAddress != "" {
 				p.macPoolMap[vmInterface.MacAddress] = AllocationStatusAllocated

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -522,7 +522,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					[]kubevirtv1.Network{newNetwork("br1")})
 				err = testClient.VirtClient.Create(context.TODO(), newVM)
 				Expect(err).To(HaveOccurred())
-				Expect(strings.Contains(err.Error(), "Failed to create virtual machine allocation error: the range is full")).To(Equal(true))
+				Expect(strings.Contains(err.Error(), "Failed to allocate mac to the vm object: the range is full")).To(Equal(true))
 
 				By("checking that the VM's NIC can be removed")
 


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Currently when a vm is created the finalizer is added in the controller, allowing for a small window for the vm to be deleted before creation reconcile puts the finalizer.
This can result with a mac to not be released properly from the kubemacpool internal cache.
The situation occurs especially in tests when create vm and deletion is very quick, and there are retryOnConflicts
    
In order to fix this, we insert the finalizer during the webhook request initiated by the vm creation.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
