### PR TITLE
Add external CNAO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,3 +307,12 @@ make cluster-down
 # Run function test
 make functest
 ```
+
+In order to run functests on external cluster
+with CNAO installed:
+
+``` bash 
+export KUBEVIRT_PROVIDER=external
+export CNAO_PROVIDER=external
+make functest
+```

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -25,11 +25,12 @@ if [[ "$KUBEVIRT_PROVIDER" != external ]]; then
     $(kubevirtci::path)/cluster-up/up.sh
 fi
 
-# Deploy CNA
-./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/namespace.yaml
-./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/network-addons-config.crd.yaml
-./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/operator.yaml
-./cluster/kubectl.sh create -f ./hack/cna/cna-cr.yaml
+if [[ "$CNAO_PROVIDER" != external ]]; then
+  # Deploy CNAO
+  ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/namespace.yaml
+  ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/network-addons-config.crd.yaml
+  ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/operator.yaml
+fi
 
 # wait for cluster operator
 ./cluster/kubectl.sh wait networkaddonsconfig cluster --for condition=Available --timeout=800s


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR adds new flag  `CNAO_PROVIDER` in cluster/up.sh
script, in order to support cluster that deployed with CNAO externally.

This is part of running tier1 tests on D/S  effort PRs, 
it will also improve the flow of how we run functest on external clusters.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
