### PR TITLE
Remove finalizer always

### DIFF
--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -12,7 +12,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -42,7 +43,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		Expect(err).ToNot(HaveOccurred(), "Should successfully list add VMs")
 		Expect(len(currentVMList.Items)).To(BeZero(), "There should be no VM's in the cluster before a test")
 
-		vmWaitConfigMap, err := testClient.KubeClient.CoreV1().ConfigMaps(managerNamespace).Get(names.WAITING_VMS_CONFIGMAP, meta_v1.GetOptions{})
+		vmWaitConfigMap, err := testClient.KubeClient.CoreV1().ConfigMaps(managerNamespace).Get(names.WAITING_VMS_CONFIGMAP, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Should successfully get %s ConfigMap", names.WAITING_VMS_CONFIGMAP))
 
 		By(fmt.Sprintf("Clearing the map inside %s configMap in-place instead of waiting to garbage-collector", names.WAITING_VMS_CONFIGMAP))
@@ -124,18 +125,52 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 
-		Context("When the client wants to create a vm on an opted-in namespace", func() {
-			It("should create a vm object and automatically assign a static MAC address", func() {
+		Context("When the client creates a vm on an opted-in namespace", func() {
+			var (
+				vm *kubevirtv1.VirtualMachine
+			)
+			BeforeEach(func() {
+				By("Restart kubemacpool to reset cache and mac range")
 				err := initKubemacpoolParams(rangeStart, rangeEnd)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "should success restarting kubemacpool to reset mac range and cache")
 
-				vm := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br", "")},
+				vm = CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br", "")},
 					[]kubevirtv1.Network{newNetwork("br")})
 
+				By("Create VM")
 				err = testClient.VirtClient.Create(context.TODO(), vm)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "should success creating the vm")
+			})
+			It("should automatically assign the vm with static MAC address within range", func() {
+				vmKey := types.NamespacedName{Namespace: vm.Namespace, Name: vm.Name}
+				By("Retrieve VM")
+				err := testClient.VirtClient.Get(context.TODO(), vmKey, vm)
+				Expect(err).ToNot(HaveOccurred(), "should success getting the VM after creating it")
+
 				_, err = net.ParseMAC(vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "should success parsing mac address")
+			})
+			Context("and then when we opt-out the namespace", func() {
+				BeforeEach(func() {
+					By("Clean test namespace labels to mark it as opted-out")
+					err := cleanNamespaceLabels(TestNamespace)
+					Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
+
+					By("Wait 5 seconds for namespace label clean-up to be propagated at server")
+					time.Sleep(5 * time.Second)
+				})
+				AfterEach(func() {
+					By("Put back the opt-in label at namespace")
+					err := addLabelsToNamespace(TestNamespace, map[string]string{vmNamespaceOptInLabel: "allocate"})
+					Expect(err).ToNot(HaveOccurred(), "should success adding opt-in label to namespace")
+
+					By("Wait 5 seconds for opt-in label at namespace to be propagated at server")
+					time.Sleep(5 * time.Second)
+				})
+				It("should able to be deleted", func() {
+					By("Delete the VM after opt-out the namespace")
+					deleteVMI(vm)
+				})
 			})
 		})
 
@@ -579,16 +614,22 @@ func newNetwork(name string) kubevirtv1.Network {
 }
 
 func deleteVMI(vm *kubevirtv1.VirtualMachine) {
+	By(fmt.Sprintf("Delete vm %s/%s", vm.Namespace, vm.Name))
 	err := testClient.VirtClient.Delete(context.TODO(), vm)
-	Expect(err).ToNot(HaveOccurred())
+	if errors.IsNotFound(err) {
+		return
+	}
+	Expect(err).ToNot(HaveOccurred(), "should success deleting VM")
 
+	By(fmt.Sprintf("Wait for vm %s/%s to be deleted", vm.Namespace, vm.Name))
 	Eventually(func() bool {
 		err = testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)
 		if err != nil && errors.IsNotFound(err) {
 			return true
 		}
+		Expect(err).ToNot(HaveOccurred(), "should success getting vm if is still there")
 		return false
-	}, timeout, pollingInterval).Should(BeTrue(), "failed to delete VM")
+	}, timeout, pollingInterval).Should(BeTrue(), "should eventually fail getting vm with IsNotFound after vm deletion")
 }
 
 func clearMap(inputMap map[string]string) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
When a VM is created at an opt-in namespace and namespace is changed to
opt-out has to be possible to delete that VM. This PR try to delete finalizer and update
mac cache always independent of being at opt-in or not.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Remove finalizer is independent of opt-in option.
```
