### PR TITLE
Correct the kube-admission-webhook version at go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/procfs v0.0.8 // indirect
-	github.com/qinqon/kube-admission-webhook v0.8.1-0.20200525102605-cc8da9191286
+	github.com/qinqon/kube-admission-webhook v0.8.0
 	go.uber.org/atomic v1.4.0 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	k8s.io/api v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -606,8 +606,6 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
 github.com/qinqon/kube-admission-webhook v0.8.0 h1:Gpe2jqav0P6ulZA3PTlmmBL+QiDD45fV3KBMEetqeaA=
 github.com/qinqon/kube-admission-webhook v0.8.0/go.mod h1:q/RO2hTfSH6UzaUVy6IN+yXSDd4FHSA/LGp7jpHFRwQ=
-github.com/qinqon/kube-admission-webhook v0.8.1-0.20200525102605-cc8da9191286 h1:sRCMbYp4N8F+ATbadjMV4EHaJ4eK4/EJKW+y2wjhijU=
-github.com/qinqon/kube-admission-webhook v0.8.1-0.20200525102605-cc8da9191286/go.mod h1:q/RO2hTfSH6UzaUVy6IN+yXSDd4FHSA/LGp7jpHFRwQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rlmcpherson/s3gof3r v0.5.0/go.mod h1:s7vv7SMDPInkitQMuZzH615G7yWHdrU2r/Go7Bo71Rs=


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
It was pointing to a commit id for the 0.8.0 not the tag.

**Special notes for your reviewer**:
They are the same version just different name.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
