### PR TITLE
Remove HEALT_PROBE_HOST and HEALT_PROBE_PORT

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -82,10 +82,6 @@ spec:
               configMapKeyRef:
                 name: mac-range-config
                 key: RANGE_END
-          - name: HEALTH_PROBE_HOST
-            value: "0.0.0.0"
-          - name: HEALTH_PROBE_PORT
-            value: "9440"
         resources:
           limits:
             cpu: 300m

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -282,10 +282,6 @@ spec:
             configMapKeyRef:
               key: RANGE_END
               name: kubemacpool-mac-range-config
-        - name: HEALTH_PROBE_HOST
-          value: 0.0.0.0
-        - name: HEALTH_PROBE_PORT
-          value: "9440"
         image: quay.io/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -282,10 +282,6 @@ spec:
             configMapKeyRef:
               key: RANGE_END
               name: kubemacpool-mac-range-config
-        - name: HEALTH_PROBE_HOST
-          value: 0.0.0.0
-        - name: HEALTH_PROBE_PORT
-          value: "9440"
         image: registry:5000/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -103,23 +103,9 @@ func (k *KubeMacPoolManager) Run(rangeStart, rangeEnd net.HardwareAddr) error {
 			log.Error(err, "failed to wait for leader election")
 			continue
 		}
-
-		healthProbeHost, ok := os.LookupEnv("HEALTH_PROBE_HOST")
-		if !ok {
-			log.Error(err, "Failed to load HEALTH_PROBE_HOST from environment variable")
-			os.Exit(1)
-		}
-
-		healthProbePort, ok := os.LookupEnv("HEALTH_PROBE_PORT")
-		if !ok {
-			log.Error(err, "Failed to load HEALTH_PROBE_PORT from environment variable")
-			os.Exit(1)
-		}
-
 		log.Info("Setting up Manager")
 		mgr, err := manager.New(k.config, manager.Options{
-			MetricsBindAddress:     k.metricsAddr,
-			HealthProbeBindAddress: fmt.Sprintf("%s:%s", healthProbeHost, healthProbePort),
+			MetricsBindAddress: k.metricsAddr,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to set up manager error %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
Latst kubemacpool does not use controller-runtime healt probe since it's using
the one at kube-admission-webhook, so we can remove the HEALT_PROBE_X environment
variables.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
