### PR TITLE
add logs to document failing scenarios in kubemacpool startup.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -87,7 +87,7 @@ func main() {
 
 	err = kubemacpoolManager.Run(rangeStart, rangeEnd)
 	if err != nil {
-		log.Error(err, "Failed to run the manager")
+		log.Error(err, "Failed to run the kubemacpool manager")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Currently in the main Run() method, we don't log error in case something fails.
We want to exit the Run() method should a irreconcilable error occur, and a proper log to be added in that case.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
