### PR TITLE
README: production user should change mac range

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,32 +8,29 @@ For VirtualMachines, it also allocates a mac address for the primary interface i
 
 ## Usage
 
-For test environment you can use the [development environment](#Develop)
+For test environment you can use the [development environment](#Develop).
 
 For Production deployment:
 
-Install any supported [Network Plumbing Working Group de-facto standard](https://github.com/k8snetworkplumbingwg/multi-net-spec) implementation.
-
-For example [Multus](https://github.com/intel/multus-cni).
-To deploy multus on a kubernetes cluster with flannel cni.
+* Install any supported [Network Plumbing Working Group de-facto standard](https://github.com/k8snetworkplumbingwg/multi-net-spec) implementation, for example [Multus](https://github.com/intel/multus-cni).
+  To deploy multus on a kubernetes cluster with flannel cni:
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/kubemacpool/master/hack/multus/kubernetes-multus.yaml
 kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/kubemacpool/master/hack/multus/multus.yaml
 ```
 
-[CNI plugins](https://github.com/containernetworking/plugins) must be installed in the cluster.
-For CNI plugins you can use the follow command to deploy them inside your cluster.
-
+* [CNI plugins](https://github.com/containernetworking/plugins) must be installed in the cluster, for example
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/kubemacpool/master/hack/cni-plugins/cni-plugins.yaml
 ```
 
-
-Download the project yaml and apply it.
-
-**note:** default mac range is from 02:00:00:00:00:00 to FD:FF:FF:FF:FF:FF the can be edited in the configmap
+* Download the project yaml and modify its mac range to avoid collisions with nearby clusters.
+  Finally, deploy the project by applying its yaml.
 ```bash
 wget https://raw.githubusercontent.com/k8snetworkplumbingwg/kubemacpool/master/config/release/kubemacpool.yaml
+mac_oui=02:`openssl rand -hex 1`:`openssl rand -hex 1`
+sed -i "s/02:00:00:00:00:00/$mac_oui:00:00:00/" kubemacpool.yaml
+sed -i "s/02:FF:FF:FF:FF:FF/$mac_oui:FF:FF:FF/" kubemacpool.yaml
 kubectl apply -f ./kubemacpool.yaml
 ```
 


### PR DESCRIPTION
It is important to set a distinct seemingly-random range for each cluster.
If nearby clusters are deployed with the same range and using Layer 2 CNIs, inter-cluster collision would be likely.

This PR states this explicitly and provides bash code to do that. While at it, this PR also makes the relevant section more readable.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
