### PR TITLE
change kubemacpool tests to work on CNAO based clusters

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -23,3 +23,5 @@ const WAITING_VMS_CONFIGMAP = "kubemacpool-vm-configmap"
 const WAIT_TIME_ARG = "wait-time"
 
 const LEADER_READY_CONDITION_TYPE = "kubemacpool.io/leader-ready"
+
+const CNAO_DEPLOYMENT = "cluster-network-addons-operator"

--- a/tests/pods_test.go
+++ b/tests/pods_test.go
@@ -52,12 +52,12 @@ var _ = Describe("Pods", func() {
 			}
 
 			// Restore the default number of managers
-			err := changeManagerReplicas(defaultNumberOfReplicas)
+			err := changeDeploymentReplicas(names.MANAGER_DEPLOYMENT, defaultNumberOfReplicas)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		testCriticalNamespace := func(namespace string, namespaceLabelMap map[string]string, matcher types.GomegaMatcher) {
-			err := changeManagerReplicas(0)
+			err := changeDeploymentReplicas(names.MANAGER_DEPLOYMENT, 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = addLabelsToNamespace(OtherTestNamespace, namespaceLabelMap)


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Currently kubemacpool u/s tests running on cnao cluster encounter the operator reconcile that returns the range values to original set range. in order to allow tests to run without this reconcile, we also initiate cnao deployment restart (if needed) at the beginning of each test.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
