### PR TITLE
Add leader election with pod restart e2e test

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -4,4 +4,4 @@ set -xe
 
 source ./cluster/kubevirtci.sh
 
-KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test ./tests/... $E2E_TEST_ARGS -timeout=40m -ginkgo.v -test.v -race
+KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test ./tests $E2E_TEST_ARGS -timeout=40m -ginkgo.v -test.v -race

--- a/tests/cmd/kubectl.go
+++ b/tests/cmd/kubectl.go
@@ -1,0 +1,10 @@
+package cmd
+
+import (
+	"github.com/k8snetworkplumbingwg/kubemacpool/tests/environment"
+)
+
+func Kubectl(arguments ...string) (string, error) {
+	kubectl := environment.GetVarWithDefault("KUBECTL", "cluster/kubectl.sh")
+	return Run(kubectl, false, arguments...)
+}

--- a/tests/cmd/run.go
+++ b/tests/cmd/run.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+)
+
+func Run(command string, quiet bool, arguments ...string) (string, error) {
+	cmd := exec.Command(command, arguments...)
+	cmd.Dir = ".."
+	if !quiet {
+		GinkgoWriter.Write([]byte(command + " " + strings.Join(arguments, " ") + "\n"))
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if !quiet {
+		GinkgoWriter.Write([]byte(fmt.Sprintf("stdout: %.500s...\n, stderr %s\n", stdout.String(), stderr.String())))
+	}
+	return stdout.String(), err
+}

--- a/tests/environment/environment.go
+++ b/tests/environment/environment.go
@@ -1,0 +1,13 @@
+package environment
+
+import (
+	"os"
+)
+
+func GetVarWithDefault(name string, defaultValue string) string {
+	value := os.Getenv(name)
+	if len(value) == 0 {
+		value = defaultValue
+	}
+	return value
+}

--- a/tests/leader_test.go
+++ b/tests/leader_test.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/k8snetworkplumbingwg/kubemacpool/tests/cmd"
+)
+
+var _ = Describe("Leader election mechanism", func() {
+	Context("when kubemacpool pod is re-started with 1 replica", func() {
+		BeforeEach(func() {
+			By("Changing replicas to 0 to start from the beginning")
+			err := changeManagerReplicas(0)
+			Expect(err).To(Succeed(), "should succeed changing replicas to 0")
+
+			By("Changing replicast to 1 to have just on pod with leader election")
+			err = changeManagerReplicas(1)
+			Expect(err).To(Succeed(), "should succeed changing replicas to 1")
+
+			By("Retrieving leader pod")
+			leaderPod, err := getLeaderPod()
+			Expect(err).To(Succeed(), "should succeed getting leader kubemacpool pod")
+
+			By("Sending SIGTERM signal to restart leader pod")
+			killCmd := []string{"exec", "-n", leaderPod.Namespace, leaderPod.Name, "--", "/bin/bash", "-c", "kill -s SIGTERM 1"}
+			output, err := cmd.Kubectl(killCmd...)
+			Expect(err).To(Succeed(), fmt.Sprintf("should succeed killing leader kubemacpool pod: %s", output))
+			waitManagerDeploymentReady()
+
+		})
+		AfterEach(func() {
+			err := changeManagerReplicas(0)
+			Expect(err).To(Succeed(), "should succeed changing replicas to 0")
+
+			err = changeManagerReplicas(2)
+			Expect(err).To(Succeed(), "should succeed changing replicas to 2")
+		})
+		It("should preserver leader label", func() {
+			Consistently(func() error {
+				_, err := getLeaderPod()
+				return err
+			}, 1*time.Minute, 1*time.Second).Should(Succeed(), "should succeed getting leader kubemacpool pod")
+		})
+	})
+})

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -302,11 +302,13 @@ func waitManagerDeploymentReady() {
 	Eventually(func() (corev1.ConditionStatus, error) {
 		managerDeployment, err := testClient.KubeClient.AppsV1().Deployments(managerNamespace).Get(context.TODO(), names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
 		if err != nil {
-			return corev1.ConditionUnknown, err
+			By(fmt.Sprintf("Retrying on getting deployments error %v", err))
+			return corev1.ConditionUnknown, nil
 		}
 		pods, err := getKubemacpoolPods()
 		if err != nil {
-			return corev1.ConditionUnknown, err
+			By(fmt.Sprintf("Retrying on getting kubemacpool pods error %v", err))
+			return corev1.ConditionUnknown, nil
 		}
 		if int32(len(pods.Items)) != *managerDeployment.Spec.Replicas {
 			return corev1.ConditionUnknown, nil

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	pool_manager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
+	"github.com/k8snetworkplumbingwg/kubemacpool/tests/cmd"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 )
 
@@ -601,6 +602,41 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
 
 				Expect(len(newVM.Spec.Template.Spec.Domain.Devices.Interfaces) == 1).To(Equal(true))
+			})
+		})
+		Context("when kubemacpool pod is re-started with 1 replica", func() {
+			BeforeEach(func() {
+				By("Changing replicas to 0 to start from the beginning")
+				err := changeManagerReplicas(0)
+				Expect(err).To(Succeed(), "should succeed changing replicas to 0")
+
+				By("Changing replicast to 1 to have just on pod with leader election")
+				err = changeManagerReplicas(1)
+				Expect(err).To(Succeed(), "should succeed changing replicas to 1")
+
+				By("Retrieving leader pod")
+				leaderPod, err := getLeaderPod()
+				Expect(err).To(Succeed(), "should succeed getting leader kubemacpool pod")
+
+				By("Sending SIGTERM signal to restart leader pod")
+				killCmd := []string{"exec", "-n", leaderPod.Namespace, leaderPod.Name, "--", "/bin/bash", "-c", "kill -s SIGTERM 1"}
+				output, err := cmd.Kubectl(killCmd...)
+				Expect(err).To(Succeed(), fmt.Sprintf("should succeed killing leader kubemacpool pod: %s", output))
+				waitManagerDeploymentReady()
+
+			})
+			AfterEach(func() {
+				err := changeManagerReplicas(0)
+				Expect(err).To(Succeed(), "should succeed changing replicas to 0")
+
+				err = changeManagerReplicas(2)
+				Expect(err).To(Succeed(), "should succeed changing replicas to 2")
+			})
+			It("should preserver leader label", func() {
+				Consistently(func() error {
+					_, err := getLeaderPod()
+					return err
+				}, 1*time.Minute, 1*time.Second).Should(Succeed(), "should succeed getting leader kubemacpool pod")
 			})
 		})
 	})

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	pool_manager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
-	"github.com/k8snetworkplumbingwg/kubemacpool/tests/cmd"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 )
 
@@ -602,41 +601,6 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
 
 				Expect(len(newVM.Spec.Template.Spec.Domain.Devices.Interfaces) == 1).To(Equal(true))
-			})
-		})
-		Context("when kubemacpool pod is re-started with 1 replica", func() {
-			BeforeEach(func() {
-				By("Changing replicas to 0 to start from the beginning")
-				err := changeManagerReplicas(0)
-				Expect(err).To(Succeed(), "should succeed changing replicas to 0")
-
-				By("Changing replicast to 1 to have just on pod with leader election")
-				err = changeManagerReplicas(1)
-				Expect(err).To(Succeed(), "should succeed changing replicas to 1")
-
-				By("Retrieving leader pod")
-				leaderPod, err := getLeaderPod()
-				Expect(err).To(Succeed(), "should succeed getting leader kubemacpool pod")
-
-				By("Sending SIGTERM signal to restart leader pod")
-				killCmd := []string{"exec", "-n", leaderPod.Namespace, leaderPod.Name, "--", "/bin/bash", "-c", "kill -s SIGTERM 1"}
-				output, err := cmd.Kubectl(killCmd...)
-				Expect(err).To(Succeed(), fmt.Sprintf("should succeed killing leader kubemacpool pod: %s", output))
-				waitManagerDeploymentReady()
-
-			})
-			AfterEach(func() {
-				err := changeManagerReplicas(0)
-				Expect(err).To(Succeed(), "should succeed changing replicas to 0")
-
-				err = changeManagerReplicas(2)
-				Expect(err).To(Succeed(), "should succeed changing replicas to 2")
-			})
-			It("should preserver leader label", func() {
-				Consistently(func() error {
-					_, err := getLeaderPod()
-					return err
-				}, 1*time.Minute, 1*time.Second).Should(Succeed(), "should succeed getting leader kubemacpool pod")
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
There is a bug that cleans up the leader label if the pod get restarted and
elected again as leader, to be sure the pod is elected again the test
set the replicas to 1

**Special notes for your reviewer**:
It copy paste some test packages from kubernetes-nmstate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
