### PR TITLE
Update leader label only at pods with label 'app=kubemacpool'

### DIFF
--- a/pkg/manager/leaderelection.go
+++ b/pkg/manager/leaderelection.go
@@ -71,7 +71,13 @@ func (k *KubeMacPoolManager) setLeadershipConditions(status corev1.ConditionStat
 func updateLeaderLabel(kubeClient client.Client, leaderPodName, managerNamespace string) error {
 	logger := logf.Log.WithName("UpdateLeaderLabel")
 	podList := corev1.PodList{}
-	err := kubeClient.List(context.TODO(), &podList, &client.ListOptions{Namespace: managerNamespace})
+
+	byNamespaceAndApp := &client.ListOptions{Namespace: managerNamespace}
+	client.MatchingLabels{
+		"app": "kubemacpool",
+	}.ApplyToList(byNamespaceAndApp)
+
+	err := kubeClient.List(context.TODO(), &podList, byNamespaceAndApp)
 	if err != nil {
 		return errors.Wrap(err, "failed to list kubemacpool manager pods")
 	}


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR update the `kubermacpool-leader` label only at pods with app=kubemacpool label, oherwise it iterate over all the pods at the same namespace, this is not a critical bug is kind of cosmetics but it reduce the time to update leader label.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
