### PR TITLE
Remove pod range change in tests

### DIFF
--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -190,7 +190,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  RANGE_END: 02:FF:FF:FF:FF:FF
+  RANGE_END: 02:00:00:00:00:0F
   RANGE_START: "02:00:00:00:00:00"
 kind: ConfigMap
 metadata:

--- a/config/test/kustomization.yaml
+++ b/config/test/kustomization.yaml
@@ -11,3 +11,8 @@ patches:
       kind: Deployment
       name: kubemacpool-mac-controller-manager
       namespace: kubemacpool-system
+  - path: manager_range_patch.yaml
+    target:
+      kind: ConfigMap
+      name: mac-range-config
+      namespace: kubemacpool-system

--- a/config/test/manager_range_patch.yaml
+++ b/config/test/manager_range_patch.yaml
@@ -1,0 +1,5 @@
+[
+{"op": "replace",
+ "path": "/data/RANGE_END",
+ "value": "02:00:00:00:00:0F"}
+]

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -18,6 +18,7 @@ package pool_manager
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net"
 	"sync"
@@ -211,4 +212,17 @@ func (p *PoolManager) isInstanceOptedIn(namespaceName, mutatingWebhookConfigName
 	}
 
 	return false, nil
+}
+
+func GetMacPoolSize(rangeStart, rangeEnd net.HardwareAddr) (uint64, error) {
+	err := checkRange(rangeStart, rangeEnd)
+	if err != nil {
+		return 0, errors.Wrap(err, "mac Pool Size  is negative")
+	}
+
+	//making sure Uint64 receives an byte slice of size 8
+	startInt := binary.BigEndian.Uint64(append([]byte{0x0, 0x0}, rangeStart...))
+	endInt := binary.BigEndian.Uint64(append([]byte{0x0, 0x0}, rangeEnd...))
+
+	return endInt - startInt + 1, nil
 }

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -110,26 +110,26 @@ var _ = Describe("Pool", func() {
 
 		table.DescribeTable("should check that a mac pool size is reported correctly", func(startMacAddr, endMacAddr string, expectedSize float64, needToSucceed bool) {
 			startMacAddrHW, err := net.ParseMAC(startMacAddr)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Should succeed parsing startMacAddr")
 			endMacAddrHW, err := net.ParseMAC(endMacAddr)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Should succeed parsing endMacAddr")
 			poolSize, err := GetMacPoolSize(startMacAddrHW, endMacAddrHW)
 			if needToSucceed {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(float64(poolSize)).To(Equal(expectedSize))
+				Expect(err).ToNot(HaveOccurred(), "Should succeed getting Mac Pool size")
+				Expect(float64(poolSize)).To(Equal(expectedSize), "Should get the expected pool size value")
 			} else {
-				Expect(err).To(HaveOccurred())
+				Expect(err).To(HaveOccurred(), "Should fail getting Mac Pool size duu to invalid params")
 			}
 		},
-			table.Entry("Start: 40:00:00:00:00:00  End: 50:00:00:00:00:00", "40:00:00:00:00:00", "50:00:00:00:00:00", math.Pow(2, 11*4)+1, true),
-			table.Entry("Start: 02:00:00:00:00:00  End: 03:00:00:00:00:00", "02:00:00:00:00:00", "03:00:00:00:00:00", math.Pow(2, 10*4)+1, true),
-			table.Entry("Start: 02:00:00:00:00:00  End: 02:01:00:00:00:00", "02:00:00:00:00:00", "02:01:00:00:00:00", math.Pow(2, 8*4)+1, true),
-			table.Entry("Start: 02:00:00:00:00:00  End: 02:00:00:10:00:00", "02:00:00:00:00:00", "02:00:00:10:00:00", math.Pow(2, 5*4)+1, true),
-			table.Entry("Start: 02:00:00:00:00:10  End: 02:00:00:00:00:00", "02:00:00:00:00:00", "02:00:00:00:00:10", math.Pow(2, 1*4)+1, true),
-			table.Entry("Start: 00:00:00:00:00:01  End: 00:00:00:00:00:00", "00:00:00:00:00:01", "00:00:00:00:00:00", float64(0), false),
-			table.Entry("Start: 80:00:00:00:00:00  End: 00:00:00:00:00:00", "80:00:00:00:00:00", "00:00:00:00:00:00", float64(0), false),
-			table.Entry("Start: FF:FF:FF:FF:FF:FF  End: FF:FF:FF:FF:FF:FF", "FF:FF:FF:FF:FF:FF", "FF:FF:FF:FF:FF:FF", float64(0), false),
-			table.Entry("Start: 00:00:00:00:00:00  End: 00:00:00:00:00:00", "00:00:00:00:00:00", "00:00:00:00:00:00", float64(0), false),
+			table.Entry("Start: 40:00:00:00:00:00  End: 50:00:00:00:00:00 should succeed", "40:00:00:00:00:00", "50:00:00:00:00:00", math.Pow(2, 11*4)+1, true),
+			table.Entry("Start: 02:00:00:00:00:00  End: 03:00:00:00:00:00 should succeed", "02:00:00:00:00:00", "03:00:00:00:00:00", math.Pow(2, 10*4)+1, true),
+			table.Entry("Start: 02:00:00:00:00:00  End: 02:01:00:00:00:00 should succeed", "02:00:00:00:00:00", "02:01:00:00:00:00", math.Pow(2, 8*4)+1, true),
+			table.Entry("Start: 02:00:00:00:00:00  End: 02:00:00:10:00:00 should succeed", "02:00:00:00:00:00", "02:00:00:10:00:00", math.Pow(2, 5*4)+1, true),
+			table.Entry("Start: 02:00:00:00:00:10  End: 02:00:00:00:00:00 should succeed", "02:00:00:00:00:00", "02:00:00:00:00:10", math.Pow(2, 1*4)+1, true),
+			table.Entry("Start: 00:00:00:00:00:01  End: 00:00:00:00:00:00 should fail", "00:00:00:00:00:01", "00:00:00:00:00:00", float64(0), false),
+			table.Entry("Start: 80:00:00:00:00:00  End: 00:00:00:00:00:00 should fail", "80:00:00:00:00:00", "00:00:00:00:00:00", float64(0), false),
+			table.Entry("Start: FF:FF:FF:FF:FF:FF  End: FF:FF:FF:FF:FF:FF should fail", "FF:FF:FF:FF:FF:FF", "FF:FF:FF:FF:FF:FF", float64(0), false),
+			table.Entry("Start: 00:00:00:00:00:00  End: 00:00:00:00:00:00 should fail", "00:00:00:00:00:00", "00:00:00:00:00:00", float64(0), false),
 		)
 	})
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package utils
 
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
 func ContainsString(slice []string, s string) bool {
 	for _, item := range slice {
 		if item == s {
@@ -33,4 +40,18 @@ func RemoveString(slice []string, s string) (result []string) {
 		result = append(result, item)
 	}
 	return
+}
+
+func ConvertHwAddrToInt64(address net.HardwareAddr) (int64, error) {
+	var addressTokenList []string
+	for _, octet := range address {
+		addressTokenList = append(addressTokenList, fmt.Sprintf("%02x", octet))
+	}
+	addressString := strings.Join(addressTokenList, "")
+	addressValue, err := strconv.ParseInt(addressString, 16, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return addressValue, nil
 }

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+"testing"
+
+. "github.com/onsi/ginkgo"
+. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"math"
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/extensions/table"
+)
+
+var _ = Describe("Utils", func() {
+
+	Describe("Internal Functions", func() {
+		table.DescribeTable("should convert from mac address to int64 correctly", func(macAddr string, expectedValue float64 ) {
+			macAddrHW, err := net.ParseMAC(macAddr)
+			Expect(err).ToNot(HaveOccurred(), "should succeed parsing the mac address")
+			convertedMacAddrValue, err := ConvertHwAddrToInt64(macAddrHW)
+			Expect(err).ToNot(HaveOccurred(), "should succeed converting the mac address to int64 value")
+			Expect(float64(convertedMacAddrValue)).To(Equal(expectedValue), "should match expected value")
+		},
+			table.Entry("10:00:00:00:00:00 -> 2^44", "10:00:00:00:00:00", math.Pow(2,11*4)),
+			table.Entry("01:00:00:00:00:00 -> 2^40", "01:00:00:00:00:00", math.Pow(2,10*4)),
+			table.Entry("00:00:00:00:00:10 -> 2^4", "00:00:00:00:00:10", math.Pow(2,1*4)),
+			table.Entry("00:00:00:10:00:00 -> 2^20", "00:00:00:10:00:00", math.Pow(2,5*4)),
+			table.Entry("00:00:00:00:00:01 -> 2^0", "00:00:00:00:00:01", math.Pow(2,0*4)),
+			table.Entry("00:00:00:00:00:00 -> 0", "00:00:00:00:00:00", float64(0)),
+			table.Entry("FF:FF:FF:FF:FF:FF -> 0", "FF:FF:FF:FF:FF:FF", math.Pow(2,12*4)-1),
+		)
+	})
+})

--- a/tests/pods_test.go
+++ b/tests/pods_test.go
@@ -24,6 +24,9 @@ var _ = Describe("Pods", func() {
 				err := addLabelsToNamespace(namespace, map[string]string{podNamespaceOptInLabel: "allocate"})
 				Expect(err).ToNot(HaveOccurred(), "should be able to add the namespace labels")
 			}
+
+			err := initKubemacpoolParams()
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -76,9 +79,6 @@ var _ = Describe("Pods", func() {
 		}
 
 		It("should create a pod when mac pool is running in a regular opted-in namespace", func() {
-			err := initKubemacpoolParams(rangeStart, rangeEnd)
-			Expect(err).ToNot(HaveOccurred())
-
 			podObject := createPodObject()
 
 			Eventually(func() bool {
@@ -92,11 +92,8 @@ var _ = Describe("Pods", func() {
 		})
 
 		It("should create a pod when mac pool is running in a regular opted-out namespace (disabled label)", func() {
-			err := initKubemacpoolParams(rangeStart, rangeEnd)
-			Expect(err).ToNot(HaveOccurred())
-
 			By("updating the namespace opt-in label to disabled")
-			err = cleanNamespaceLabels(TestNamespace)
+			err := cleanNamespaceLabels(TestNamespace)
 			Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
 			err = addLabelsToNamespace(TestNamespace, map[string]string{podNamespaceOptInLabel: "disable"})
 			Expect(err).ToNot(HaveOccurred(), "should be able to add the namespace labels")
@@ -114,11 +111,8 @@ var _ = Describe("Pods", func() {
 		})
 
 		It("should create a pod when mac pool is running in a regular opted-out namespace (no label)", func() {
-			err := initKubemacpoolParams(rangeStart, rangeEnd)
-			Expect(err).ToNot(HaveOccurred())
-
 			By("removing the namespace opt-in label")
-			err = cleanNamespaceLabels(TestNamespace)
+			err := cleanNamespaceLabels(TestNamespace)
 			Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
 
 			podObject := createPodObject()

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -190,7 +190,7 @@ func initKubemacpoolParams() error {
 	return nil
 }
 
-func getMacPoolSize() uint64 {
+func getMacPoolSize() int64 {
 	configMap, err := testClient.KubeClient.CoreV1().ConfigMaps(managerNamespace).Get(context.TODO(), "kubemacpool-mac-range-config", metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred(), "Should succeed getting kubemacpool range configmap")
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -200,11 +200,8 @@ func setRangeInRangeConfigMap(rangeStart, rangeEnd string) error {
 }
 
 func initKubemacpoolParams(rangeStart, rangeEnd string) error {
-	By("Restart kubemacpool to reset cache and mac range")
-	err := setRangeInRangeConfigMap(rangeStart, rangeEnd)
-	Expect(err).ToNot(HaveOccurred(), "Should succeed setting range in the range config map")
-
-	err = restartKubemacpoolManagerPods()
+	By("Restart Kubemacpool Pods")
+	err := restartKubemacpoolManagerPods()
 	Expect(err).ToNot(HaveOccurred(), "Should succeed resetting the kubemacpool pods")
 
 	return nil

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -43,8 +43,6 @@ const (
 var (
 	managerNamespace         = ""
 	gracePeriodSeconds int64 = 3
-	rangeStart               = "02:00:00:00:00:00"
-	rangeEnd                 = "02:FF:FF:FF:FF:FF"
 	testClient         *TestClient
 )
 
@@ -199,7 +197,7 @@ func setRangeInRangeConfigMap(rangeStart, rangeEnd string) error {
 	return nil
 }
 
-func initKubemacpoolParams(rangeStart, rangeEnd string) error {
+func initKubemacpoolParams() error {
 	By("Restart Kubemacpool Pods")
 	err := restartKubemacpoolManagerPods()
 	Expect(err).ToNot(HaveOccurred(), "Should succeed resetting the kubemacpool pods")

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -180,23 +180,6 @@ func restartKubemacpoolManagerPods() error {
 	return nil
 }
 
-func setRangeInRangeConfigMap(rangeStart, rangeEnd string) error {
-	configMap, err := testClient.KubeClient.CoreV1().ConfigMaps(managerNamespace).Get(context.TODO(), "kubemacpool-mac-range-config", metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	configMap.Data["RANGE_START"] = rangeStart
-	configMap.Data["RANGE_END"] = rangeEnd
-
-	_, err = testClient.KubeClient.CoreV1().ConfigMaps(managerNamespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func initKubemacpoolParams() error {
 	By("Restart Kubemacpool Pods")
 	err := restartKubemacpoolManagerPods()

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -278,7 +278,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 		Context("When trying to create a VM after all MAC addresses in range have been occupied", func() {
-			PIt("[test_id:2162]should return an error because no MAC address is available", func() {
+			It("[test_id:2162]should return an error because no MAC address is available", func() {
 				//err := initKubemacpoolParams("02:00:00:00:00:00", "02:00:00:00:00:01")
 				//Expect(err).ToNot(HaveOccurred())
 
@@ -300,7 +300,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 		Context("when trying to create a VM after a MAC address has just been released duo to a VM deletion", func() {
-			PIt("[test_id:2165]should re-use the released MAC address for the creation of the new VM and not return an error", func() {
+			It("[test_id:2165]should re-use the released MAC address for the creation of the new VM and not return an error", func() {
 				//err := initKubemacpoolParams("02:00:00:00:00:00", "02:00:00:00:00:02")
 				//Expect(err).ToNot(HaveOccurred())
 				vm1 := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br1", ""),
@@ -515,7 +515,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 		Context("When a VM's NIC is removed and a new VM is created with the same MAC", func() {
-			PIt("[test_id:2995]should successfully release the MAC and the new VM should be created with no errors", func() {
+			It("[test_id:2995]should successfully release the MAC and the new VM should be created with no errors", func() {
 				//err := initKubemacpoolParams("02:00:00:00:00:00", "02:00:00:00:00:01")
 				//Expect(err).ToNot(HaveOccurred())
 

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -297,7 +297,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 		Context("When trying to create a VM after all MAC addresses in range have been occupied", func() {
-			It("[test_id:2162]should return an error because no MAC address is available", func() {
+			PIt("[test_id:2162]should return an error because no MAC address is available", func() {
 				err := initKubemacpoolParams("02:00:00:00:00:00", "02:00:00:00:00:01")
 				Expect(err).ToNot(HaveOccurred())
 
@@ -319,7 +319,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 		Context("when trying to create a VM after a MAC address has just been released duo to a VM deletion", func() {
-			It("[test_id:2165]should re-use the released MAC address for the creation of the new VM and not return an error", func() {
+			PIt("[test_id:2165]should re-use the released MAC address for the creation of the new VM and not return an error", func() {
 				err := initKubemacpoolParams("02:00:00:00:00:00", "02:00:00:00:00:02")
 				Expect(err).ToNot(HaveOccurred())
 
@@ -553,7 +553,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 		Context("When a VM's NIC is removed and a new VM is created with the same MAC", func() {
-			It("[test_id:2995]should successfully release the MAC and the new VM should be created with no errors", func() {
+			PIt("[test_id:2995]should successfully release the MAC and the new VM should be created with no errors", func() {
 				err := initKubemacpoolParams("02:00:00:00:00:00", "02:00:00:00:00:01")
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Currently during each start of kubemacpool tier1 test, we perform an initilazaion of the mac-range configmap.
This ability is not supported outside of the kubemacpool standalone repo, and so it makes it a problem to run tier1 tests on CNAO (for example).
We would like to change the test behavior to stop using range change.
In order to do that, we will remove the mac range change, and instead change tests the check depleted mac pools, to allocate filler vms that will deplete the mac pool. Also, we will change the range in kubemacpool repo to 16 macs in the test manifest.
This way, if some external repo like CNAO wants to run teir1 tests, they can will skip these tests using the common phrase "mac-pool is full".

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
