### PR TITLE
Fix external provider cluster up

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -19,43 +19,45 @@ set -ex
 source ./cluster/kubevirtci.sh
 CNAO_VERSIOV=0.35.0
 KUBEVIRT_VERSION=v0.29.0
+DEPLOY_KUBEVIRT=${DEPLOY_KUBEVIRT:-true}
 kubevirtci::install
 
-if [[ "$KUBEVIRT_PROVIDER" != external ]]; then
+if [[ "${KUBEVIRT_PROVIDER}" != external ]]; then
     $(kubevirtci::path)/cluster-up/up.sh
+
+    # Deploy CNAO
+    ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/namespace.yaml
+    ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/network-addons-config.crd.yaml
+    ./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/operator.yaml
+    ./cluster/kubectl.sh create -f ./hack/cna/cna-cr.yaml
+
+    # wait for cluster operator
+    ./cluster/kubectl.sh wait networkaddonsconfig cluster --for condition=Available --timeout=800s
 fi
 
-# Deploy CNA
-./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/namespace.yaml
-./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/network-addons-config.crd.yaml
-./cluster/kubectl.sh create -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/${CNAO_VERSIOV}/operator.yaml
-./cluster/kubectl.sh create -f ./hack/cna/cna-cr.yaml
+if [[ "${DEPLOY_KUBEVIRT}" == "true" ]]; then
+    # deploy kubevirt
+    ./cluster/kubectl.sh apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
 
-# wait for cluster operator
-./cluster/kubectl.sh wait networkaddonsconfig cluster --for condition=Available --timeout=800s
+    # Ensure the KubeVirt CRD is created
+    count=0
+    until ./cluster/kubectl.sh get crd kubevirts.kubevirt.io; do
+        ((count++)) && ((count == 30)) && echo "KubeVirt CRD not found" && exit 1
+        echo "waiting for KubeVirt CRD"
+        sleep 1
+    done
 
+    ./cluster/kubectl.sh apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
 
-# deploy kubevirt
-./cluster/kubectl.sh apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
+    # Ensure the KubeVirt CR is created
+    count=0
+    until ./cluster/kubectl.sh -n kubevirt get kv kubevirt; do
+        ((count++)) && ((count == 30)) && echo "KubeVirt CR not found" && exit 1
+        echo "waiting for KubeVirt CR"
+        sleep 1
+    done
 
-# Ensure the KubeVirt CRD is created
-count=0
-until ./cluster/kubectl.sh get crd kubevirts.kubevirt.io; do
-    ((count++)) && ((count == 30)) && echo "KubeVirt CRD not found" && exit 1
-    echo "waiting for KubeVirt CRD"
-    sleep 1
-done
-
-./cluster/kubectl.sh apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
-
-# Ensure the KubeVirt CR is created
-count=0
-until ./cluster/kubectl.sh -n kubevirt get kv kubevirt; do
-    ((count++)) && ((count == 30)) && echo "KubeVirt CR not found" && exit 1
-    echo "waiting for KubeVirt CR"
-    sleep 1
-done
-
-./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 180s || (echo "KubeVirt not ready in time" && exit 1)
+    ./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 180s || (echo "KubeVirt not ready in time" && exit 1)
+fi
 
 echo "Done"


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Currently external provider does not exclude deployment of private CNAO instance and kubevirt deployment.
We want to ignore apply of private CNAO component, since if run in external provider, they are already deployed by external cluster.
Also, we want to change kubevirt deployment to be optional by env var, should we want to run in hco cluster where kubevirt is already deployed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
