### PR TITLE
move to use latest z stream kubevirt release

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -14,11 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex
+set -ex pipefail
+
+function getLatestPatchVersion {
+  local major_minors=$1
+  curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep .tag_name | grep ${major_minors} | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs
+}
 
 source ./cluster/kubevirtci.sh
 CNAO_VERSIOV=0.35.0
-KUBEVIRT_VERSION=v0.29.0
+#use kubevirt latest z stream release
+
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.31)
 kubevirtci::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>


**What this PR does / why we need it**:
Currently we're using a fixed version of kubevirt.
Lets move to use the latest z stram  release kubevirt release of a fixed major, and benefit from the bug improvements and featuresthat the latest stable release has to offer.
master branch can use fixed major-minor of v0.31. 
I think it's not very risky considering kubevirt's role in kubemacpool operation.

**Special notes for your reviewer**:

**Release note**:

```release-note
use kubevirt latest release
```
