### PR TITLE
update damonsets to apps/v1 in manifests

### DIFF
--- a/hack/cni-plugins/cni-plugins.yaml
+++ b/hack/cni-plugins/cni-plugins.yaml
@@ -27,8 +27,21 @@ spec:
         effect: NoSchedule
       containers:
       - name: cni-plugins
-        image: quay.io/kubevirt/cni-default-plugins@sha256:bbb636f838711f035cd5ce0d0578c6a69b60416a363293f1b7f2e009c040d53a
+        image: quay.io/kubevirt/cni-default-plugins:v0.8.6
         imagePullPolicy: IfNotPresent
+        command:
+          - /bin/bash
+          - -c
+          - |
+            cp -rf /usr/src/containernetworking/plugins/bin/*bridge /opt/cni/bin/
+            cp -rf /usr/src/containernetworking/plugins/bin/*tuning /opt/cni/bin/
+            # Some projects (e.g. openshift/console) use cnv- prefix to distinguish between
+            # binaries shipped by OpenShift and those shipped by KubeVirt (D/S matters).
+            # Following two lines make sure we will provide both names when needed.
+            find /opt/cni/bin/cnv-bridge || ln -s /opt/cni/bin/bridge /opt/cni/bin/cnv-bridge
+            find /opt/cni/bin/cnv-tuning || ln -s /opt/cni/bin/tuning /opt/cni/bin/cnv-tuning
+            echo "Entering sleep... (success)"
+            sleep infinity
         resources:
           requests:
             cpu: "100m"

--- a/hack/cni-plugins/cni-plugins.yaml
+++ b/hack/cni-plugins/cni-plugins.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-cni-plugins-ds-amd64
@@ -8,6 +8,10 @@ metadata:
     tier: node
     app: cni-plugins
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: cni-plugins
   template:
     metadata:
       labels:

--- a/hack/multus/multus.yaml
+++ b/hack/multus/multus.yaml
@@ -57,7 +57,7 @@ metadata:
   name: multus
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-amd64
@@ -66,6 +66,10 @@ metadata:
     tier: node
     app: multus
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: multus
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Ram Lavi <ralavi@redhat.com>

**What this PR does / why we need it**:
Currently kubemacpool contains manifests with daemonset with apiVersion extensions/v1beta1. We want to upgrade them to apps/v1.
fixes #221 
**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
