### PR TITLE
Kaw 0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/procfs v0.0.8 // indirect
-	github.com/qinqon/kube-admission-webhook v0.9.0
+	github.com/qinqon/kube-admission-webhook v0.10.0
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
-github.com/qinqon/kube-admission-webhook v0.9.0 h1:MtS7DQILMNWSzx5Q7SFi3KqGtYfD8be8pvhCnkb4gI0=
-github.com/qinqon/kube-admission-webhook v0.9.0/go.mod h1:VX4R05NoFy8Tm/571Dg0GIjTvhFEsTe7QLYdKuuTfrE=
+github.com/qinqon/kube-admission-webhook v0.10.0 h1:jM/OkeIwFyeO32jXtlCvIgH+w3ygXoK7Cv06UuaFpO4=
+github.com/qinqon/kube-admission-webhook v0.10.0/go.mod h1:VX4R05NoFy8Tm/571Dg0GIjTvhFEsTe7QLYdKuuTfrE=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -45,7 +45,7 @@ var AddToWebhookFuncs []func(*webhookserver.Server, *pool_manager.PoolManager) e
 
 // AddToManager adds all Controllers to the Manager
 func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) error {
-	s := webhookserver.New(mgr.GetClient(), names.MUTATE_WEBHOOK_CONFIG, certificate.MutatingWebhook, webhookserver.WithPort(WebhookServerPort))
+	s := webhookserver.New(mgr.GetClient(), names.MUTATE_WEBHOOK_CONFIG, certificate.MutatingWebhook, certificate.OneYearDuration, webhookserver.WithPort(WebhookServerPort))
 
 	for _, f := range AddToWebhookFuncs {
 		if err := f(s, poolManager); err != nil {

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/cleanup.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/cleanup.go
@@ -1,0 +1,85 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/qinqon/kube-admission-webhook/pkg/certificate/triple"
+)
+
+// earliestElapsedForCleanup return a subtraction between earliestCleanupDeadline and
+// `now`
+func (m *Manager) earliestElapsedForCleanup() (time.Duration, error) {
+	deadline, err := m.earliestCleanupDeadline()
+	if err != nil {
+		return time.Duration(0), errors.Wrap(err, "failed calculating cleanup deadline")
+	}
+	now := m.now()
+	elapsedForCleanup := deadline.Sub(now)
+	m.log.Info(fmt.Sprintf("earliestElapsedForCleanup {now: %s, deadline: %s, elapsedForCleanup: %s}", now, deadline, elapsedForCleanup))
+	return elapsedForCleanup, nil
+}
+
+// earliestCleanupDeadline get all the certificates at CABundle and return the
+// deadline calculated by earliestCleanupDeadlineForCerts
+func (m *Manager) earliestCleanupDeadline() (time.Time, error) {
+	cas, err := m.getCACertsFromCABundle()
+	if err != nil {
+		return m.now(), errors.Wrap(err, "failed getting CA certificates from CA bundle")
+	}
+
+	return m.earliestCleanupDeadlineForCerts(cas), nil
+}
+
+// earliestCleanupDeadlineForCACerts will inspect CA certificates
+// select the deadline based on certificate that is going to expire
+// sooner so cleanup is triggered then
+func (m *Manager) earliestCleanupDeadlineForCerts(certificates []*x509.Certificate) time.Time {
+
+	var selectedCertificate *x509.Certificate
+
+	for _, certificate := range certificates {
+		if selectedCertificate == nil || certificate.NotAfter.Before(selectedCertificate.NotAfter) {
+			selectedCertificate = certificate
+		}
+	}
+	if selectedCertificate == nil {
+		return m.now()
+	}
+
+	return selectedCertificate.NotAfter
+}
+
+func (m *Manager) cleanUpCABundle() error {
+	logger := m.log.WithName("cleanUpCABundle")
+	logger.Info("Cleaning up expired certificates at CA bundle")
+	_, err := m.updateWebhookCABundleWithFunc(func([]byte) ([]byte, error) {
+		cas, err := m.getCACertsFromCABundle()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed getting ca certs to start cleanup")
+		}
+		cleanedCAs := m.cleanUpExpiredCertificates(cas)
+		pem := triple.EncodeCertsPEM(cleanedCAs)
+		return pem, nil
+	})
+
+	if err != nil {
+		return errors.Wrap(err, "failed updating webhook config after ca certificates cleanup")
+	}
+	return nil
+}
+
+func (m *Manager) cleanUpExpiredCertificates(certificates []*x509.Certificate) []*x509.Certificate {
+	now := m.now()
+	// create a zero-length slice with the same underlying array
+	cleanedUpCertificates := certificates[:0]
+	for _, certificate := range certificates {
+		if certificate.NotAfter.After(now) {
+			cleanedUpCertificates = append(cleanedUpCertificates, certificate)
+		}
+	}
+	return cleanedUpCertificates
+}

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/triple/pem.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/triple/pem.go
@@ -71,6 +71,16 @@ func EncodeCertPEM(cert *x509.Certificate) []byte {
 	return pem.EncodeToMemory(&block)
 }
 
+// EncodeCertsPEM returns PEM-endcoded certificates data
+func EncodeCertsPEM(certs []*x509.Certificate) []byte {
+	certsPEM := []byte{}
+	for _, cert := range certs {
+		certPEM := EncodeCertPEM(cert)
+		certsPEM = append(certsPEM, certPEM...)
+	}
+	return certsPEM
+}
+
 // ParsePrivateKeyPEM returns a private key parsed from a PEM block in the supplied data.
 // Recognizes PEM blocks for "EC PRIVATE KEY", "RSA PRIVATE KEY", or "PRIVATE KEY"
 func ParsePrivateKeyPEM(keyData []byte) (interface{}, error) {

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/webhook/server/server.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/webhook/server/server.go
@@ -33,13 +33,13 @@ type ServerModifier func(w *webhook.Server)
 
 // Add creates a new Conditions Mutating Webhook and adds it to the Manager. The Manager will set fields on the Webhook
 // and Start it when the Manager is Started.
-func New(client client.Client, webhookName string, webhookType certificate.WebhookType, serverOpts ...ServerModifier) *Server {
+func New(client client.Client, webhookName string, webhookType certificate.WebhookType, caRotateInterval time.Duration, serverOpts ...ServerModifier) *Server {
 	s := &Server{
 		webhookServer: &webhook.Server{
 			Port:    8443,
 			CertDir: "/etc/webhook/certs/",
 		},
-		certManager: certificate.NewManager(client, webhookName, webhookType, certificate.OneYearDuration),
+		certManager: certificate.NewManager(client, webhookName, webhookType, caRotateInterval),
 		log:         logf.Log.WithName("webhook/server"),
 	}
 	s.UpdateOpts(serverOpts...)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/qinqon/kube-admission-webhook v0.9.0
+# github.com/qinqon/kube-admission-webhook v0.10.0
 github.com/qinqon/kube-admission-webhook/pkg/certificate
 github.com/qinqon/kube-admission-webhook/pkg/certificate/triple
 github.com/qinqon/kube-admission-webhook/pkg/webhook/server


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR bumps kube-admission-webhook library to 0.10.0 it add two features:
- A parameter to configure CA expiration time
- A overlap mechanism have multiple certificates at CA bundle

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bump kube-admission-webhook to 0.10.0
```
