### PR TITLE
waitToStartLeading goroutine does not catch error.

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -106,7 +106,13 @@ func (k *KubeMacPoolManager) Run(rangeStart, rangeEnd net.HardwareAddr) error {
 		}
 		go k.waitForSignal()
 
-		go k.waitToStartLeading(poolManager)
+		go func() {
+			err := k.waitToStartLeading(poolManager)
+			if err != nil {
+				log.Error(err, "wait To Start Leading process failed, restarting pod")
+				close(k.restartChannel)
+			}
+		}()
 
 		log.Info("Setting up controllers")
 		err = controller.AddToManager(k.runtimeManager, poolManager)


### PR DESCRIPTION

**What this PR does / why we need it**:
Let's add a wrapping function to catch the errs.
If an Error occur - also restart pod to initiate election.

Signed-off-by: Ram Lavi <ralavi@redhat.com>

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
