### PR TITLE
Kaw 0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/procfs v0.0.8 // indirect
-	github.com/qinqon/kube-admission-webhook v0.11.0
+	github.com/qinqon/kube-admission-webhook v0.12.0
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
-github.com/qinqon/kube-admission-webhook v0.11.0 h1:rQMjl+ClHwea8yy+8R4B8Iibd5Bsnn3zJiuNAPY2BMs=
-github.com/qinqon/kube-admission-webhook v0.11.0/go.mod h1:VX4R05NoFy8Tm/571Dg0GIjTvhFEsTe7QLYdKuuTfrE=
+github.com/qinqon/kube-admission-webhook v0.12.0 h1:5VLcdJo7JWjIhjqjrLZT/ry80J7/sZ83EUmTPFeXIGQ=
+github.com/qinqon/kube-admission-webhook v0.12.0/go.mod h1:VX4R05NoFy8Tm/571Dg0GIjTvhFEsTe7QLYdKuuTfrE=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -121,7 +121,7 @@ func (k *KubeMacPoolManager) Run(rangeStart, rangeEnd net.HardwareAddr) error {
 		}
 
 		log.Info("Setting up webhooks")
-		err = webhook.AddToManager(k.runtimeManager, poolManager)
+		err = webhook.AddToManager(k.podNamespace, k.runtimeManager, poolManager)
 		if err != nil {
 			return errors.Wrap(err, "unable to register webhooks to the manager")
 		}

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/cleanup.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/cleanup.go
@@ -35,14 +35,18 @@ func (m *Manager) earliestCleanupDeadline() (time.Time, error) {
 }
 
 // earliestCleanupDeadlineForCACerts will inspect CA certificates
-// select the deadline based on certificate that is going to expire
-// sooner so cleanup is triggered then
+// select the deadline based on certificate NotBefore + caOverlapDuration
+// returning the daedline that is going to happend sooner
 func (m *Manager) earliestCleanupDeadlineForCerts(certificates []*x509.Certificate) time.Time {
-
 	var selectedCertificate *x509.Certificate
 
+	// There is no overlap just return expiration time
+	if len(certificates) == 1 {
+		return certificates[0].NotAfter
+	}
+
 	for _, certificate := range certificates {
-		if selectedCertificate == nil || certificate.NotAfter.Before(selectedCertificate.NotAfter) {
+		if selectedCertificate == nil || certificate.NotBefore.Before(selectedCertificate.NotBefore) {
 			selectedCertificate = certificate
 		}
 	}
@@ -50,18 +54,18 @@ func (m *Manager) earliestCleanupDeadlineForCerts(certificates []*x509.Certifica
 		return m.now()
 	}
 
-	return selectedCertificate.NotAfter
+	// Add the overlap duration since is the time certs are going to be living
+	// add CABundle
+	return selectedCertificate.NotBefore.Add(m.caOverlapDuration)
 }
 
 func (m *Manager) cleanUpCABundle() error {
-	logger := m.log.WithName("cleanUpCABundle")
-	logger.Info("Cleaning up expired certificates at CA bundle")
 	_, err := m.updateWebhookCABundleWithFunc(func([]byte) ([]byte, error) {
 		cas, err := m.getCACertsFromCABundle()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed getting ca certs to start cleanup")
 		}
-		cleanedCAs := m.cleanUpExpiredCertificates(cas)
+		cleanedCAs := m.cleanUpCertificates(cas)
 		pem := triple.EncodeCertsPEM(cleanedCAs)
 		return pem, nil
 	})
@@ -72,14 +76,35 @@ func (m *Manager) cleanUpCABundle() error {
 	return nil
 }
 
-func (m *Manager) cleanUpExpiredCertificates(certificates []*x509.Certificate) []*x509.Certificate {
+func (m *Manager) cleanUpCertificates(certificates []*x509.Certificate) []*x509.Certificate {
+	logger := m.log.WithName("cleanUpCertificates")
+	logger.Info("Cleaning up expired or beyond overlap duration limit at CA bundle")
+	// There is no overlap
+	if len(certificates) <= 1 {
+		return certificates
+	}
+
 	now := m.now()
 	// create a zero-length slice with the same underlying array
 	cleanedUpCertificates := certificates[:0]
-	for _, certificate := range certificates {
-		if certificate.NotAfter.After(now) {
-			cleanedUpCertificates = append(cleanedUpCertificates, certificate)
+	for i, certificate := range certificates {
+		logger.Info("Checking certificate for cleanup", "now", now, "caOverlapDuration", m.caOverlapDuration, "NotBefore", certificate.NotBefore, "NotAfter", certificate.NotAfter)
+
+		// Expired certificate are cleaned up
+		caExpirationDate := certificate.NotAfter
+		if now.After(caExpirationDate) {
+			logger.Info("Cleaning up expired certificate", "now", now, "NotBefore", certificate.NotBefore, "NotAfter", certificate.NotAfter)
+			continue
 		}
+
+		// Clean up certificates that pass CA Overlap Duration limit,
+		// except for the last appended one (i.e. the last generated from a rotation) since we need at least one valid certificate
+		caOverlapDate := certificate.NotBefore.Add(m.caOverlapDuration)
+		if i != len(certificates)-1 && !now.Before(caOverlapDate) {
+			logger.Info("Cleaning up certificate beyond CA overlap duration", "now", now, "caOverlapDuration", m.caOverlapDuration, "NotBefore", certificate.NotBefore, "NotAfter", certificate.NotAfter)
+			continue
+		}
+		cleanedUpCertificates = append(cleanedUpCertificates, certificate)
 	}
 	return cleanedUpCertificates
 }

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/options.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/options.go
@@ -1,0 +1,93 @@
+package certificate
+
+import (
+	"fmt"
+	"time"
+)
+
+type WebhookType string
+
+const (
+	MutatingWebhook   WebhookType = "Mutating"
+	ValidatingWebhook WebhookType = "Validating"
+	OneYearDuration               = 365 * 24 * time.Hour
+)
+
+type Options struct {
+
+	// webhookName The Mutating or Validating Webhook configuration name
+	WebhookName string
+
+	// webhookType The Mutating or Validating Webhook configuration type
+	WebhookType WebhookType
+
+	// The namespace where ca secret will be created or service secrets
+	// for ClientConfig that has URL instead of ServiceRef
+	Namespace string
+
+	// CARotateInterval configurated duration for CA and certificate
+	CARotateInterval time.Duration
+
+	// CAOverlapInterval the duration of CA Certificates at CABundle if
+	// not set it will default to CARotateInterval
+	CAOverlapInterval time.Duration
+
+	// CertRotateInterval configurated duration for of service certificate
+	// the the webhook configuration is referencing different services all
+	// of them will share the same duration
+	CertRotateInterval time.Duration
+}
+
+func (o *Options) validate() error {
+	if o.WebhookName == "" {
+		return fmt.Errorf("failed validating certificate options, 'WebhookName' field is missing")
+	}
+	if o.Namespace == "" {
+		return fmt.Errorf("failed validating certificate options, 'Namespace' field is missing")
+	}
+
+	if o.CAOverlapInterval > o.CARotateInterval {
+		return fmt.Errorf("failed validating certificate options, 'CAOverlapInterval' has to be <= 'CARotateInterval'")
+	}
+
+	if o.CertRotateInterval > o.CARotateInterval {
+		return fmt.Errorf("failed validating certificate options, 'CertRotateInterval' has to be <= 'CARotateInterval'")
+	}
+
+	if o.WebhookType != MutatingWebhook && o.WebhookType != ValidatingWebhook {
+		return fmt.Errorf("failed validating certificate options, 'WebhookType' has to be %s or %s", MutatingWebhook, ValidatingWebhook)
+	}
+
+	return nil
+
+}
+
+func (o Options) withDefaults() Options {
+	withDefaultsOptions := o
+	if o.WebhookType == "" {
+		withDefaultsOptions.WebhookType = MutatingWebhook
+	}
+
+	if o.CARotateInterval == 0 {
+		withDefaultsOptions.CARotateInterval = OneYearDuration
+	}
+
+	if o.CAOverlapInterval == 0 {
+		withDefaultsOptions.CAOverlapInterval = withDefaultsOptions.CARotateInterval
+	}
+
+	if o.CertRotateInterval == 0 {
+		withDefaultsOptions.CertRotateInterval = withDefaultsOptions.CARotateInterval
+	}
+	return withDefaultsOptions
+}
+
+func (o *Options) setDefaultsAndValidate() error {
+	withDefaultsOptions := o.withDefaults()
+	err := withDefaultsOptions.validate()
+	if err != nil {
+		return err
+	}
+	*o = withDefaultsOptions
+	return nil
+}

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/secret.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/secret.go
@@ -2,6 +2,8 @@ package certificate
 
 import (
 	"context"
+	"crypto/rsa"
+	"reflect"
 
 	"github.com/pkg/errors"
 
@@ -16,9 +18,23 @@ import (
 
 const (
 	secretManagedAnnotatoinKey = "kubevirt.io/kube-admission-webhook"
+	CACertKey                  = "ca.crt"
+	CAPrivateKeyKey            = "ca.key"
 )
 
-func updateTLSSecret(secret corev1.Secret, keyPair *triple.KeyPair) *corev1.Secret {
+func populateCASecret(secret corev1.Secret, keyPair *triple.KeyPair) *corev1.Secret {
+	if secret.Annotations == nil {
+		secret.Annotations = map[string]string{}
+	}
+	secret.Annotations[secretManagedAnnotatoinKey] = ""
+	secret.Data = map[string][]byte{
+		CACertKey:       triple.EncodeCertPEM(keyPair.Cert),
+		CAPrivateKeyKey: triple.EncodePrivateKeyPEM(keyPair.Key),
+	}
+	return &secret
+}
+
+func populateTLSSecret(secret corev1.Secret, keyPair *triple.KeyPair) *corev1.Secret {
 	if secret.Annotations == nil {
 		secret.Annotations = map[string]string{}
 	}
@@ -27,46 +43,53 @@ func updateTLSSecret(secret corev1.Secret, keyPair *triple.KeyPair) *corev1.Secr
 		corev1.TLSCertKey:       triple.EncodeCertPEM(keyPair.Cert),
 		corev1.TLSPrivateKeyKey: triple.EncodePrivateKeyPEM(keyPair.Key),
 	}
-	secret.Type = corev1.SecretTypeTLS
 	return &secret
 }
 
-func (m *Manager) newTLSSecret(secretKey types.NamespacedName, keyPair *triple.KeyPair) (*corev1.Secret, error) {
-
-	secret := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        secretKey.Name,
-			Namespace:   secretKey.Namespace,
-			Annotations: map[string]string{},
-		},
-	}
-
-	return &secret, nil
+func (m *Manager) applyTLSSecret(secret types.NamespacedName, keyPair *triple.KeyPair) error {
+	return m.applySecret(secret, corev1.SecretTypeTLS, keyPair, populateTLSSecret)
 }
 
-func (m *Manager) applyTLSSecret(service types.NamespacedName, keyPair *triple.KeyPair) error {
+func (m *Manager) applyCASecret(keyPair *triple.KeyPair) error {
+	return m.applySecret(m.caSecretKey(), corev1.SecretTypeOpaque, keyPair, populateCASecret)
+}
+
+func (m *Manager) applySecret(secretKey types.NamespacedName, secretType corev1.SecretType, keyPair *triple.KeyPair,
+	populateSecretFn func(corev1.Secret, *triple.KeyPair) *corev1.Secret) error {
 	secret := corev1.Secret{}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		err := m.get(service, &secret)
+		err := m.get(secretKey, &secret)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				tlsSecret, err := m.newTLSSecret(service, keyPair)
-				if err != nil {
-					return errors.Wrapf(err, "failed initailizing secret %s", service)
+				newSecret := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        secretKey.Name,
+						Namespace:   secretKey.Namespace,
+						Annotations: map[string]string{},
+					},
+					Type: secretType,
 				}
-				return m.client.Create(context.TODO(), updateTLSSecret(*tlsSecret, keyPair))
+				err = m.client.Create(context.TODO(), populateSecretFn(newSecret, keyPair))
+				if err != nil {
+					return errors.Wrap(err, "failed creating secret")
+				}
+				return nil
 			} else {
 				return err
 			}
 		}
-		return m.client.Update(context.TODO(), updateTLSSecret(secret, keyPair))
+		err = m.client.Update(context.TODO(), populateSecretFn(secret, keyPair))
+		if err != nil {
+			return errors.Wrap(err, "failed updating secret")
+		}
+		return nil
 	})
 }
 
 // verifyTLSSecret will verify that the caBundle and Secret are valid and can
 // be used to verify
-func (m *Manager) verifyTLSSecret(secretKey types.NamespacedName, caBundle []byte) error {
+func (m *Manager) verifyTLSSecret(secretKey types.NamespacedName, caKeyPair *triple.KeyPair, caBundle []byte) error {
 	secret := corev1.Secret{}
 	err := m.get(secretKey, &secret)
 	if err != nil {
@@ -83,10 +106,88 @@ func (m *Manager) verifyTLSSecret(secretKey types.NamespacedName, caBundle []byt
 		return errors.New("TLS certs not found")
 	}
 
-	err = triple.VerifyTLS(certsPEM, keyPEM, []byte(caBundle))
+	certsFromCABundle, err := triple.ParseCertsPEM(caBundle)
+	if err != nil {
+		return errors.Wrap(err, "failed parsing CABundle as pem encoded certificates")
+	}
+
+	if len(certsFromCABundle) == 0 {
+		return errors.New("CA bundle has no certificates")
+	}
+
+	lastCertFromCABundle := certsFromCABundle[len(certsFromCABundle)-1]
+
+	if !reflect.DeepEqual(*lastCertFromCABundle, *caKeyPair.Cert) {
+		return errors.New("CA bundle and CA secret certificate are different")
+	}
+
+	err = triple.VerifyTLS(certsPEM, keyPEM, caBundle)
 	if err != nil {
 		return errors.Wrapf(err, "failed verifying TLS from server Secret %s", secretKey)
 	}
 
 	return nil
+}
+
+func (m *Manager) getCAKeyPair() (*triple.KeyPair, error) {
+	caSecret := corev1.Secret{}
+	err := m.get(m.caSecretKey(), &caSecret)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed reading ca secret %s", m.caSecretKey())
+	}
+
+	caPrivateKeyPEM, found := caSecret.Data[CAPrivateKeyKey]
+	if !found {
+		return nil, errors.Wrapf(err, "ca private key not found at secret %s", m.caSecretKey())
+	}
+
+	caCertPEM, found := caSecret.Data[CACertKey]
+	if !found {
+		return nil, errors.Wrapf(err, "ca cert not found at secret %s", m.caSecretKey())
+	}
+
+	caCerts, err := triple.ParseCertsPEM(caCertPEM)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed parsing ca cert PEM at secret %s", m.caSecretKey())
+	}
+
+	caPrivateKey, err := triple.ParsePrivateKeyPEM(caPrivateKeyPEM)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed parsing ca private key PEM at secret %s", m.caSecretKey())
+	}
+	return &triple.KeyPair{Key: caPrivateKey.(*rsa.PrivateKey), Cert: caCerts[0]}, nil
+}
+
+func (m *Manager) getTLSKeyPair(secretKey types.NamespacedName) (*triple.KeyPair, error) {
+	secret := corev1.Secret{}
+	err := m.get(secretKey, &secret)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed reading ca secret %s", secretKey)
+	}
+
+	privateKeyPEM, found := secret.Data[corev1.TLSPrivateKeyKey]
+	if !found {
+		return nil, errors.Wrapf(err, "TLS private key not found at secret %s", secretKey)
+	}
+
+	certPEM, found := secret.Data[corev1.TLSCertKey]
+	if !found {
+		return nil, errors.Wrapf(err, "TLS cert not found at secret %s", secretKey)
+	}
+
+	certs, err := triple.ParseCertsPEM(certPEM)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed parsing TLS cert PEM at secret %s", secretKey)
+	}
+
+	privateKey, err := triple.ParsePrivateKeyPEM(privateKeyPEM)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed parsing TLS private key PEM at secret %s", secretKey)
+	}
+	return &triple.KeyPair{Key: privateKey.(*rsa.PrivateKey), Cert: certs[0]}, nil
+}
+
+//FIXME: Is this default/webhookname good key for ca secret
+func (m *Manager) caSecretKey() types.NamespacedName {
+	return types.NamespacedName{Namespace: m.namespace, Name: m.webhookName + "-ca"}
 }

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/webhook/server/server.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/webhook/server/server.go
@@ -33,18 +33,23 @@ type ServerModifier func(w *webhook.Server)
 
 // Add creates a new Conditions Mutating Webhook and adds it to the Manager. The Manager will set fields on the Webhook
 // and Start it when the Manager is Started.
-func New(client client.Client, webhookName string, webhookType certificate.WebhookType, caRotateInterval time.Duration, serverOpts ...ServerModifier) *Server {
+func New(client client.Client, certificateOpts certificate.Options, serverOpts ...ServerModifier) (*Server, error) {
+	certManager, err := certificate.NewManager(client, certificateOpts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed constructing certificate manager")
+	}
+
 	s := &Server{
 		webhookServer: &webhook.Server{
 			Port:    8443,
 			CertDir: "/etc/webhook/certs/",
 		},
-		certManager: certificate.NewManager(client, webhookName, webhookType, caRotateInterval),
+		certManager: certManager,
 		log:         logf.Log.WithName("webhook/server"),
 	}
 	s.UpdateOpts(serverOpts...)
 	s.webhookServer.Register("/readyz", healthz.CheckHandler{Checker: healthz.Ping})
-	return s
+	return s, nil
 }
 
 func WithHook(path string, hook *webhook.Admission) ServerModifier {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/qinqon/kube-admission-webhook v0.11.0
+# github.com/qinqon/kube-admission-webhook v0.12.0
 github.com/qinqon/kube-admission-webhook/pkg/certificate
 github.com/qinqon/kube-admission-webhook/pkg/certificate/triple
 github.com/qinqon/kube-admission-webhook/pkg/webhook/server


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
This PR bumps the kube-admission-webhook to 0.12.0 It contains the knob CAOverlapInterval and also some refactorings on how the certificate options are passed to it.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Bump kube-admission-webhook to 0.12.0
```
