### PR TITLE
Expose kube-admission-webhook cert manager knobs as env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,22 @@ k8s.v1.cni.cncf.io/networks: [{"name":"ovs-conf","namespace":"default","mac":"02
 MAC address can be also set manually by the user using the MAC field in the annotation.
 If the mac is already in used the system will reject it even if the MAC address is outside of the range.
 
+### Modifing webhook certificate handling
+
+Part of the kubemacpool functionality is implemented as a
+[kubernetes mutating admission webhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) to ensure that mac is assigned before vm is created.
+
+Using admission webhooks forces application to handle TLS ca and server
+certificates, at kubemacpool this task is delegated to [kube-admission-webook](https://github.com/qinqon/kube-admission-webhook)
+library, this library do a mix of controller-runtime webhook server and a
+small cert manager so certificates are rotated.
+
+To customaize how the this rotation works some knobs from the library has being
+exposed as environment variables at kubemacpool pod:
+
+- `CA_ROTATE_INTERVAL`:  Expiration time for CA certificate, default is one year
+- `CA_OVERLAP_INTERVAL`:  Duration the previous to rotate CA certificate live with the new one, defaults to one year
+- `CERT_ROTATE_INTERVAL`:  Expiration time for server certificates, defauilt is half a year
 
 ## Develop
 

--- a/README.md
+++ b/README.md
@@ -240,15 +240,14 @@ Part of the kubemacpool functionality is implemented as a
 
 Using admission webhooks forces application to handle TLS ca and server
 certificates, at kubemacpool this task is delegated to [kube-admission-webook](https://github.com/qinqon/kube-admission-webhook)
-library, this library do a mix of controller-runtime webhook server and a
-small cert manager so certificates are rotated.
+library, this library manages certificates rotation using a controller-runtime webhook server and a small cert manager.
 
-To customaize how the this rotation works some knobs from the library has being
+To customize how this rotation works some knobs from the library has being
 exposed as environment variables at kubemacpool pod:
 
 - `CA_ROTATE_INTERVAL`:  Expiration time for CA certificate, default is one year
 - `CA_OVERLAP_INTERVAL`:  Duration the previous to rotate CA certificate live with the new one, defaults to one year
-- `CERT_ROTATE_INTERVAL`:  Expiration time for server certificates, defauilt is half a year
+- `CERT_ROTATE_INTERVAL`:  Expiration time for server certificates, default is half a year
 
 ## Develop
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,14 +24,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/qinqon/kube-admission-webhook/pkg/certificate"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/manager"
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	poolmanager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
-
-	"github.com/qinqon/kube-admission-webhook/pkg/certificate"
 )
 
 func loadMacAddressFromEnvVar(envName string) (net.HardwareAddr, error) {

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -86,6 +86,12 @@ spec:
               configMapKeyRef:
                 name: mac-range-config
                 key: RANGE_END
+          - name: CA_ROTATE_INTERVAL
+            value: "8760h0m0s" # One Year
+          - name: CA_OVERLAP_INTERVAL
+            value: "8760h0m0s" # One Year
+          - name: CERT_ROTATE_INTERVAL
+            value: "4380h0m0s" # Half Year
         resources:
           limits:
             cpu: 300m

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -283,6 +283,12 @@ spec:
             configMapKeyRef:
               key: RANGE_END
               name: kubemacpool-mac-range-config
+        - name: CA_ROTATE_INTERVAL
+          value: 8760h0m0s
+        - name: CA_OVERLAP_INTERVAL
+          value: 8760h0m0s
+        - name: CERT_ROTATE_INTERVAL
+          value: 4380h0m0s
         image: quay.io/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -283,6 +283,12 @@ spec:
             configMapKeyRef:
               key: RANGE_END
               name: kubemacpool-mac-range-config
+        - name: CA_ROTATE_INTERVAL
+          value: 8760h0m0s
+        - name: CA_OVERLAP_INTERVAL
+          value: 8760h0m0s
+        - name: CERT_ROTATE_INTERVAL
+          value: 4380h0m0s
         image: registry:5000/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -23,7 +23,6 @@ import (
 	webhookserver "github.com/qinqon/kube-admission-webhook/pkg/webhook/server"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
 )
 
@@ -44,13 +43,7 @@ const (
 var AddToWebhookFuncs []func(*webhookserver.Server, *pool_manager.PoolManager) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(namespace string, mgr manager.Manager, poolManager *pool_manager.PoolManager) error {
-	certOptions := certificate.Options{
-		Namespace:        namespace,
-		WebhookName:      names.MUTATE_WEBHOOK_CONFIG,
-		WebhookType:      certificate.MutatingWebhook,
-		CARotateInterval: certificate.OneYearDuration,
-	}
+func AddToManager(certOptions certificate.Options, mgr manager.Manager, poolManager *pool_manager.PoolManager) error {
 	s, err := webhookserver.New(mgr.GetClient(), certOptions, webhookserver.WithPort(WebhookServerPort))
 	if err != nil {
 		return errors.Wrap(err, "failed creating new webhook server")


### PR DESCRIPTION
It will expose the following knobs to pod's environment variables:

- CARotateInterval -> CA_ROTATE_INTERVAL
- CAOverlapInterval -> CA_OVERLAP_INTERVAL
- CertRotateInterval  -> CERT_ROTATE_INTERVAL

The values at manifests are

- CA_ROTATE_INTERVAL -> One year
- CA_OVERLAP_INTERVAL -> One year
_ CERT_ROTATE_INTERVAL -> Half year

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Expose certificate handling knobs CA_ROTATE_INTERVAL, CA_OVERLAP_INTERVAL, CERT_ROTATE_INTERVAL
```
