### PR TITLE
fix cert test to use manager namespace

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -1,7 +1,5 @@
 package names
 
-const MANAGER_NAMESPACE = "kubemacpool-system"
-
 const MANAGER_DEPLOYMENT = "kubemacpool-mac-controller-manager"
 
 const WEBHOOK_SERVICE = "kubemacpool-service"

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -39,11 +39,12 @@ import (
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 )
 
+const testManagerNamespace = "kubemacpool-system"
 var _ = Describe("Pool", func() {
 	beforeAllocationAnnotation := map[string]string{networksAnnotation: `[{ "name": "ovs-conf"}]`}
 	afterAllocationAnnotation := map[string]string{networksAnnotation: `[{"name":"ovs-conf","namespace":"default","mac":"02:00:00:00:00:00"}]`}
 	samplePod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podpod", Namespace: "default", Annotations: afterAllocationAnnotation}}
-	vmConfigMap := v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: names.MANAGER_NAMESPACE, Name: names.WAITING_VMS_CONFIGMAP}}
+	vmConfigMap := v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: testManagerNamespace, Name: names.WAITING_VMS_CONFIGMAP}}
 
 	createPoolManager := func(startMacAddr, endMacAddr string, fakeObjectsForClient ...runtime.Object) *PoolManager {
 		fakeClient := fake.NewSimpleClientset(fakeObjectsForClient...)
@@ -51,7 +52,7 @@ var _ = Describe("Pool", func() {
 		Expect(err).ToNot(HaveOccurred(), "should successfully parse starting mac address range")
 		endPoolRangeEnv, err := net.ParseMAC(endMacAddr)
 		Expect(err).ToNot(HaveOccurred(), "should successfully parse ending mac address range")
-		poolManager, err := NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, names.MANAGER_NAMESPACE, false, 10)
+		poolManager, err := NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, testManagerNamespace, false, 10)
 		Expect(err).ToNot(HaveOccurred(), "should successfully initialize poolManager")
 		err = poolManager.Start()
 		Expect(err).ToNot(HaveOccurred(), "should successfully start poolManager routines")
@@ -144,7 +145,7 @@ var _ = Describe("Pool", func() {
 			Expect(err).ToNot(HaveOccurred())
 			endPoolRangeEnv, err := net.ParseMAC("02:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, names.MANAGER_NAMESPACE, false, 10)
+			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, testManagerNamespace, false, 10)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Invalid range. rangeStart: 0a:00:00:00:00:00 rangeEnd: 02:00:00:00:00:00"))
 
@@ -156,7 +157,7 @@ var _ = Describe("Pool", func() {
 			Expect(err).ToNot(HaveOccurred())
 			endPoolRangeEnv, err := net.ParseMAC("06:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, names.MANAGER_NAMESPACE, false, 10)
+			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, testManagerNamespace, false, 10)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("RangeStart is invalid: invalid mac address. Multicast addressing is not supported. Unicast addressing must be used. The first octet is 0X3"))
 
@@ -168,7 +169,7 @@ var _ = Describe("Pool", func() {
 			Expect(err).ToNot(HaveOccurred())
 			endPoolRangeEnv, err := net.ParseMAC("05:00:00:00:00:00")
 			Expect(err).ToNot(HaveOccurred())
-			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, names.MANAGER_NAMESPACE, false, 10)
+			_, err = NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, testManagerNamespace, false, 10)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("RangeEnd is invalid: invalid mac address. Multicast addressing is not supported. Unicast addressing must be used. The first octet is 0X5"))
 		})

--- a/tests/certificates_test.go
+++ b/tests/certificates_test.go
@@ -48,7 +48,7 @@ var _ = Describe("kube-admission library", func() {
 
 func deleteServiceSecret() {
 	secret := v1.Secret{}
-	err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: names.MANAGER_NAMESPACE, Name: names.WEBHOOK_SERVICE}, &secret)
+	err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: managerNamespace, Name: names.WEBHOOK_SERVICE}, &secret)
 	Expect(err).ToNot(HaveOccurred(), "Should successfully get kubemacpool secret")
 
 	err = testClient.VirtClient.Delete(context.TODO(), &secret)
@@ -58,7 +58,7 @@ func deleteServiceSecret() {
 func deleteServiceCaBundle() {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		mutatingWebhook := v1beta1.MutatingWebhookConfiguration{}
-		err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: names.MANAGER_NAMESPACE, Name: names.MUTATE_WEBHOOK_CONFIG}, &mutatingWebhook)
+		err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: managerNamespace, Name: names.MUTATE_WEBHOOK_CONFIG}, &mutatingWebhook)
 		Expect(err).ToNot(HaveOccurred(), "Should successfully get MutatingWebhookConfiguration")
 
 		for i, _ := range mutatingWebhook.Webhooks {
@@ -81,12 +81,12 @@ func checkCertLibraryRecovery(oldCABundle []byte, oldSecret *v1.Secret) {
 }
 
 func GetCurrentSecret(secret *v1.Secret) error {
-	return testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: names.MANAGER_NAMESPACE, Name: names.WEBHOOK_SERVICE}, secret)
+	return testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: managerNamespace, Name: names.WEBHOOK_SERVICE}, secret)
 }
 
 func GetCurrentCABundle() (caBundle []byte) {
 	mutatingWebhook := v1beta1.MutatingWebhookConfiguration{}
-	err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: names.MANAGER_NAMESPACE, Name: names.MUTATE_WEBHOOK_CONFIG}, &mutatingWebhook)
+	err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: managerNamespace, Name: names.MUTATE_WEBHOOK_CONFIG}, &mutatingWebhook)
 	Expect(err).ToNot(HaveOccurred(), "Should successfully get MutatingWebhookConfiguration")
 
 	//get the first one
@@ -110,7 +110,7 @@ func checkCaBundleRecovery(oldCABundle []byte) {
 	Eventually(func() ([][]byte, error) {
 		By("Getting the MutatingWebhookConfiguration")
 		mutatingWebhook := v1beta1.MutatingWebhookConfiguration{}
-		err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: names.MANAGER_NAMESPACE, Name: names.MUTATE_WEBHOOK_CONFIG}, &mutatingWebhook)
+		err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: managerNamespace, Name: names.MUTATE_WEBHOOK_CONFIG}, &mutatingWebhook)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the cert test uses specific manager namespace
that will only be correct if running on kubemacpool repo.
Let fix by using managerNamespace which gets the real namespace
from the cluster at  the beginning of the test suite.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
