### PR TITLE
move 'test_id' tests to a new context, using the default opt-mode cluster config

### DIFF
--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -489,13 +489,20 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(err).ToNot(HaveOccurred(), "should set opt-mode to mutatingwebhookconfiguration")
 			})
 
-			It("should create a VM object without a MAC assigned", func() {
-				vm := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br", "")},
-					[]kubevirtv1.Network{newNetwork("br")})
+			Context("and kubemacpool is not opted-in on a namespace", func() {
+				BeforeEach(func() {
+					By("Removing any namespace labels to make sure that kubemacpool is not opted in on the namespace")
+					err := cleanNamespaceLabels(TestNamespace)
+					Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
+				})
+				It("should create a VM object without a MAC assigned", func() {
+					vm := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br", "")},
+						[]kubevirtv1.Network{newNetwork("br")})
 
-				err := testClient.VirtClient.Create(context.TODO(), vm)
-				Expect(err).ToNot(HaveOccurred(), "Should succeed creating the vm")
-				Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).Should(Equal(""), "should not allocated a mac to the opted-out vm")
+					err := testClient.VirtClient.Create(context.TODO(), vm)
+					Expect(err).ToNot(HaveOccurred(), "Should succeed creating the vm")
+					Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).Should(Equal(""), "should not allocated a mac to the opted-out vm")
+				})
 			})
 
 			Context("and kubemacpool is opted-in on a namespace", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves polarion tests to a new context, using the default opt-mode config

- **move test_id related tests to a new context**
Currently all 'test_id' test are performed in opt-out context
There is no specific reason they were put there, since
they can run on either opt-mode, as long as they are running
on the same opt-mode configured by the cluster configuration (in order to prevent
the oprator deploying kubemacpool to reconcile back from the opt-mode configured by the test).
Let's therefor move the tests to a new context that will run using the
default opt-mode config that is set on the cluster.
Also this commit includes a small format fix in AllocateFillerVms

- **add BeforeEach to opt-In test**
Since opt-mode contexts may run in different order,
we need to make sure that opt-in context start with
a "fresh" namespace.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
