### PR TITLE
functests, fix functests flags

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -4,4 +4,4 @@ set -xe
 
 source ./cluster/kubevirtci.sh
 
-KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test ./tests/... $E2E_TEST_ARGS -timeout=40m -ginkgo.v -test.v -race --test-suite-params="$POLARION_TEST_SUITE_PARAMS"
+KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test ./tests/... $E2E_TEST_ARGS -test.timeout=40m -ginkgo.v -test.v --test-suite-params="$POLARION_TEST_SUITE_PARAMS"


### PR DESCRIPTION
**What this PR does / why we need it**:
When running kubemacpool tier1 in CNAO repo,
the test [panics](https://prow.apps.ovirt.org/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/655/pull-e2e-cluster-network-addons-operator-kubemacpool-functests/1326935780098052096), 
updated the functest flags.
changed timeout flag to test.timeout
removed no longer supported race flag

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
