### PR TITLE
functest, Revert #251 and fix test flags

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -4,4 +4,4 @@ set -xe
 
 source ./cluster/kubevirtci.sh
 
-KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test ./tests/... $E2E_TEST_ARGS -test.timeout=40m -ginkgo.v -test.v --test-suite-params="$POLARION_TEST_SUITE_PARAMS"
+KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test ./tests/... $E2E_TEST_ARGS -timeout=40m -ginkgo.v -test.v -race --test-suite-params="$POLARION_TEST_SUITE_PARAMS"

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -4,4 +4,4 @@ set -xe
 
 source ./cluster/kubevirtci.sh
 
-KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test ./tests/... $E2E_TEST_ARGS -timeout=40m -ginkgo.v -test.v -race --test-suite-params="$POLARION_TEST_SUITE_PARAMS"
+KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test -test.timeout=40m -race -test.v ./tests/... $E2E_TEST_ARGS -ginkgo.v --test-suite-params="$POLARION_TEST_SUITE_PARAMS"


### PR DESCRIPTION
This PR reverts the former PR #251 that attempted to fix the go test flags.
Furthermore, it fixes the flags to git the correct order, now needed in golang1.15

- **Revert "functests, fix functests flags (#251)"**

- **functest, fix flags to git golang1.15 changes**
After a change dojne in golang1.15 [1],
go test flags should be as follows:
go test [test flags] [packages] [flags for test binary]
Changed go test flags to appear before package
[1] https://go-review.googlesource.com/c/go/+/14826/

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
