### PR TITLE
test 2995, Fix wrong expected error

### DIFF
--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -435,7 +435,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Eventually(func() error {
 						err = testClient.VirtClient.Create(context.TODO(), newVM)
 						if err != nil {
-							Expect(err).Should(MatchError(errors.New("Failed to create virtual machine allocation error: the range is full")), "Should only get a range full error until cache get updated")
+							Expect(err).Should(MatchError(errors.New("admission webhook \"mutatevirtualmachines.kubemacpool.io\" denied the request: Failed to create virtual machine allocation error: Failed to allocate mac to the vm object: failed to allocate requested mac address")), "Should only get a mac-allocation denial error until cache get updated")
 						}
 						return err
 


### PR DESCRIPTION
**What this PR does / why we need it**:
During test_id:2995 we allow getting an error saying that the mac
is still occupied until it is released by the controller.
The current error message is wrong, as the range is not full in this
specific test.
Fixed to the correct expected error.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
