### PR TITLE
logs, Make important logs more visible

### DIFF
--- a/pkg/controller/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualmachine/virtualmachine_controller.go
@@ -86,7 +86,7 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 	//used for multi thread log separation
 	reconcileRequestId := rand.Int()
 	logger := log.WithName("Reconcile").WithValues("RequestId", reconcileRequestId, "virtualMachineName", request.Name, "virtualMachineNamespace", request.Namespace)
-	logger.V(1).Info("got a virtual machine event in the controller")
+	logger.Info("got a virtual machine event in the controller")
 
 	instance := &kubevirt.VirtualMachine{}
 	err := r.Get(context.TODO(), request.NamespacedName, instance)
@@ -106,7 +106,7 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 		}
 
 		if !instanceOptedIn {
-			logger.V(1).Info("vm is opted-out from kubemacpool")
+			logger.Info("vm is opted-out from kubemacpool")
 			return reconcile.Result{}, nil
 		}
 
@@ -146,7 +146,7 @@ func (r *ReconcilePolicy) removeFinalizerAndReleaseMac(request *reconcile.Reques
 		}
 
 		// our finalizer is present, so lets handle our external dependency
-		logger.V(1).Info("The VM contains the finalizer. Releasing mac")
+		logger.Info("The VM contains the finalizer. Releasing mac")
 		err = r.poolManager.ReleaseVirtualMachineMac(virtualMachine, parentLogger)
 		if err != nil {
 			return errors.Wrap(err, "failed to release mac")
@@ -165,7 +165,7 @@ func (r *ReconcilePolicy) removeFinalizerAndReleaseMac(request *reconcile.Reques
 		return errors.Wrap(err, "Failed to updated VM instance with finalizer removal")
 	}
 
-	logger.V(1).Info("Successfully updated VM instance with finalizer removal")
+	logger.Info("Successfully updated VM instance with finalizer removal")
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In This PR I move some logs from `DEBUG` to `INFO` and vise versa. 
When running KMP from HCO/CNAO/CNV then only `INFO` logs are shown.
This change should make it easier for us to follow the KMP logs when in production environment.

- **logs, Make important logs more visible**
Currently it is not easy to understand the the logs when in production mode
Also, we keep a 3 second reoccurring log on production which is annoying.
Refactored the logs in order to give a good picture of what's happening in
production mode.
Moved the 3 second reoccurring log to be a debug log.

**Special notes for your reviewer**:
`logger.V(1).info` will result to a `DEBUG` log. `logger.info`, will appear as `INFO`

**Release note**:

```release-note
NONE
```
