### PR TITLE
webhook, Enhance logs to better track KMP manager

### DIFF
--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -38,7 +38,7 @@ func (p *PoolManager) AllocateVirtualMachineMac(virtualMachine *kubevirt.Virtual
 	p.poolMutex.Lock()
 	defer p.poolMutex.Unlock()
 	logger := parentLogger.WithName("AllocateVirtualMachineMac")
-	logger.Info("data before allocation", "macmap", p.macPoolMap)
+	logger.Info("data before allocation", "macmap", p.macPoolMap, "VM interfaces", virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces)
 
 	if len(virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces) == 0 {
 		logger.Info("no interfaces found for virtual machine, skipping mac allocation", "virtualMachine", virtualMachine)
@@ -89,8 +89,8 @@ func (p *PoolManager) AllocateVirtualMachineMac(virtualMachine *kubevirt.Virtual
 		return err
 	}
 
-	logger.Info("data after allocation", "macmap", p.macPoolMap)
 	virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces = copyVM.Spec.Template.Spec.Domain.Devices.Interfaces
+	logger.Info("data after allocation", "macmap", p.macPoolMap, "current VM interfaces", virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces)
 
 	return nil
 }
@@ -119,14 +119,14 @@ func (p *PoolManager) ReleaseVirtualMachineMac(vm *kubevirt.VirtualMachine, pare
 		}
 	}
 
-	logger.Info("released macs in virtua machine", "macmap", p.macPoolMap)
+	logger.Info("released macs in virtual machine", "macmap", p.macPoolMap)
 
 	return nil
 }
 
 func (p *PoolManager) UpdateMacAddressesForVirtualMachine(previousVirtualMachine, virtualMachine *kubevirt.VirtualMachine, parentLogger logr.Logger) error {
 	logger := parentLogger.WithName("UpdateMacAddressesForVirtualMachine")
-	logger.Info("data before allocation", "macmap", p.macPoolMap)
+	logger.Info("data before allocation", "macmap", p.macPoolMap, "pre-request VM interfaces", previousVirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces, "request VM intefaces", virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces)
 	p.poolMutex.Lock()
 	if previousVirtualMachine == nil {
 		p.poolMutex.Unlock()
@@ -193,8 +193,8 @@ func (p *PoolManager) UpdateMacAddressesForVirtualMachine(previousVirtualMachine
 		"interfaces Map", releaseOldAllocations)
 	p.releaseMacAddressesFromInterfaceMap(releaseOldAllocations)
 
-	logger.Info("data after allocation", "macmap", p.macPoolMap)
 	virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces = copyVM.Spec.Template.Spec.Domain.Devices.Interfaces
+	logger.Info("data after allocation", "macmap", p.macPoolMap, "current VM interfaces", virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces)
 	return nil
 }
 

--- a/pkg/webhook/virtualmachine/virtualmachine.go
+++ b/pkg/webhook/virtualmachine/virtualmachine.go
@@ -140,7 +140,7 @@ func patchChange(pathChange string, original, current interface{}) ([]jsonpatch.
 // mutateCreateVirtualMachinesFn calls the create allocation function
 func (a *virtualMachineAnnotator) mutateCreateVirtualMachinesFn(ctx context.Context, virtualMachine *kubevirt.VirtualMachine, parentLogger logr.Logger) error {
 	logger := parentLogger.WithName("mutateCreateVirtualMachinesFn")
-	logger.Info("got a create mutate virtual machine event")
+	logger.Info("got a create mutate virtual machine event", "resourceVersion", virtualMachine.GetResourceVersion())
 
 	existingVirtualMachine := &kubevirt.VirtualMachine{}
 	err := a.client.Get(context.TODO(), client.ObjectKey{Namespace: virtualMachine.Namespace, Name: virtualMachine.Name}, existingVirtualMachine)
@@ -171,7 +171,7 @@ func (a *virtualMachineAnnotator) mutateCreateVirtualMachinesFn(ctx context.Cont
 // mutateUpdateVirtualMachinesFn calls the update allocation function
 func (a *virtualMachineAnnotator) mutateUpdateVirtualMachinesFn(ctx context.Context, virtualMachine *kubevirt.VirtualMachine, parentLogger logr.Logger) error {
 	logger := parentLogger.WithName("mutateUpdateVirtualMachinesFn")
-	logger.Info("got an update mutate virtual machine event")
+	logger.Info("got an update mutate virtual machine event", "resourceVersion", virtualMachine.GetResourceVersion())
 	previousVirtualMachine := &kubevirt.VirtualMachine{}
 	err := a.client.Get(context.TODO(), client.ObjectKey{Namespace: virtualMachine.Namespace, Name: virtualMachine.Name}, previousVirtualMachine)
 	if err != nil {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -3,16 +3,19 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
+	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
+
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 )
 
 func TestTests(t *testing.T) {
@@ -81,7 +84,21 @@ func KubemacPoolFailedFunction(message string, callerSkip ...int) {
 		Fail(message, callerSkip...)
 	}
 
-	fmt.Printf("Endpoint: %v", endpoint)
+	fmt.Printf("Endpoint: %v \n", endpoint)
+
+	var testVms []*kubevirtv1.VirtualMachine
+	for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
+		vmList := &kubevirtv1.VirtualMachine{}
+		err := testClient.VirtClient.List(context.TODO(), vmList, &client.ListOptions{Namespace: namespace})
+		if err != nil {
+			fmt.Println(err)
+			Fail(message, callerSkip...)
+		}
+
+		testVms = append(testVms, vmList)
+	}
+
+	fmt.Printf("test virtualMachines: %v \n", testVms)
 
 	Fail(message, callerSkip...)
 }

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -428,6 +428,9 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					})
 					Expect(err).ToNot(HaveOccurred(), "should succeed to remove NIC from vm")
 
+					By("checking that the VM's NIC has been successfully removed")
+					err = testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)
+					Expect(err).ToNot(HaveOccurred(), "Should succeed getting vm")
 					Expect(len(vm.Spec.Template.Spec.Domain.Devices.Interfaces) == 1).To(Equal(true), "vm's total NICs should be 1")
 
 					By("checking that a new VM can be created after the VM's NIC had been removed ")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a several log improvements in order to better track the manager's operation.
Also it fixes a small issue in test_id:2995 where the interface length was wrongly sampled.

- **webhook, Add VM interfaces to create/update webhook logs**

- **webhook, Add RequestID to patchVMChanges**
currently patchVMChanges's logs are not printed with the generated RequestID
Added RequestID to better track the webhook logs

- **webhook, Add resourceVersion to create/update logs**

- **ci, Add test test VMs to prints during test failure**

- **ci, Correct interface removal check in test_id:2995**
After removal of br01 interface we check if the inteface number has reduced to 1
But since the vm object is not refreshed it doesn't really reflect the reality
and in fact will always be correct.
Added a call to re-get the vm instance in order to correct to test.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
