### PR TITLE
opt-out, Fix opt-out mode not updating configMap

### DIFF
--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -277,7 +277,7 @@ func (p *PoolManager) revertAllocationOnPod(podName string, allocations []string
 
 // Checks if the namespace of a pod instance is opted in for kubemacpool
 func (p *PoolManager) IsPodInstanceOptedIn(namespaceName string) (bool, error) {
-	return p.isInstanceOptedIn(namespaceName, "kubemacpool-mutator", "mutatepods.kubemacpool.io")
+	return p.isNamespaceSelectorCompatibleWithOptModeLabel(namespaceName, "kubemacpool-mutator", "mutatepods.kubemacpool.io", OptInMode)
 }
 
 func podNamespaced(pod *corev1.Pod) string {

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -29,6 +29,7 @@ import (
 
 	multus "github.com/intel/multus-cni/types"
 	"github.com/onsi/ginkgo/extensions/table"
+	"k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -588,5 +589,224 @@ var _ = Describe("Pool", func() {
 				Expect(err).To(HaveOccurred(), "should fail to allocate mac address due to bad annotation format")
 			})
 		})
+	})
+
+	type isNamespaceSelectorCompatibleWithOptModeLabelParams struct {
+		mutatingWebhookConfigurationName string
+		namespaceName                    string
+		optMode                          OptMode
+		ErrorTextExpected                string
+		expectedResult                   bool
+		failureDescription               string
+	}
+
+	Describe("isNamespaceSelectorCompatibleWithOptModeLabel API Tests", func() {
+		webhookName := "webhook"
+		LabelKey := "targetLabel.kubemacpool.io"
+		includingValue := "allocate"
+		excludingValue := "ignore"
+		optOutMutatingWebhookConfigurationName := "optOutMutatingWebhookConfiguration"
+		optInMutatingWebhookConfigurationName := "optInMutatingWebhookConfiguration"
+		namespaceWithIncludingLabelName := "withIncludingLabel"
+		namespaceWithExcludingLabelName := "withExcludingLabel"
+		namespaceWithNoLabelsName := "withNoLabels"
+		namespaceWithIrrelevantLabelsName := "withIrrelevantLabels"
+
+		optOutMutatingWebhookConfiguration := &v1beta1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: optOutMutatingWebhookConfigurationName,
+			},
+			Webhooks: []v1beta1.MutatingWebhook{
+				v1beta1.MutatingWebhook{
+					Name: webhookName,
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							metav1.LabelSelectorRequirement{
+								Key:      "runlevel",
+								Operator: "NotIn",
+								Values:   []string{"0", "1"},
+							},
+							metav1.LabelSelectorRequirement{
+								Key:      "openshift.io/run-level",
+								Operator: "NotIn",
+								Values:   []string{"0", "1"},
+							},
+							metav1.LabelSelectorRequirement{
+								Key:      LabelKey,
+								Operator: "NotIn",
+								Values:   []string{excludingValue},
+							},
+						},
+					},
+				},
+			},
+		}
+		optInMutatingWebhookConfiguration := &v1beta1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: optInMutatingWebhookConfigurationName,
+			},
+			Webhooks: []v1beta1.MutatingWebhook{
+				v1beta1.MutatingWebhook{
+					Name: webhookName,
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							metav1.LabelSelectorRequirement{
+								Key:      "runlevel",
+								Operator: "NotIn",
+								Values:   []string{"0", "1"},
+							},
+							metav1.LabelSelectorRequirement{
+								Key:      "openshift.io/run-level",
+								Operator: "NotIn",
+								Values:   []string{"0", "1"},
+							},
+							metav1.LabelSelectorRequirement{
+								Key:      LabelKey,
+								Operator: "In",
+								Values:   []string{includingValue},
+							},
+						},
+					},
+				},
+			},
+		}
+		namespaceWithIncludingLabel := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   namespaceWithIncludingLabelName,
+				Labels: map[string]string{LabelKey: includingValue},
+			},
+		}
+		namespaceWithExcludingLabel := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   namespaceWithExcludingLabelName,
+				Labels: map[string]string{LabelKey: excludingValue},
+			},
+		}
+		namespaceWithNoLabels := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceWithNoLabelsName,
+			},
+		}
+		namespaceWithIrrelevantLabels := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   namespaceWithIrrelevantLabelsName,
+				Labels: map[string]string{"other": "label"},
+			},
+		}
+		var poolManager *PoolManager
+		BeforeEach(func() {
+			poolManager = createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:01", optOutMutatingWebhookConfiguration, optInMutatingWebhookConfiguration, namespaceWithIncludingLabel, namespaceWithExcludingLabel, namespaceWithNoLabels, namespaceWithIrrelevantLabels)
+		})
+		table.DescribeTable("Should return the expected namespace acceptance outcome according to the opt-mode or return an error",
+			func(n *isNamespaceSelectorCompatibleWithOptModeLabelParams) {
+				isNamespaceManaged, err := poolManager.isNamespaceSelectorCompatibleWithOptModeLabel(n.namespaceName, n.mutatingWebhookConfigurationName, webhookName, n.optMode)
+				if n.ErrorTextExpected != "" {
+					Expect(err).Should(MatchError(n.ErrorTextExpected), "isNamespaceSelectorCompatibleWithOptModeLabel should match expected error message")
+				} else {
+					Expect(err).ToNot(HaveOccurred(), "isNamespaceSelectorCompatibleWithOptModeLabel should not return an error")
+				}
+
+				Expect(isNamespaceManaged).To(Equal(n.expectedResult), n.failureDescription)
+			},
+			table.Entry("when opt-mode is opt-in and using a namespace with including label",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptInMode,
+					mutatingWebhookConfigurationName: optInMutatingWebhookConfigurationName,
+					namespaceName:                    namespaceWithIncludingLabelName,
+					ErrorTextExpected:                "",
+					expectedResult:                   true,
+					failureDescription:               "Should include namespace when in opt-in and including label is set in the namespace",
+				}),
+			table.Entry("when opt-mode is opt-in and using a namespace with irrelevant label",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptInMode,
+					mutatingWebhookConfigurationName: optInMutatingWebhookConfigurationName,
+					namespaceName:                    namespaceWithIrrelevantLabelsName,
+					ErrorTextExpected:                "",
+					expectedResult:                   false,
+					failureDescription:               "Should not include namespace by default unless including label is set in the namespace",
+				}),
+			table.Entry("when opt-mode is opt-in and using a namespace with no labels",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptInMode,
+					mutatingWebhookConfigurationName: optInMutatingWebhookConfigurationName,
+					namespaceName:                    namespaceWithNoLabelsName,
+					ErrorTextExpected:                "",
+					expectedResult:                   false,
+					failureDescription:               "Should not include namespace by default unless including label is set in the namespace",
+				}),
+			table.Entry("when opt-mode is opt-in and using a namespace with excluding label",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptInMode,
+					mutatingWebhookConfigurationName: optInMutatingWebhookConfigurationName,
+					namespaceName:                    namespaceWithExcludingLabelName,
+					ErrorTextExpected:                "",
+					expectedResult:                   false,
+					failureDescription:               "Should not include namespace by default unless including label is set in the namespace",
+				}),
+			table.Entry("when opt-mode is opt-out and using a namespace with excluding label",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptOutMode,
+					mutatingWebhookConfigurationName: optOutMutatingWebhookConfigurationName,
+					namespaceName:                    namespaceWithExcludingLabelName,
+					ErrorTextExpected:                "",
+					expectedResult:                   false,
+					failureDescription:               "Should exclude namespace when in opt-out and excluding label is set in the namespace",
+				}),
+			table.Entry("when opt-mode is opt-out and using a namespace with irrelevant label",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptOutMode,
+					mutatingWebhookConfigurationName: optOutMutatingWebhookConfigurationName,
+					namespaceName:                    namespaceWithIrrelevantLabelsName,
+					ErrorTextExpected:                "",
+					expectedResult:                   true,
+					failureDescription:               "Should include namespace by default unless excluding label is set in the namespace",
+				}),
+			table.Entry("when opt-mode is opt-out and using a namespace with no labels",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptOutMode,
+					mutatingWebhookConfigurationName: optOutMutatingWebhookConfigurationName,
+					namespaceName:                    namespaceWithNoLabelsName,
+					ErrorTextExpected:                "",
+					expectedResult:                   true,
+					failureDescription:               "Should include namespace by default unless excluding label is set in the namespace",
+				}),
+			table.Entry("when opt-mode is opt-out and using a namespace with including label",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptOutMode,
+					mutatingWebhookConfigurationName: optOutMutatingWebhookConfigurationName,
+					namespaceName:                    namespaceWithNoLabelsName,
+					ErrorTextExpected:                "",
+					expectedResult:                   true,
+					failureDescription:               "Should include namespace by default unless excluding label is set in the namespace",
+				}),
+			table.Entry("when opt-mode parameter is not valid",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptMode("not-valid"),
+					mutatingWebhookConfigurationName: optInMutatingWebhookConfigurationName,
+					namespaceName:                    namespaceWithIncludingLabelName,
+					ErrorTextExpected:                "Failed to check if namespaces are managed by default by opt-mode: opt-mode is not defined: not-valid",
+					expectedResult:                   false,
+					failureDescription:               "Should reject namespace if an error has occurred during the function operation",
+				}),
+			table.Entry("when namespace is not found",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptInMode,
+					mutatingWebhookConfigurationName: optInMutatingWebhookConfigurationName,
+					namespaceName:                    "non-existing-namespace-name",
+					ErrorTextExpected:                "Failed to get Namespace: namespaces \"non-existing-namespace-name\" not found",
+					expectedResult:                   false,
+					failureDescription:               "Should reject namespace if an error has occurred during the function operation",
+				}),
+			table.Entry("when mutatingWebhookConfiguration is not found",
+				&isNamespaceSelectorCompatibleWithOptModeLabelParams{
+					optMode:                          OptInMode,
+					mutatingWebhookConfigurationName: "non-existing-mutatingWebhookConfiguration-name",
+					namespaceName:                    namespaceWithIncludingLabelName,
+					ErrorTextExpected:                "Failed lookup webhook in MutatingWebhookConfig: Failed to get mutatingWebhookConfig: mutatingwebhookconfigurations.admissionregistration.k8s.io \"non-existing-mutatingWebhookConfiguration-name\" not found",
+					expectedResult:                   false,
+					failureDescription:               "Should reject namespace if an error has occurred during the function operation",
+				}),
+		)
 	})
 })

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -316,6 +316,15 @@ func getOptOutLabel(webhookName string) metav1.LabelSelectorRequirement {
 	return metav1.LabelSelectorRequirement{Key: webhookName, Operator: "NotIn", Values: []string{"ignore"}}
 }
 
+func getVmWaitConfigMapData() (map[string]string, error) {
+	vmWaitConfigMap, err := testClient.KubeClient.CoreV1().ConfigMaps(managerNamespace).Get(context.TODO(), names.WAITING_VMS_CONFIGMAP, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %s ConfigMap", names.WAITING_VMS_CONFIGMAP)
+	}
+
+	return vmWaitConfigMap.Data, nil
+}
+
 // function checks what is the currently configured opt-mode configured in a specific webhook
 func getOptMode(webhookName string) (string, error) {
 	mutatingWebhook, err := testClient.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), mutatingWebhookConfiguration, metav1.GetOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:
currently vm controller reconcile checks opt-in case.
in case of vm creation in opt-out mode the vmWaitConfigMap is not cleared as
part of normal vm creation, and after 10 minutes will be removed from cache.
Added opt-mode check in vm reconcile
Added test in opt-in/out to make sure vmWaitConfigMap is working well.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
