### PR TITLE
[DNM] controller, Refactor controller reconciler for updates

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -4,4 +4,4 @@ set -xe
 
 source ./cluster/kubevirtci.sh
 
-KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test -test.timeout=40m -race -test.v ./tests/... $E2E_TEST_ARGS -ginkgo.v --test-suite-params="$POLARION_TEST_SUITE_PARAMS"
+KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test -test.timeout=2h -race -test.v ./tests/... $E2E_TEST_ARGS -ginkgo.v --test-suite-params="$POLARION_TEST_SUITE_PARAMS"

--- a/pkg/controller/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualmachine/virtualmachine_controller.go
@@ -145,7 +145,7 @@ func (r *ReconcilePolicy) removeFinalizerAndReleaseMac(request *reconcile.Reques
 
 		// our finalizer is present, so lets handle our external dependency
 		logger.Info("The VM contains the finalizer. Releasing mac")
-		err = r.poolManager.ReleaseVirtualMachineMac(virtualMachine, parentLogger)
+		err = r.poolManager.ReleaseVirtualMachineMacOnVmDelete(virtualMachine, parentLogger)
 		if err != nil {
 			return errors.Wrap(err, "failed to release mac")
 		}

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -67,8 +67,10 @@ const (
 type AllocationStatus string
 
 const (
-	AllocationStatusAllocated     AllocationStatus = "Allocated"
-	AllocationStatusWaitingForPod AllocationStatus = "WaitingForPod"
+	AllocationStatusAllocated          AllocationStatus = "Allocated"
+	AllocationStatusWaitingForPod      AllocationStatus = "WaitingForPod"
+	AllocationStatusWaitingForDeletion AllocationStatus = "WaitingForDeletion"
+	AllocationStatusRestored           AllocationStatus = "Restored"
 )
 
 type macChanges struct {

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -134,6 +134,16 @@ var _ = Describe("Pool", func() {
 			table.Entry("Start: FF:FF:FF:FF:FF:FF  End: FF:FF:FF:FF:FF:FF should fail", "FF:FF:FF:FF:FF:FF", "FF:FF:FF:FF:FF:FF", float64(0), false),
 			table.Entry("Start: 00:00:00:00:00:00  End: 00:00:00:00:00:00 should fail", "00:00:00:00:00:00", "00:00:00:00:00:00", float64(0), false),
 		)
+
+		table.DescribeTable("should mergeMaps correctly", func(map1, map2, expectedMergedMap map[string]string, failDescription string) {
+			mergedMap := mergeMaps([]map[string]string{map1, map2})
+			Expect(mergedMap).To(Equal(expectedMergedMap), failDescription)
+		},
+			table.Entry("when given 2 empty maps", map[string]string{}, map[string]string{}, map[string]string{}, "merged map of two empty maps should be empty as well"),
+			table.Entry("when given empty map and non-empty map", map[string]string{"br1": "40:00:00:00:00:00"}, map[string]string{}, map[string]string{"br1": "40:00:00:00:00:00"}, "merged map of two empty maps should have same values as non-empty map"),
+			table.Entry("when given 2 non-empty maps", map[string]string{"br1": "40:00:00:00:00:00"}, map[string]string{"br2": "02:00:00:00:00:00"}, map[string]string{"br1": "40:00:00:00:00:00", "br2": "02:00:00:00:00:00"}, "merged map of two non-empty maps should include all values"),
+		)
+
 	})
 
 	Describe("Pool Manager General Functions ", func() {
@@ -244,7 +254,7 @@ var _ = Describe("Pool", func() {
 
 			Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:01"))
 
-			err = poolManager.ReleaseVirtualMachineMac(&newVM, logger)
+			err = poolManager.ReleaseVirtualMachineMacOnVmDelete(&newVM, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(poolManager.macPoolMap)).To(Equal(1))
 			_, exist = poolManager.macPoolMap["02:00:00:00:00:00"]
@@ -280,7 +290,7 @@ var _ = Describe("Pool", func() {
 			Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:01"))
 			Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:02"))
 
-			err = poolManager.ReleaseVirtualMachineMac(newVM, logf.Log.WithName("VirtualMachine Controller"))
+			err = poolManager.ReleaseVirtualMachineMacOnVmDelete(newVM, logf.Log.WithName("VirtualMachine Controller"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(poolManager.macPoolMap)).To(Equal(1))
 			_, exist = poolManager.macPoolMap["02:00:00:00:00:00"]

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -249,10 +249,12 @@ func (p *PoolManager) allocateRequestedVirtualMachineInterfaceMac(virtualMachine
 	}
 
 	if _, exist := p.macPoolMap[requestedMac]; exist {
-		err := fmt.Errorf("failed to allocate requested mac address")
-		logger.Error(err, "mac address already allocated")
-
-		return err
+		// check if mac already belongs to the vm
+		if macFromVmMap, _ := p.vmToMacPoolMap[vmNamespaced(virtualMachine)][iface.Name]; macFromVmMap != requestedMac {
+			err := fmt.Errorf("failed to allocate requested mac address")
+			logger.Error(err, "mac address already allocated to another vm")
+			return err
+		}
 	}
 
 	p.macPoolMap[requestedMac] = AllocationStatusWaitingForPod

--- a/pkg/webhook/virtualmachine/virtualmachine.go
+++ b/pkg/webhook/virtualmachine/virtualmachine.go
@@ -170,7 +170,7 @@ func (a *virtualMachineAnnotator) mutateCreateVirtualMachinesFn(ctx context.Cont
 // mutateUpdateVirtualMachinesFn calls the update allocation function
 func (a *virtualMachineAnnotator) mutateUpdateVirtualMachinesFn(ctx context.Context, virtualMachine *kubevirt.VirtualMachine, parentLogger logr.Logger) error {
 	logger := parentLogger.WithName("mutateUpdateVirtualMachinesFn")
-	logger.Info("got an update mutate virtual machine event")
+	logger.Info("got an update mutate virtual machine event", "req rv", virtualMachine.GetResourceVersion(), "req ifaces", virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces, "req Annotations", virtualMachine.GetAnnotations())
 	previousVirtualMachine := &kubevirt.VirtualMachine{}
 	err := a.client.Get(context.TODO(), client.ObjectKey{Namespace: virtualMachine.Namespace, Name: virtualMachine.Name}, previousVirtualMachine)
 	if err != nil {
@@ -179,6 +179,7 @@ func (a *virtualMachineAnnotator) mutateUpdateVirtualMachinesFn(ctx context.Cont
 		}
 		return err
 	}
+	logger.Info("fetching previous VirtualMachine instance", "prev rv", previousVirtualMachine.GetResourceVersion(), "prev ifaces", previousVirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces, "prev Annotations", previousVirtualMachine.GetAnnotations())
 	if !reflect.DeepEqual(virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces, previousVirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces) {
 		return a.poolManager.UpdateMacAddressesForVirtualMachine(previousVirtualMachine, virtualMachine, logger)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a change to the controller: MACs added/deleted due to an update change will be now handled in the controller and configMap. 
This fix tackles the current inability to handle webhook rejections in KMP that has been reproduced on the tier1 CNAO [test_id:2995](https://github.com/kubevirt/cluster-network-addons-operator/issues/720) which [fails](https://github.com/kubevirt/cluster-network-addons-operator/issues/720) occasionally.
The solution includes a change in the KMP controller design, as well as changes added to the tests to allow cache restoration in case of conflict, and tests meant to make sure the change works well.

- **vmToMacPoolMap, Add a vm name to interface:mac map**
In order to follow the macs inserted/deleted from any vm we add a new
map to the macPool module.
The function implemented to update this map is updateVmToMacPoolMap().
We update added macs in the webhook context to avoid allocation races,
and update removed macs when vm is deleted.
We also populate it during the init of the KMP manager
Added vmToMacPoolMap to vm macpool module
Added updateVmToMacPoolMap() to handle mac additions/removals

- **MarkVMAsReady, Change mac status according to vmToMacPoolMap**
Currently the mac status is updated only for newly created vms. The mac
status is updated according to the current vm spec retreived at the
moment of the controller runtime reconcile.
To avoid possible races between webhook and reconcile runs, we change
the controller reconciler to update the mac's status according to values
set in vmToMacPoolMap, which adds new macs during the webhook context.
Furthermore, we expand the controller recocile to also handle
updated/deleted macs. Macs added will be updated in the webhook context,
where deleted macs will be marked for deletion and removed only in
controller reconcile context.

-  **vmToMacPoolMap, Avoid rejecting a mac if a vm already has it**
Added a check in allocateRequestedVirtualMachineInterfaceMac when adding
a predefined mac to a vm, and the mac is already in the mac map,
to avoid rejecting it if it is already set in the vm according to
vmToMacPoolMap.

- **vmWaitingConfigMap, Support deleted macs**
In order to support mac update (addition/removal) restorations due to
webhook rejection, we also populate the vmWaiting ConfigMap with macs
marked for removal/update in the webhook context.
For that we expand the ConfigMap Entry to also hold the vm's namespaced
name, related interface, and current mac status (pending
deletion/addition)

- **webhook, Add logs to track conflicts in vm handler**

- **ci, Allow for random conflict handling in tests**
Occationally a webhook update request could get rejected due to
conlflict. These case are handled by design so that after a period of
time the rejected change is reverted.
Since our tests are also subjected to these conflicts, we should allow
for the kubemacpool cache to restore itself before going on with the
test.
Added retryOnConflictAndWaitForRestoreCache method that waits for the
configured waitTime should an update conflict occurr.
Changed all tests that update the vms to use this instead of the regular
retryOnConflict.
Added additional timeout to functest to allow for such conflict to be
handled.

- **ci, Add tests to check mac allocation/deletions**
Added tests to check mac updates: mac additions and removals.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
