### PR TITLE
webhook, Fix newAllocations list in webhook update

### DIFF
--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -152,6 +152,7 @@ func (p *PoolManager) UpdateMacAddressesForVirtualMachine(previousVirtualMachine
 		if ifaceExist {
 			if iface.MacAddress == "" {
 				copyVM.Spec.Template.Spec.Domain.Devices.Interfaces[idx].MacAddress = allocatedMacAddress
+				newAllocations[iface.Name] = allocatedMacAddress
 			} else if iface.MacAddress != allocatedMacAddress {
 				// Specific mac address was requested
 				err := p.allocateRequestedVirtualMachineInterfaceMac(copyVM, iface, logger)
@@ -178,7 +179,7 @@ func (p *PoolManager) UpdateMacAddressesForVirtualMachine(previousVirtualMachine
 					return err
 				}
 				copyVM.Spec.Template.Spec.Domain.Devices.Interfaces[idx].MacAddress = macAddr
-				newAllocations[iface.Name] = iface.MacAddress
+				newAllocations[iface.Name] = macAddr
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
During interface update, new macs are collected on newAllocations list.
in some situation, an empty mac is inserted, instead of the added mac.
Fixed to add the correct mac Address

**Special notes for your reviewer**:
Although we currently don't really use the newAllocations list in webhook update, it will be need in future design so better fix it now.

**Release note**:

```release-note
NONE
```
