### PR TITLE
Change macPoolMap to use transaction timestamps

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -5,4 +5,4 @@ set -xe
 source ./cluster/kubevirtci.sh
 
 export KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION=v1
-KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test -test.timeout=40m -race -test.v ./tests/... $E2E_TEST_ARGS -ginkgo.v --test-suite-params="$POLARION_TEST_SUITE_PARAMS"
+KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)} $GO test -test.timeout=1h -race -test.v ./tests/... $E2E_TEST_ARGS -ginkgo.v --test-suite-params="$POLARION_TEST_SUITE_PARAMS"

--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -93,7 +93,7 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 	err = r.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if kuberneteserror.IsNotFound(err) {
-			err := r.poolManager.ReleasePodMac(fmt.Sprintf("%s/%s", request.Namespace, request.Name))
+			err := r.poolManager.ReleaseAllPodMacs(fmt.Sprintf("pod/%s/%s", request.Namespace, request.Name))
 			if err != nil {
 				logging.Errorf("%v, failed to release mac for pod %s: %v", logging.ErrorLevel, request.NamespacedName, err)
 			}

--- a/pkg/controller/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualmachine/virtualmachine_controller.go
@@ -99,7 +99,7 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, errors.Wrap(err, "Failed to read the request object")
 	}
 
-	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !pool_manager.IsVirtualMachineDeletionInProgress(instance) {
 		vmShouldBeManaged, err := r.poolManager.IsNamespaceManaged(instance.GetNamespace())
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "Failed to check if vm is managed")
@@ -111,9 +111,18 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 
 		logger.V(1).Info("vm create/update event")
 		// The object is not being deleted, so we can set the macs to allocated
-		err = r.poolManager.MarkVMAsReady(instance, logger)
+		latestPersistedTransactionTimeStamp, err := pool_manager.GetTransactionTimestampAnnotationFromVm(instance)
 		if err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "Failed to reconcile kubemacpool after virtual machine's creation event")
+			if apierrors.IsNotFound(err) {
+				logger.Info("TransactionTimestampAnnotation didn't persist yet, aborting reconcile")
+				return reconcile.Result{}, nil
+			}
+			return reconcile.Result{}, errors.Wrap(err, "Failed to reconcile kubemacpool after virtual machine's creation/update event")
+		}
+
+		err = r.poolManager.MarkVMAsReady(instance, &latestPersistedTransactionTimeStamp, logger)
+		if err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "Failed to reconcile kubemacpool after virtual machine's creation/update event")
 		}
 	} else {
 		// The object is being deleted
@@ -135,6 +144,9 @@ func (r *ReconcilePolicy) removeFinalizerAndReleaseMac(request *reconcile.Reques
 		virtualMachine := &kubevirt.VirtualMachine{}
 		err := r.Get(context.TODO(), request.NamespacedName, virtualMachine)
 		if err != nil {
+			if isVmDeletionAlreadyPersistedByFormerUpdates(err, logger) {
+				return nil
+			}
 			// Error reading the object - requeue the request.
 			return errors.Wrap(err, "Failed to refresh the vm object")
 		}
@@ -145,7 +157,7 @@ func (r *ReconcilePolicy) removeFinalizerAndReleaseMac(request *reconcile.Reques
 
 		// our finalizer is present, so lets handle our external dependency
 		logger.Info("The VM contains the finalizer. Releasing mac")
-		err = r.poolManager.ReleaseVirtualMachineMac(virtualMachine, parentLogger)
+		err = r.poolManager.ReleaseAllVirtualMachineMacs(virtualMachine, parentLogger)
 		if err != nil {
 			return errors.Wrap(err, "failed to release mac")
 		}
@@ -166,4 +178,12 @@ func (r *ReconcilePolicy) removeFinalizerAndReleaseMac(request *reconcile.Reques
 	logger.Info("Successfully updated VM instance with finalizer removal")
 
 	return nil
+}
+
+func isVmDeletionAlreadyPersistedByFormerUpdates(err error, parentLogger logr.Logger) bool {
+	if apierrors.IsNotFound(err) {
+		parentLogger.V(1).Info("vm not found")
+		return true
+	}
+	return false
 }

--- a/pkg/controller/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualmachine/virtualmachine_controller.go
@@ -18,6 +18,7 @@ package virtualmachine
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 
 	"github.com/go-logr/logr"
@@ -84,8 +85,8 @@ type ReconcilePolicy struct {
 // Reconcile reads that state of the cluster for a virtual machine object and makes changes based on the state
 func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	//used for multi thread log separation
-	reconcileRequestId := rand.Int()
-	logger := log.WithName("Reconcile").WithValues("RequestId", reconcileRequestId, "virtualMachineName", request.Name, "virtualMachineNamespace", request.Namespace)
+	reconcileRequestId := rand.Intn(100000)
+	logger := log.WithName("Reconcile").WithValues("RequestId", reconcileRequestId, "vmFullName", fmt.Sprintf("vm/%s/%s", request.Namespace, request.Name))
 	logger.Info("got a virtual machine event in the controller")
 
 	instance := &kubevirt.VirtualMachine{}

--- a/pkg/pool-manager/macentry.go
+++ b/pkg/pool-manager/macentry.go
@@ -1,0 +1,42 @@
+package pool_manager
+
+import "time"
+
+func (m macEntry) hasPendingTransaction() bool {
+	return m.transactionTimestamp != nil
+}
+
+// hasReadyTransaction checks if the transaction TS recorded on the mac entry has passed the last
+// timestamp annotation that persisted in the vm instance, signalling that we need to update this entry.
+func (m macEntry) hasReadyTransaction(lastPersistentTime *time.Time) bool {
+	if !m.hasPendingTransaction() {
+		return false
+	}
+	return !m.transactionTimestamp.After(*lastPersistentTime)
+}
+
+func (m macEntry) resetTransaction() macEntry {
+	return macEntry{
+		instanceName:         m.instanceName,
+		macInstanceKey:       m.macInstanceKey,
+		transactionTimestamp: nil,
+	}
+}
+
+func (m macEntry) setTransaction(timestamp *time.Time) macEntry {
+	return macEntry{
+		instanceName:         m.instanceName,
+		macInstanceKey:       m.macInstanceKey,
+		transactionTimestamp: timestamp,
+	}
+}
+
+func (m macEntry) hasExpiredTransaction(waitTime int) (bool, error) {
+	if m.hasPendingTransaction() {
+		macTransactionExpiration := m.transactionTimestamp.Add(time.Duration(waitTime) * time.Second)
+		if now().After(macTransactionExpiration) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/pool-manager/macentry.go
+++ b/pkg/pool-manager/macentry.go
@@ -2,6 +2,10 @@ package pool_manager
 
 import "time"
 
+func (m macEntry) isDummyEntry() bool {
+	return m.instanceName == tempVmName && m.macInstanceKey == tempVmInterface
+}
+
 func (m macEntry) hasPendingTransaction() bool {
 	return m.transactionTimestamp != nil
 }

--- a/pkg/pool-manager/macentry_test.go
+++ b/pkg/pool-manager/macentry_test.go
@@ -1,0 +1,181 @@
+package pool_manager
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("mac-entry", func() {
+	waitTimeSeconds := 10
+
+	Context("check operations on mac-entry", func() {
+		poolManager := &PoolManager{}
+		// Freeze time
+		now := time.Now()
+		currentTimestamp := now
+		timestampBeforeCurrentTimestamp := now.Add(-time.Second)
+		staleTimestamp := now.Add(-time.Duration(waitTimeSeconds+1) * time.Second)
+		newTimestamp := now.Add(time.Second)
+		BeforeEach(func() {
+			poolManager.waitTime = waitTimeSeconds
+			poolManager.macPoolMap = map[string]macEntry{
+				"02:00:00:00:00:00": macEntry{
+					instanceName:         "vm/default/vm0",
+					macInstanceKey:       "validInterface",
+					transactionTimestamp: &currentTimestamp,
+				},
+				"02:00:00:00:00:01": macEntry{
+					instanceName:         "vm/ns0/vm1",
+					macInstanceKey:       "staleInterface",
+					transactionTimestamp: &staleTimestamp,
+				},
+				"02:00:00:00:00:02": macEntry{
+					instanceName:         "vm/ns2/vm2",
+					macInstanceKey:       "validInterface",
+					transactionTimestamp: &currentTimestamp,
+				},
+				"02:00:00:00:00:03": macEntry{
+					instanceName:         "vm/ns3-4/vm3-4",
+					macInstanceKey:       "staleInterface",
+					transactionTimestamp: &staleTimestamp,
+				},
+				"02:00:00:00:00:04": macEntry{
+					instanceName:         "vm/ns3-4/vm3-4",
+					macInstanceKey:       "validInterface",
+					transactionTimestamp: &currentTimestamp,
+				},
+				"02:00:00:00:00:05": macEntry{
+					instanceName:         "vm/default/vm0",
+					macInstanceKey:       "validInterface",
+					transactionTimestamp: nil,
+				},
+			}
+		})
+
+		type hasExpiredTransactionParams struct {
+			macAddress    string
+			shouldSucceed bool
+		}
+		table.DescribeTable("and performing hasExpiredTransaction on macPoolMap entry",
+			func(i *hasExpiredTransactionParams) {
+				entry := poolManager.macPoolMap[i.macAddress]
+				isStale, err := entry.hasExpiredTransaction(poolManager.waitTime)
+				Expect(err).ToNot(HaveOccurred(), "hasExpiredTransaction should not return error")
+				Expect(isStale).To(Equal(i.shouldSucceed), fmt.Sprintf("mac entry %s staleness status is not as expected", i.macAddress))
+			},
+			table.Entry("Should find all stale entries in macPoolMap on entry mac: 02:00:00:00:00:00",
+				&hasExpiredTransactionParams{
+					macAddress:    "02:00:00:00:00:00",
+					shouldSucceed: false,
+				}),
+			table.Entry("Should find all stale entries in macPoolMap on entry mac: 02:00:00:00:00:01",
+				&hasExpiredTransactionParams{
+					macAddress:    "02:00:00:00:00:01",
+					shouldSucceed: true,
+				}),
+			table.Entry("Should find all stale entries in macPoolMap on entry mac: mac: 02:00:00:00:00:02",
+				&hasExpiredTransactionParams{
+					macAddress:    "02:00:00:00:00:02",
+					shouldSucceed: false,
+				}),
+			table.Entry("Should find all stale entries in macPoolMap on entry mac: mac: 02:00:00:00:00:03",
+				&hasExpiredTransactionParams{
+					macAddress:    "02:00:00:00:00:03",
+					shouldSucceed: true,
+				}),
+			table.Entry("Should find all stale entries in macPoolMap on entry mac: mac: 02:00:00:00:00:04",
+				&hasExpiredTransactionParams{
+					macAddress:    "02:00:00:00:00:04",
+					shouldSucceed: false,
+				}),
+			table.Entry("Should find all stale entries in macPoolMap on entry mac: mac: 02:00:00:00:00:05",
+				&hasExpiredTransactionParams{
+					macAddress:    "02:00:00:00:00:05",
+					shouldSucceed: false,
+				}),
+		)
+
+		type hasPendingTransactionParams struct {
+			macAddress    string
+			shouldSucceed bool
+		}
+		table.DescribeTable("and performing hasPendingTransaction on macPoolMap entry",
+			func(i *hasPendingTransactionParams) {
+				entry := poolManager.macPoolMap[i.macAddress]
+				hasPendingTransaction := entry.hasPendingTransaction()
+				Expect(hasPendingTransaction).To(Equal(i.shouldSucceed), fmt.Sprintf("mac entry %s update required status is not as expected", i.macAddress))
+			},
+			table.Entry("Should distinguish between entries that needs update on mac entry: 02:00:00:00:00:00",
+				&hasPendingTransactionParams{
+					macAddress:    "02:00:00:00:00:00",
+					shouldSucceed: true,
+				}),
+			table.Entry("Should distinguish between entries that needs update on mac entry: 02:00:00:00:00:01",
+				&hasPendingTransactionParams{
+					macAddress:    "02:00:00:00:00:01",
+					shouldSucceed: true,
+				}),
+			table.Entry("Should distinguish between entries that needs update on mac entry: 02:00:00:00:00:02",
+				&hasPendingTransactionParams{
+					macAddress:    "02:00:00:00:00:02",
+					shouldSucceed: true,
+				}),
+			table.Entry("Should distinguish between entries that needs update on mac entry: 02:00:00:00:00:03",
+				&hasPendingTransactionParams{
+					macAddress:    "02:00:00:00:00:03",
+					shouldSucceed: true,
+				}),
+			table.Entry("Should distinguish between entries that needs update on mac entry: 02:00:00:00:00:04",
+				&hasPendingTransactionParams{
+					macAddress:    "02:00:00:00:00:04",
+					shouldSucceed: true,
+				}),
+			table.Entry("Should distinguish between entries that needs update on mac entry: 02:00:00:00:00:05",
+				&hasPendingTransactionParams{
+					macAddress:    "02:00:00:00:00:05",
+					shouldSucceed: false,
+				}),
+		)
+
+		type hasReadyTransactionParams struct {
+			macAddress               string
+			latestPersistedTimestamp *time.Time
+			expectedEntryReadiness   bool
+		}
+		table.DescribeTable("and performing hasReadyTransaction on macPoolMap",
+			func(i *hasReadyTransactionParams) {
+				entry := poolManager.macPoolMap[i.macAddress]
+				isUpdated := entry.hasReadyTransaction(i.latestPersistedTimestamp)
+				Expect(isUpdated).To(Equal(i.expectedEntryReadiness), fmt.Sprintf("should get expected readiness on mac %s", i.macAddress))
+			},
+			table.Entry("Should deem mac entry with old timestamp as ready if persistent timestamp occurred after it",
+				&hasReadyTransactionParams{
+					macAddress:               "02:00:00:00:00:01",
+					latestPersistedTimestamp: &timestampBeforeCurrentTimestamp,
+					expectedEntryReadiness:   true,
+				}),
+			table.Entry("Should deem mac entry with current timestamp as ready if persistent timestamp occurred after it",
+				&hasReadyTransactionParams{
+					macAddress:               "02:00:00:00:00:02",
+					latestPersistedTimestamp: &newTimestamp,
+					expectedEntryReadiness:   true,
+				}),
+			table.Entry("Should deem mac entry with current timestamp as ready if persistent timestamp equals to it",
+				&hasReadyTransactionParams{
+					macAddress:               "02:00:00:00:00:02",
+					latestPersistedTimestamp: &currentTimestamp,
+					expectedEntryReadiness:   true,
+				}),
+			table.Entry("Should deem mac entry with current timestamp as not ready if persistent timestamp occurred before it",
+				&hasReadyTransactionParams{
+					macAddress:               "02:00:00:00:00:02",
+					latestPersistedTimestamp: &timestampBeforeCurrentTimestamp,
+					expectedEntryReadiness:   false,
+				}),
+		)
+	})
+})

--- a/pkg/pool-manager/macpoolmap.go
+++ b/pkg/pool-manager/macpoolmap.go
@@ -1,0 +1,115 @@
+package pool_manager
+
+import (
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+
+	kubevirt "kubevirt.io/client-go/api/v1"
+)
+
+// clearMacTransactionFromMacEntry clears mac entry's transactionTimestamp, signalling that no further update is needed
+func (m *macMap) clearMacTransactionFromMacEntry(macAddress string) {
+	macEntry, exist := m.findByMacAddress(macAddress)
+	if exist {
+		(*m)[macAddress] = macEntry.resetTransaction()
+	}
+}
+
+func (m macMap) findByMacAddress(macAddress string) (macEntry, bool) {
+	macEntry, exist := m[macAddress]
+	return macEntry, exist
+}
+
+func (m macMap) findByMacAddressAndInstanceName(macAddress, instanceFullName string) (macEntry, error) {
+	if entry, exist := m.findByMacAddress(macAddress); exist {
+		if entry.instanceName == instanceFullName {
+			return entry, nil
+		} else {
+			err := errors.New("updateMacTransactionTimestampForUpdatedMacs failed")
+			log.Error(err, "mac address does not belong to instance", "instanceFullName", instanceFullName, "macmap", m)
+			return macEntry{}, err
+		}
+	} else {
+		err := errors.New("updateMacTransactionTimestampForUpdatedMacs failed")
+		log.Error(err, "mac address does not exist in macPoolMap", "instanceFullName", instanceFullName, "macmap", m)
+		return macEntry{}, err
+	}
+}
+
+// removeMacEntry deletes a macEntry from macPoolMap
+func (m *macMap) removeMacEntry(macAddress string) {
+	delete(*m, macAddress)
+}
+
+// filterInByInstanceName creates a subset map from macPoolMap, holding only macs that belongs to a specific instance (pod/vm)
+func (m macMap) filterInByInstanceName(instanceName string) (*macMap, error) {
+	instanceMacMap := macMap{}
+
+	for macAddress, macEntry := range m {
+		if macEntry.instanceName == instanceName {
+			instanceMacMap[macAddress] = macEntry
+		}
+	}
+	return &instanceMacMap, nil
+}
+
+func (m *macMap) createOrUpdateEntry(macAddress, instanceFullName, macInstanceKey string) {
+	(*m)[macAddress] = macEntry{
+		instanceName:         instanceFullName,
+		macInstanceKey:       macInstanceKey,
+		transactionTimestamp: nil,
+	}
+}
+
+// updateMacTransactionTimestampForUpdatedMacs updates the macEntry with the current transactionTimestamp
+func (m *macMap) updateMacTransactionTimestampForUpdatedMacs(instanceFullName string, transactionTimestamp *time.Time, macByInterfaceUpdated map[string]string) error {
+	for _, macAddress := range macByInterfaceUpdated {
+		entry, err := m.findByMacAddressAndInstanceName(macAddress, instanceFullName)
+		if err != nil {
+			return err
+		}
+		(*m)[macAddress] = entry.setTransaction(transactionTimestamp)
+	}
+	return nil
+}
+
+func (m *macMap) filterMacsThatRequireCommit(latestPersistedTransactionTimeStamp *time.Time, parentLogger logr.Logger) error {
+	filteredMap := macMap{}
+	parentLogger.V(1).Info("checking macMap Alignment", "macMAp", *m, "latestPersistedTransactionTimeStamp", latestPersistedTransactionTimeStamp)
+	for macAddress, macEntry := range *m {
+		if macEntry.hasPendingTransaction() {
+			parentLogger.V(1).Info("macAddress params:", "interfaceName", macEntry.macInstanceKey, "transactionTimeStamp", macEntry.transactionTimestamp)
+			if macEntry.hasReadyTransaction(latestPersistedTransactionTimeStamp) {
+				parentLogger.V(1).Info("macAddress ready for update", "macAddress", macAddress)
+				filteredMap[macAddress] = macEntry
+			} else {
+				parentLogger.V(1).Info("change for mac Address did not persist yet", "macAddress", macAddress)
+			}
+		}
+	}
+	*m = filteredMap
+	return nil
+}
+
+// alignMacEntryAccordingToVmInterface compares the mac entry with the current vm yaml interface and aligns itself to it
+func (m *macMap) alignMacEntryAccordingToVmInterface(macAddress, instanceFullName string, vmInterfaces []kubevirt.Interface) {
+	macEntry, _ := m.findByMacAddress(macAddress)
+	for _, iface := range vmInterfaces {
+		if iface.MacAddress == macAddress {
+			if iface.Name == macEntry.macInstanceKey {
+				log.V(1).Info("alignMacEntryAccordingToVmInterface marked mac as allocated", "macAddress", macAddress)
+				m.clearMacTransactionFromMacEntry(macAddress)
+				return
+			} else if macEntry.isDummyEntry() {
+				m.removeMacEntry(macAddress)
+				m.createOrUpdateEntry(macAddress, instanceFullName, iface.Name)
+			}
+		}
+	}
+
+	// if not match found, then it means that the mac was removed. also remove from macPoolMap
+	log.V(1).Info("alignMacEntryAccordingToVmInterface released a mac from macMap", "macAddress", macAddress)
+	m.removeMacEntry(macAddress)
+}

--- a/pkg/pool-manager/macpoolmap_test.go
+++ b/pkg/pool-manager/macpoolmap_test.go
@@ -1,0 +1,459 @@
+package pool_manager
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	kubevirt "kubevirt.io/client-go/api/v1"
+)
+
+var _ = Describe("mac-pool-map", func() {
+	waitTimeSeconds := 10
+
+	Context("check operations on macPoolMap entries", func() {
+		poolManager := &PoolManager{}
+		// Freeze time
+		now := time.Now()
+		timestampBeforeCurrentTimestamp := now.Add(-time.Second)
+		currentTimestamp := now
+		staleTimestamp := now.Add(-time.Duration(waitTimeSeconds+1) * time.Second)
+		newTimestamp := now.Add(time.Second)
+		BeforeEach(func() {
+			poolManager.waitTime = waitTimeSeconds
+			poolManager.macPoolMap = macMap{
+				"02:00:00:00:00:00": macEntry{
+					instanceName:         "vm/default/vm0",
+					macInstanceKey:       "validInterface",
+					transactionTimestamp: &currentTimestamp,
+				},
+				"02:00:00:00:00:01": macEntry{
+					instanceName:         "vm/ns0/vm1",
+					macInstanceKey:       "staleInterface",
+					transactionTimestamp: &staleTimestamp,
+				},
+				"02:00:00:00:00:02": macEntry{
+					instanceName:         "vm/ns2/vm2",
+					macInstanceKey:       "validInterface",
+					transactionTimestamp: &currentTimestamp,
+				},
+				"02:00:00:00:00:03": macEntry{
+					instanceName:         "vm/ns3-4/vm3-4",
+					macInstanceKey:       "staleInterface",
+					transactionTimestamp: &staleTimestamp,
+				},
+				"02:00:00:00:00:04": macEntry{
+					instanceName:         "vm/ns3-4/vm3-4",
+					macInstanceKey:       "validInterface",
+					transactionTimestamp: &currentTimestamp,
+				},
+				"02:00:00:00:00:05": macEntry{
+					instanceName:         "vm/default/vm0",
+					macInstanceKey:       "validInterface",
+					transactionTimestamp: nil,
+				},
+			}
+		})
+
+		type filterInByInstanceNameParams struct {
+			vmName           string
+			expectedVmMacMap *macMap
+		}
+		table.DescribeTable("and performing filterInByInstanceName on macPoolMap",
+			func(i *filterInByInstanceNameParams) {
+				vmMacMap, err := poolManager.macPoolMap.filterInByInstanceName(i.vmName)
+				Expect(err).ToNot(HaveOccurred(), "filterInByInstanceName should not return error")
+				Expect(vmMacMap).To(Equal(i.expectedVmMacMap), "should match expected vm mac map")
+			},
+			table.Entry("Should return empty map when vm not in macPoolMap",
+				&filterInByInstanceNameParams{
+					vmName:           "some-random-name",
+					expectedVmMacMap: &macMap{},
+				}),
+			table.Entry("Should return sub map of vm name: vm/default/vm0",
+				&filterInByInstanceNameParams{
+					vmName: "vm/default/vm0",
+					expectedVmMacMap: &macMap{
+						"02:00:00:00:00:00": macEntry{
+							instanceName:         "vm/default/vm0",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: &currentTimestamp,
+						},
+						"02:00:00:00:00:05": macEntry{
+							instanceName:         "vm/default/vm0",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: nil,
+						},
+					},
+				}),
+			table.Entry("Should return sub map of vm name: vm/ns0/vm1",
+				&filterInByInstanceNameParams{
+					vmName: "vm/ns0/vm1",
+					expectedVmMacMap: &macMap{
+						"02:00:00:00:00:01": macEntry{
+							instanceName:         "vm/ns0/vm1",
+							macInstanceKey:       "staleInterface",
+							transactionTimestamp: &staleTimestamp,
+						},
+					},
+				}),
+			table.Entry("Should return sub map of vm name: vm/ns2/vm2",
+				&filterInByInstanceNameParams{
+					vmName: "vm/ns2/vm2",
+					expectedVmMacMap: &macMap{
+						"02:00:00:00:00:02": macEntry{
+							instanceName:         "vm/ns2/vm2",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: &currentTimestamp,
+						},
+					},
+				}),
+			table.Entry("Should return sub map of vm name: vm/ns3-4/vm3-4",
+				&filterInByInstanceNameParams{
+					vmName: "vm/ns3-4/vm3-4",
+					expectedVmMacMap: &macMap{
+						"02:00:00:00:00:03": macEntry{
+							instanceName:         "vm/ns3-4/vm3-4",
+							macInstanceKey:       "staleInterface",
+							transactionTimestamp: &staleTimestamp,
+						},
+						"02:00:00:00:00:04": macEntry{
+							instanceName:         "vm/ns3-4/vm3-4",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: &currentTimestamp,
+						},
+					},
+				}),
+		)
+
+		type alignMacEntryAccordingToVmInterfaceParams struct {
+			macAddress       string
+			vmName           string
+			vmInterfaces     []kubevirt.Interface
+			expectedExist    bool
+			expectedMacEntry macEntry
+		}
+		table.DescribeTable("and performing alignMacEntryAccordingToVmInterface on macPoolMap entry",
+			func(a *alignMacEntryAccordingToVmInterfaceParams) {
+				poolManager.macPoolMap.alignMacEntryAccordingToVmInterface(a.macAddress, a.vmName, a.vmInterfaces)
+				macEntry, exist := poolManager.macPoolMap[a.macAddress]
+				Expect(exist).To(Equal(a.expectedExist))
+				Expect(macEntry).To(Equal(a.expectedMacEntry), "should align mac entry according to current interface")
+			},
+			table.Entry("Should keep the mac entry and remove the transaction timestamp when interface exists in the vm interfaces list",
+				&alignMacEntryAccordingToVmInterfaceParams{
+					macAddress: "02:00:00:00:00:00",
+					vmName:     "vm/default/vm0",
+					vmInterfaces: []kubevirt.Interface{
+						kubevirt.Interface{
+							Name:       "validInterface",
+							MacAddress: "02:00:00:00:00:00",
+						},
+					},
+					expectedExist: true,
+					expectedMacEntry: macEntry{
+						instanceName:         "vm/default/vm0",
+						macInstanceKey:       "validInterface",
+						transactionTimestamp: nil,
+					},
+				}),
+			table.Entry("Should remove the mac entry when interface does not exist in the vm interfaces list",
+				&alignMacEntryAccordingToVmInterfaceParams{
+					macAddress: "02:00:00:00:00:00",
+					vmName:     "vm/default/vm0",
+					vmInterfaces: []kubevirt.Interface{
+						kubevirt.Interface{
+							Name:       "validInterface",
+							MacAddress: "02:00:00:00:00:01",
+						},
+					},
+					expectedExist:    false,
+					expectedMacEntry: macEntry{},
+				}),
+		)
+
+		type updateMacTransactionTimestampForUpdatedMacsParams struct {
+			vmName               string
+			transactionTimestamp *time.Time
+			updatedInterfaceMap  map[string]string
+			shouldSucceed        bool
+		}
+		table.DescribeTable("and performing updateMacTransactionTimestampForUpdatedMacs on macPoolMap",
+			func(u *updateMacTransactionTimestampForUpdatedMacsParams) {
+				err := poolManager.macPoolMap.updateMacTransactionTimestampForUpdatedMacs(u.vmName, u.transactionTimestamp, u.updatedInterfaceMap)
+				if !u.shouldSucceed {
+					Expect(err).To(HaveOccurred(), "should fail updating mac transaction timestamp")
+				} else {
+					Expect(err).ToNot(HaveOccurred(), "should not fail updating macEntry")
+
+					for _, macAddress := range u.updatedInterfaceMap {
+						Expect(poolManager.macPoolMap[macAddress].transactionTimestamp).To(Equal(u.transactionTimestamp))
+						Expect(poolManager.macPoolMap[macAddress].instanceName).To(Equal(u.vmName))
+					}
+				}
+			},
+			table.Entry("Should fail updating updating mac timestamp when the mac belongs to other vm",
+				&updateMacTransactionTimestampForUpdatedMacsParams{
+					vmName:               "new-vm",
+					transactionTimestamp: &newTimestamp,
+					updatedInterfaceMap:  map[string]string{"iface1": "02:00:00:00:00:00"},
+					shouldSucceed:        false,
+				}),
+			table.Entry("Should fail updating mac timestamp when the mac does not exist in macPoolMap",
+				&updateMacTransactionTimestampForUpdatedMacsParams{
+					vmName:               "vm/default/vm0",
+					transactionTimestamp: &newTimestamp,
+					updatedInterfaceMap:  map[string]string{"iface1": "02:00:00:00:00:FF"},
+					shouldSucceed:        false,
+				}),
+			table.Entry("Should succeed updating mac that already has a timestamp",
+				&updateMacTransactionTimestampForUpdatedMacsParams{
+					vmName:               "vm/default/vm0",
+					transactionTimestamp: &newTimestamp,
+					updatedInterfaceMap:  map[string]string{"iface1": "02:00:00:00:00:00"},
+					shouldSucceed:        true,
+				}),
+			table.Entry("Should succeed updating mac that has a no pending transaction timestamp",
+				&updateMacTransactionTimestampForUpdatedMacsParams{
+					vmName:               "vm/default/vm0",
+					transactionTimestamp: &newTimestamp,
+					updatedInterfaceMap:  map[string]string{"iface1": "02:00:00:00:00:05"},
+					shouldSucceed:        true,
+				}),
+		)
+
+		type clearMacTransactionFromMacEntryParams struct {
+			macAddress string
+		}
+		table.DescribeTable("and performing clearMacTransactionFromMacEntry on macPoolMap entry",
+			func(c *clearMacTransactionFromMacEntryParams) {
+				macPoolMapCopy := map[string]macEntry{}
+				for macAddress, macEntry := range poolManager.macPoolMap {
+					macPoolMapCopy[macAddress] = macEntry
+				}
+
+				poolManager.macPoolMap.clearMacTransactionFromMacEntry(c.macAddress)
+				for macAddress, originalMacEntry := range macPoolMapCopy {
+					updatedMacEntry, exist := poolManager.macPoolMap[macAddress]
+					Expect(exist).To(BeTrue(), fmt.Sprintf("mac %s's entry should not be deleted from macPoolMap after running clearMacTransactionFromMacEntry", macAddress))
+					if macAddress == c.macAddress {
+						expectedMacEntry := macEntry{
+							instanceName:         originalMacEntry.instanceName,
+							macInstanceKey:       originalMacEntry.macInstanceKey,
+							transactionTimestamp: nil,
+						}
+						Expect(updatedMacEntry).To(Equal(expectedMacEntry), fmt.Sprintf("cleaned mac entry %s should only remove transactionTimestamp from entry", macAddress))
+					} else {
+						Expect(updatedMacEntry).To(Equal(originalMacEntry), fmt.Sprintf("untouched mac entry %s should remain the same", macAddress))
+					}
+				}
+			},
+			table.Entry("Should only remove the timestamp from the mac entry mac: 02:00:00:00:00:00",
+				&clearMacTransactionFromMacEntryParams{
+					macAddress: "02:00:00:00:00:00",
+				}),
+			table.Entry("Should only remove the timestamp from the mac entry mac: 02:00:00:00:00:01",
+				&clearMacTransactionFromMacEntryParams{
+					macAddress: "02:00:00:00:00:01",
+				}),
+			table.Entry("Should only remove the timestamp from the mac entry mac: 02:00:00:00:00:02",
+				&clearMacTransactionFromMacEntryParams{
+					macAddress: "02:00:00:00:00:02",
+				}),
+			table.Entry("Should only remove the timestamp from the mac entry mac: 02:00:00:00:00:03",
+				&clearMacTransactionFromMacEntryParams{
+					macAddress: "02:00:00:00:00:03",
+				}),
+			table.Entry("Should only remove the timestamp from the mac entry mac: 02:00:00:00:00:04",
+				&clearMacTransactionFromMacEntryParams{
+					macAddress: "02:00:00:00:00:04",
+				}),
+			table.Entry("Should only remove the timestamp from the mac entry mac: 02:00:00:00:00:05",
+				&clearMacTransactionFromMacEntryParams{
+					macAddress: "02:00:00:00:00:05",
+				}),
+		)
+
+		type findByMacAddressParams struct {
+			macAddress    string
+			shouldExist   bool
+			expectedEntry macEntry
+		}
+		table.DescribeTable("and performing findByMacAddress on macPoolMap",
+			func(f *findByMacAddressParams) {
+				macEntry, exist := poolManager.macPoolMap.findByMacAddress(f.macAddress)
+				Expect(exist).To(Equal(f.shouldExist), fmt.Sprintf("mac %s's entry existance should be as expected", f.macAddress))
+				Expect(macEntry).To(Equal(f.expectedEntry), fmt.Sprintf("mac %s's entry should be as expected", f.macAddress))
+			},
+			table.Entry("Should not find non existent mac: 02:00:00:00:00:0F",
+				&findByMacAddressParams{
+					macAddress:    "02:00:00:00:00:0F",
+					shouldExist:   false,
+					expectedEntry: macEntry{},
+				}),
+			table.Entry("Should find mac in macPoolMap: 02:00:00:00:00:01",
+				&findByMacAddressParams{
+					macAddress:  "02:00:00:00:00:01",
+					shouldExist: true,
+					expectedEntry: macEntry{
+						instanceName:         "vm/ns0/vm1",
+						macInstanceKey:       "staleInterface",
+						transactionTimestamp: &staleTimestamp,
+					},
+				}),
+			table.Entry("Should find mac in macPoolMap: 02:00:00:00:00:02",
+				&findByMacAddressParams{
+					macAddress:  "02:00:00:00:00:02",
+					shouldExist: true,
+					expectedEntry: macEntry{
+						instanceName:         "vm/ns2/vm2",
+						macInstanceKey:       "validInterface",
+						transactionTimestamp: &currentTimestamp,
+					},
+				}),
+			table.Entry("Should find mac in macPoolMap: 02:00:00:00:00:05",
+				&findByMacAddressParams{
+					macAddress:  "02:00:00:00:00:05",
+					shouldExist: true,
+					expectedEntry: macEntry{
+						instanceName:         "vm/default/vm0",
+						macInstanceKey:       "validInterface",
+						transactionTimestamp: nil,
+					},
+				}),
+		)
+
+		It("Should remove mac entry when running removeMacEntry", func() {
+			for macAddress := range poolManager.macPoolMap {
+				poolManager.macPoolMap.removeMacEntry(macAddress)
+				_, exist := poolManager.macPoolMap[macAddress]
+				Expect(exist).To(BeFalse(), "mac entry should be deleted by removeMacEntry")
+			}
+			Expect(poolManager.macPoolMap).To(BeEmpty(), "macPoolMap should be empty after removing all its entries")
+		})
+
+		type createOrUpdateInMacPoolMapParams struct {
+			vmName        string
+			macAddress    string
+			interfaceName string
+		}
+		table.DescribeTable("and adding a new mac to macPoolMap",
+			func(c *createOrUpdateInMacPoolMapParams) {
+				poolManager.macPoolMap.createOrUpdateEntry(c.macAddress, c.vmName, c.interfaceName)
+				updatedMacEntry, exist := poolManager.macPoolMap[c.macAddress]
+				Expect(exist).To(BeTrue(), "mac entry should exist after added/updated")
+				expectedMacEntry := macEntry{
+					instanceName:         c.vmName,
+					macInstanceKey:       c.interfaceName,
+					transactionTimestamp: nil,
+				}
+				Expect(updatedMacEntry).To(Equal(expectedMacEntry), "macEntry should be added/updated")
+			},
+			table.Entry("Should succeed Adding a mac if mac is not in macPoolMap",
+				&createOrUpdateInMacPoolMapParams{
+					vmName:        "vm/default/vm0",
+					interfaceName: "iface6",
+					macAddress:    "02:00:00:00:00:06",
+				}),
+			table.Entry("Should succeed updating a mac if mac is already in macPoolMap",
+				&createOrUpdateInMacPoolMapParams{
+					vmName:        "vm/default/vm0",
+					interfaceName: "validInterface",
+					macAddress:    "02:00:00:00:00:00",
+				}),
+		)
+
+		type filterMacsThatRequireCommitParams struct {
+			latestPersistedTimestamp *time.Time
+			expectedMacMap           macMap
+		}
+		table.DescribeTable("and performing filterMacsThatRequireCommit on macPoolMap",
+			func(f *filterMacsThatRequireCommitParams) {
+				testMacMap := poolManager.macPoolMap
+				testMacMap.filterMacsThatRequireCommit(f.latestPersistedTimestamp, log.WithName("fake-logger"))
+				Expect(testMacMap).To(Equal(f.expectedMacMap), "should get expected mac list")
+			},
+			table.Entry("Should only get stale mac entries if latestPersistedTimestamp is before the current timestamp",
+				&filterMacsThatRequireCommitParams{
+					latestPersistedTimestamp: &timestampBeforeCurrentTimestamp,
+					expectedMacMap: macMap{
+						"02:00:00:00:00:01": macEntry{
+							instanceName:         "vm/ns0/vm1",
+							macInstanceKey:       "staleInterface",
+							transactionTimestamp: &staleTimestamp,
+						},
+						"02:00:00:00:00:03": macEntry{
+							instanceName:         "vm/ns3-4/vm3-4",
+							macInstanceKey:       "staleInterface",
+							transactionTimestamp: &staleTimestamp,
+						},
+					},
+				}),
+			table.Entry("Should only get all pending mac entries if latestPersistedTimestamp equals the current timestamp",
+				&filterMacsThatRequireCommitParams{
+					latestPersistedTimestamp: &currentTimestamp,
+					expectedMacMap: macMap{
+						"02:00:00:00:00:00": macEntry{
+							instanceName:         "vm/default/vm0",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: &currentTimestamp,
+						},
+						"02:00:00:00:00:01": macEntry{
+							instanceName:         "vm/ns0/vm1",
+							macInstanceKey:       "staleInterface",
+							transactionTimestamp: &staleTimestamp,
+						},
+						"02:00:00:00:00:02": macEntry{
+							instanceName:         "vm/ns2/vm2",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: &currentTimestamp,
+						},
+						"02:00:00:00:00:03": macEntry{
+							instanceName:         "vm/ns3-4/vm3-4",
+							macInstanceKey:       "staleInterface",
+							transactionTimestamp: &staleTimestamp,
+						},
+						"02:00:00:00:00:04": macEntry{
+							instanceName:         "vm/ns3-4/vm3-4",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: &currentTimestamp,
+						},
+					},
+				}),
+			table.Entry("Should only get all pending mac entries if latestPersistedTimestamp is after current timestamp",
+				&filterMacsThatRequireCommitParams{
+					latestPersistedTimestamp: &newTimestamp,
+					expectedMacMap: macMap{
+						"02:00:00:00:00:00": macEntry{
+							instanceName:         "vm/default/vm0",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: &currentTimestamp,
+						},
+						"02:00:00:00:00:01": macEntry{
+							instanceName:         "vm/ns0/vm1",
+							macInstanceKey:       "staleInterface",
+							transactionTimestamp: &staleTimestamp,
+						},
+						"02:00:00:00:00:02": macEntry{
+							instanceName:         "vm/ns2/vm2",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: &currentTimestamp,
+						},
+						"02:00:00:00:00:03": macEntry{
+							instanceName:         "vm/ns3-4/vm3-4",
+							macInstanceKey:       "staleInterface",
+							transactionTimestamp: &staleTimestamp,
+						},
+						"02:00:00:00:00:04": macEntry{
+							instanceName:         "vm/ns3-4/vm3-4",
+							macInstanceKey:       "validInterface",
+							transactionTimestamp: &currentTimestamp,
+						},
+					},
+				}),
+		)
+	})
+})

--- a/pkg/pool-manager/migratelegacyconfigmap.go
+++ b/pkg/pool-manager/migratelegacyconfigmap.go
@@ -1,0 +1,91 @@
+package pool_manager
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
+)
+
+const (
+	tempVmName      = "tempVmName"
+	tempVmInterface = "tempInterfaceName"
+)
+
+// the legacy configMap is no longer used in KMP, but after upgrade we might find macs in there.
+// This can be from either 2 scenarios:
+// 1. the webhook that allocated this mac failed
+// 2. the webhook succeeded but configMap didn't remove it yet.
+// initMacMapFromLegacyConfigMap migrates missing entries to macPoolMap to prevent collisions, and then
+// deletes the no longer needed configMap.
+func (p *PoolManager) initMacMapFromLegacyConfigMap() error {
+	waitingMacData, err := p.getVmMacWaitMap()
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("legacy configMap does not exist")
+			return nil
+		}
+		return err
+	}
+
+	err = p.migrateMacsFromConfigMap(waitingMacData)
+	if err != nil {
+		return err
+	}
+	p.deleteVmMacWaitConfigMap()
+
+	return nil
+}
+
+// migrateMacsFromConfigMap goes over the KMP configMap data and migrates the ones that are not yet
+// in the macPoolMap to it to prevent future collisions.
+func (p *PoolManager) migrateMacsFromConfigMap(waitingMacData map[string]string) error {
+	if len(waitingMacData) == 0 {
+		log.V(1).Info("legacy configMap data is empty")
+		return nil
+	}
+	var recreatedMacs []string
+	for macAddressDashes, transactionTimestampString := range waitingMacData {
+		macAddress := strings.Replace(macAddressDashes, "-", ":", 5)
+		if _, exist := p.macPoolMap.findByMacAddress(macAddress); !exist {
+			// configMap timestamps are in RFC3339 format, but it is also applicable in the new RFC3339Nano format
+			transactionTimestamp, err := parseTransactionTimestamp(transactionTimestampString)
+			if err != nil {
+				log.Error(err, "failed to parse legacy mac entry", "macAddress", macAddress, "ts", transactionTimestampString)
+				continue
+			}
+			p.macPoolMap.createOrUpdateDummyEntryWithTimestamp(macAddress, &transactionTimestamp)
+			recreatedMacs = append(recreatedMacs, macAddress)
+		}
+	}
+	log.Info("migrateMacsFromConfigMap", "recreatedMacs", recreatedMacs)
+	return nil
+}
+
+// createOrUpdateDummyEntryWithTimestamp adds/updates a Dummy entry in the macPollMap. Since the transaction timestamp,
+// is migrated we also copy the timestamp, to signal that the transaction is still pending.
+func (m *macMap) createOrUpdateDummyEntryWithTimestamp(macAddress string, timestamp *time.Time) {
+	(*m)[macAddress] = macEntry{
+		instanceName:         tempVmName,
+		macInstanceKey:       tempVmInterface,
+		transactionTimestamp: timestamp,
+	}
+}
+
+// getVmMacWaitMap return a config map that contains mac address and the allocation time.
+func (p *PoolManager) getVmMacWaitMap() (map[string]string, error) {
+	configMap, err := p.kubeClient.CoreV1().ConfigMaps(p.managerNamespace).Get(context.TODO(), names.WAITING_VMS_CONFIGMAP, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return configMap.Data, nil
+}
+
+func (p *PoolManager) deleteVmMacWaitConfigMap() error {
+	return p.kubeClient.CoreV1().ConfigMaps(p.managerNamespace).Delete(context.TODO(), names.WAITING_VMS_CONFIGMAP, metav1.DeleteOptions{})
+}

--- a/pkg/pool-manager/migratelegacyconfigmap_test.go
+++ b/pkg/pool-manager/migratelegacyconfigmap_test.go
@@ -1,0 +1,100 @@
+package pool_manager
+
+import (
+	"context"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
+)
+
+var _ = Describe("migrate legacy vm configMap", func() {
+	legacyVmConfigMap := v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: testManagerNamespace, Name: names.WAITING_VMS_CONFIGMAP}}
+	waitTimeSeconds := 10
+
+	createPoolManager := func(startMacAddr, endMacAddr string, fakeObjectsForClient ...runtime.Object) *PoolManager {
+		fakeClient := fake.NewSimpleClientset(fakeObjectsForClient...)
+		startPoolRangeEnv, err := net.ParseMAC(startMacAddr)
+		Expect(err).ToNot(HaveOccurred(), "should successfully parse starting mac address range")
+		endPoolRangeEnv, err := net.ParseMAC(endMacAddr)
+		Expect(err).ToNot(HaveOccurred(), "should successfully parse ending mac address range")
+		poolManager, err := NewPoolManager(fakeClient, startPoolRangeEnv, endPoolRangeEnv, testManagerNamespace, false, waitTimeSeconds)
+		Expect(err).ToNot(HaveOccurred(), "should successfully initialize poolManager")
+		err = poolManager.Start()
+		Expect(err).ToNot(HaveOccurred(), "should successfully start poolManager routines")
+
+		return poolManager
+	}
+	var poolManager *PoolManager
+	// Freeze time
+	now := time.Now()
+	timestamp := now.Format(time.RFC3339)
+	BeforeEach(func() {
+		poolManager = createPoolManager("02:00:00:00:00:00", "02:FF:FF:FF:FF:FF")
+		Expect(poolManager).ToNot(BeNil())
+	})
+	Context("check migrate of legacy vm configMap to macPoolMap entries", func() {
+		Context("and legacy vm configMap does not exist", func() {
+			It("should not fail to run initMacMapFromLegacyConfigMap", func() {
+				By("initiating the macPoolMap")
+				Expect(poolManager.initMacMapFromLegacyConfigMap()).To(Succeed(), "should not fail migration if configMap does not exist")
+				By("checking the configMap successfully deleted")
+				_, err := poolManager.getVmMacWaitMap()
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "configMap should be removed after macPoolMap initialization")
+				By("checking macPoolMap is empty")
+				Expect(poolManager.macPoolMap).To(BeEmpty(), "migrate should not add any entries to macPoolMap")
+			})
+		})
+
+		Context("and legacy vm configMap exists", func() {
+			type initMacMapFromLegacyConfigMapParams struct {
+				configMapEntries         map[string]string
+				expectedMacsInMacPoolMap []string
+			}
+			table.DescribeTable("and running initMacMapFromLegacyConfigMapParams",
+				func(i *initMacMapFromLegacyConfigMapParams) {
+					By("updating configMap entries")
+					legacyVmConfigMap.Data = i.configMapEntries
+					_, err := poolManager.kubeClient.CoreV1().ConfigMaps(testManagerNamespace).Create(context.Background(), &legacyVmConfigMap, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred(), "should succeed updating the configMap")
+					By("initiating the macPoolMap")
+					Expect(poolManager.initMacMapFromLegacyConfigMap()).To(Succeed(), "should not fail migration if configMap does not exist")
+
+					By("checking the configMap successfully deleted")
+					_, err = poolManager.getVmMacWaitMap()
+					Expect(apierrors.IsNotFound(err)).To(BeTrue(), "configMap should be removed after macPoolMap initialization")
+					By("checking entries migrated to macPoolMap")
+					Expect(poolManager.macPoolMap).To(HaveLen(len(i.expectedMacsInMacPoolMap)))
+					for _, macAddress := range i.expectedMacsInMacPoolMap {
+						macEntry, exist := poolManager.macPoolMap[macAddress]
+						Expect(exist).To(BeTrue(), "mac should be migrated to macPoolMap")
+						Expect(macEntry.isDummyEntry()).To(BeTrue(), "mac entry should be marked as Dummy")
+						expectedTimestamp, err := time.Parse(time.RFC3339Nano, timestamp)
+						Expect(err).ToNot(HaveOccurred(), "should succeed to parse the migrated timestamp")
+						Expect(*macEntry.transactionTimestamp).To(Equal(expectedTimestamp), "mac entry should be marked as Dummy")
+					}
+				},
+				table.Entry("Should successfully migrate entries from legacy configMap when configMap is empty",
+					&initMacMapFromLegacyConfigMapParams{
+						configMapEntries:         map[string]string{},
+						expectedMacsInMacPoolMap: []string{},
+					}),
+				table.Entry("Should successfully migrate entries from legacy configMap when configMap is not empty",
+					&initMacMapFromLegacyConfigMapParams{
+						configMapEntries:         map[string]string{"02:00:00:00:00:00": timestamp, "02:00:00:FF:00:00": timestamp, "02:00:00:00:00:FF": timestamp},
+						expectedMacsInMacPoolMap: []string{"02:00:00:00:00:00", "02:00:00:FF:00:00", "02:00:00:00:00:FF"},
+					}),
+			)
+		})
+	})
+})

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/api/admissionregistration/v1beta1"
@@ -42,6 +43,9 @@ const (
 )
 
 var log = logf.Log.WithName("PoolManager")
+
+// now is an artifact to do some unit testing without waiting for expiration time.
+var now = func() time.Time { return time.Now() }
 
 type PoolManager struct {
 	kubeClient       kubernetes.Interface // kubernetes client
@@ -96,7 +100,8 @@ func NewPoolManager(kubeClient kubernetes.Interface, rangeStart, rangeEnd net.Ha
 		podToMacPoolMap:  map[string]map[string]string{},
 		macPoolMap:       map[string]AllocationStatus{},
 		poolMutex:        sync.Mutex{},
-		waitTime:         waitTime}
+		waitTime:         waitTime,
+	}
 
 	return poolManger, nil
 }

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -54,7 +54,7 @@ type PoolManager struct {
 	rangeEnd         net.HardwareAddr     // last mac in range
 	currentMac       net.HardwareAddr     // last given mac
 	managerNamespace string
-	macPoolMap       map[string]AllocationStatus  // allocated mac map and status
+	macPoolMap       macMap                       // allocated mac map and macEntry
 	podToMacPoolMap  map[string]map[string]string // map allocated mac address by networkname and namespace/podname: {"namespace/podname: {"network name": "mac address"}}
 	poolMutex        sync.Mutex                   // mutex for allocation an release
 	isKubevirt       bool                         // bool if kubevirt virtualmachine crd exist in the cluster
@@ -68,12 +68,13 @@ const (
 	OptOutMode OptMode = "Opt-out"
 )
 
-type AllocationStatus string
+type macEntry struct {
+	instanceName         string
+	macInstanceKey       string // for vms, it holds the interface Name, for pods, it holds the network Name
+	transactionTimestamp *time.Time
+}
 
-const (
-	AllocationStatusAllocated     AllocationStatus = "Allocated"
-	AllocationStatusWaitingForPod AllocationStatus = "WaitingForPod"
-)
+type macMap map[string]macEntry
 
 func NewPoolManager(kubeClient kubernetes.Interface, rangeStart, rangeEnd net.HardwareAddr, managerNamespace string, kubevirtExist bool, waitTime int) (*PoolManager, error) {
 	err := checkRange(rangeStart, rangeEnd)
@@ -99,7 +100,7 @@ func NewPoolManager(kubeClient kubernetes.Interface, rangeStart, rangeEnd net.Ha
 		currentMac:       currentMac,
 		managerNamespace: managerNamespace,
 		podToMacPoolMap:  map[string]map[string]string{},
-		macPoolMap:       map[string]AllocationStatus{},
+		macPoolMap:       macMap{},
 		poolMutex:        sync.Mutex{},
 		waitTime:         waitTime,
 	}
@@ -117,6 +118,49 @@ func (p *PoolManager) Start() error {
 		go p.vmWaitingCleanupLook()
 	}
 	return nil
+}
+
+func (p *PoolManager) InitMaps() error {
+	err := p.initPodMap()
+	if err != nil {
+		return err
+	}
+
+	err = p.initVirtualMachineMap()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkRange(startMac, endMac net.HardwareAddr) error {
+	for idx := 0; idx <= 5; idx++ {
+		if startMac[idx] < endMac[idx] {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Invalid range. rangeStart: %s rangeEnd: %s", startMac.String(), endMac.String())
+}
+
+func GetMacPoolSize(rangeStart, rangeEnd net.HardwareAddr) (int64, error) {
+	err := checkRange(rangeStart, rangeEnd)
+	if err != nil {
+		return 0, errors.Wrap(err, "mac Pool Size  is negative")
+	}
+
+	startInt, err := utils.ConvertHwAddrToInt64(rangeStart)
+	if err != nil {
+		return 0, errors.Wrap(err, "error converting rangeStart to int64")
+	}
+
+	endInt, err := utils.ConvertHwAddrToInt64(rangeEnd)
+	if err != nil {
+		return 0, errors.Wrap(err, "error converting rangeEnd to int64")
+	}
+
+	return endInt - startInt + 1, nil
 }
 
 func (p *PoolManager) getFreeMac() (net.HardwareAddr, error) {
@@ -154,30 +198,6 @@ func (p *PoolManager) getFreeMac() (net.HardwareAddr, error) {
 	}
 
 	return nil, fmt.Errorf("the range is full")
-}
-
-func (p *PoolManager) InitMaps() error {
-	err := p.initPodMap()
-	if err != nil {
-		return err
-	}
-
-	err = p.initVirtualMachineMap()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func checkRange(startMac, endMac net.HardwareAddr) error {
-	for idx := 0; idx <= 5; idx++ {
-		if startMac[idx] < endMac[idx] {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("Invalid range. rangeStart: %s rangeEnd: %s", startMac.String(), endMac.String())
 }
 
 func checkCast(mac net.HardwareAddr) error {
@@ -295,23 +315,4 @@ func (p *PoolManager) getOptMode(mutatingWebhookConfigName, webhookName string) 
 	}
 
 	return "", fmt.Errorf("No Opt mode defined for webhook %s in mutatingWebhookConfig %s", webhookName, mutatingWebhookConfigName)
-}
-
-func GetMacPoolSize(rangeStart, rangeEnd net.HardwareAddr) (int64, error) {
-	err := checkRange(rangeStart, rangeEnd)
-	if err != nil {
-		return 0, errors.Wrap(err, "mac Pool Size  is negative")
-	}
-
-	startInt, err := utils.ConvertHwAddrToInt64(rangeStart)
-	if err != nil {
-		return 0, errors.Wrap(err, "error converting rangeStart to int64")
-	}
-
-	endInt, err := utils.ConvertHwAddrToInt64(rangeEnd)
-	if err != nil {
-		return 0, errors.Wrap(err, "error converting rangeEnd to int64")
-	}
-
-	return endInt - startInt + 1, nil
 }

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -35,11 +35,12 @@ import (
 )
 
 const (
-	RangeStartEnv              = "RANGE_START"
-	RangeEndEnv                = "RANGE_END"
-	RuntimeObjectFinalizerName = "k8s.v1.cni.cncf.io/kubeMacPool"
-	networksAnnotation         = "k8s.v1.cni.cncf.io/networks"
-	networksStatusAnnotation   = "k8s.v1.cni.cncf.io/networks-status"
+	RangeStartEnv                  = "RANGE_START"
+	RangeEndEnv                    = "RANGE_END"
+	RuntimeObjectFinalizerName     = "k8s.v1.cni.cncf.io/kubeMacPool"
+	networksAnnotation             = "k8s.v1.cni.cncf.io/networks"
+	networksStatusAnnotation       = "k8s.v1.cni.cncf.io/networks-status"
+	TransactionTimestampAnnotation = "kubemacpool.io/transaction-timestamp"
 )
 
 var log = logf.Log.WithName("PoolManager")

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -23,12 +23,14 @@ import (
 	"math"
 	"net"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	multus "github.com/intel/multus-cni/types"
+	"github.com/pkg/errors"
 	"k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +64,28 @@ var _ = Describe("Pool", func() {
 		Expect(err).ToNot(HaveOccurred(), "should successfully start poolManager routines")
 
 		return poolManager
+	}
+
+	checkMacPoolMapEntries := func(macPoolMap map[string]macEntry, updatedTransactionTimestamp *time.Time, updatedMacs, notUpdatedMacs []string) error {
+		for _, macAddress := range updatedMacs {
+			macEntry, exist := macPoolMap[macAddress]
+			if !exist {
+				return errors.New(fmt.Sprintf("mac %s should exist in macPoolMap %v", macAddress, macPoolMap))
+			}
+			if macEntry.transactionTimestamp != updatedTransactionTimestamp {
+				return errors.New(fmt.Sprintf("mac %s has transactionTimestamp %s, should have an updated transactionTimestamp %s", macAddress, macEntry.transactionTimestamp, updatedTransactionTimestamp))
+			}
+		}
+		for _, macAddress := range notUpdatedMacs {
+			macEntry, exist := macPoolMap[macAddress]
+			if !exist {
+				return errors.New(fmt.Sprintf("mac %s should exist in macPoolMap %v", macAddress, macPoolMap))
+			}
+			if macEntry.transactionTimestamp == updatedTransactionTimestamp {
+				return errors.New(fmt.Sprintf("mac %s has transactionTimestamp %s, should not have an updated transactionTimestamp %s", macAddress, macEntry.transactionTimestamp, updatedTransactionTimestamp))
+			}
+		}
+		return nil
 	}
 
 	Describe("Internal Functions", func() {
@@ -231,68 +255,59 @@ var _ = Describe("Pool", func() {
 						Devices: kubevirt.Devices{
 							Interfaces: []kubevirt.Interface{masqueradeInterface, multusBridgeInterface}}},
 					Networks: []kubevirt.Network{podNetwork, multusNetwork}}}}}
-
-		It("should allocate a new mac and release it for masquerade", func() {
-			poolManager := createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &samplePod, &vmConfigMap)
-			newVM := masqueradeVM
-			newVM.Name = "newVM"
-
-			err := poolManager.AllocateVirtualMachineMac(&newVM, logger)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(len(poolManager.macPoolMap)).To(Equal(2))
-			_, exist := poolManager.macPoolMap["02:00:00:00:00:00"]
-			Expect(exist).To(BeTrue())
-			_, exist = poolManager.macPoolMap["02:00:00:00:00:01"]
-			Expect(exist).To(BeTrue())
-
-			Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:01"))
-
-			err = poolManager.ReleaseVirtualMachineMac(&newVM, logger)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(poolManager.macPoolMap)).To(Equal(1))
-			_, exist = poolManager.macPoolMap["02:00:00:00:00:00"]
-			Expect(exist).To(BeTrue())
-			_, exist = poolManager.macPoolMap["02:00:00:00:00:01"]
-			Expect(exist).To(BeFalse())
-		})
+		updateTransactionTimestamp := func(secondsPassed time.Duration) time.Time {
+			return time.Now().Add(secondsPassed * time.Second)
+		}
 		It("should not allocate a new mac for bridge interface on pod network", func() {
 			poolManager := createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &vmConfigMap)
 			newVM := sampleVM
 			newVM.Name = "newVM"
 
-			err := poolManager.AllocateVirtualMachineMac(&newVM, logger)
+			transactionTimestamp := updateTransactionTimestamp(0)
+			err := poolManager.AllocateVirtualMachineMac(&newVM, &transactionTimestamp, logger)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(poolManager.macPoolMap)).To(Equal(0))
+			Expect(poolManager.macPoolMap).To(BeEmpty(), "Should not allocate mac for unsupported bridge binding")
 		})
-		It("should allocate a new mac and release it for multiple interfaces", func() {
-			poolManager := createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &samplePod, &vmConfigMap)
-			newVM := multipleInterfacesVM.DeepCopy()
-			newVM.Name = "newVM"
+		Context("and there is a pre-existing pod with mac allocated to it", func() {
+			var poolManager *PoolManager
+			BeforeEach(func() {
+				poolManager = createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &samplePod, &vmConfigMap)
+			})
+			It("should allocate a new mac and release it for masquerade", func() {
+				newVM := masqueradeVM
+				newVM.Name = "newVM"
+				transactionTimestamp := updateTransactionTimestamp(0)
+				err := poolManager.AllocateVirtualMachineMac(&newVM, &transactionTimestamp, logger)
+				Expect(err).ToNot(HaveOccurred())
 
-			err := poolManager.AllocateVirtualMachineMac(newVM, logger)
-			Expect(err).ToNot(HaveOccurred())
+				Expect(poolManager.macPoolMap).To(HaveLen(2))
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{"02:00:00:00:00:01"}, []string{"02:00:00:00:00:00"})).To(Succeed(), "Failed to check macs in macMap")
+				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:01"))
 
-			Expect(len(poolManager.macPoolMap)).To(Equal(3))
-			_, exist := poolManager.macPoolMap["02:00:00:00:00:00"]
-			Expect(exist).To(BeTrue())
-			_, exist = poolManager.macPoolMap["02:00:00:00:00:01"]
-			Expect(exist).To(BeTrue())
-			_, exist = poolManager.macPoolMap["02:00:00:00:00:02"]
-			Expect(exist).To(BeTrue())
+				err = poolManager.ReleaseAllVirtualMachineMacs(&newVM, logger)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(poolManager.macPoolMap).To(HaveLen(1), "Should keep the pod mac in the macMap")
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{}, []string{"02:00:00:00:00:00"})).To(Succeed(), "Failed to check macs in macMap")
+			})
+			It("should allocate a new mac and release it for multiple interfaces", func() {
+				newVM := multipleInterfacesVM.DeepCopy()
+				newVM.Name = "newVM"
 
-			Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:01"))
-			Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:02"))
+				transactionTimestamp := updateTransactionTimestamp(0)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
+				Expect(err).ToNot(HaveOccurred())
 
-			err = poolManager.ReleaseVirtualMachineMac(newVM, logf.Log.WithName("VirtualMachine Controller"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(poolManager.macPoolMap)).To(Equal(1))
-			_, exist = poolManager.macPoolMap["02:00:00:00:00:00"]
-			Expect(exist).To(BeTrue())
-			_, exist = poolManager.macPoolMap["02:00:00:00:00:01"]
-			Expect(exist).To(BeFalse())
-			_, exist = poolManager.macPoolMap["02:00:00:00:00:02"]
-			Expect(exist).To(BeFalse())
+				Expect(poolManager.macPoolMap).To(HaveLen(3))
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{"02:00:00:00:00:01", "02:00:00:00:00:02"}, []string{"02:00:00:00:00:00"})).To(Succeed(), "Failed to check macs in macMap")
+
+				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:01"))
+				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:02"))
+
+				err = poolManager.ReleaseAllVirtualMachineMacs(newVM, logf.Log.WithName("VirtualMachine Controller"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(poolManager.macPoolMap).To(HaveLen(1), "Should keep the pod mac in the macMap")
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{}, []string{"02:00:00:00:00:00"})).To(Succeed(), "Failed to check macs in macMap")
+			})
 		})
 		Describe("Update vm object", func() {
 			It("should preserve disk.io configuration on update", func() {
@@ -305,14 +320,15 @@ var _ = Describe("Pool", func() {
 				newVM.Name = "newVM"
 
 				addDiskIO(newVM, "native-new")
-				err := poolManager.AllocateVirtualMachineMac(newVM, logger)
+				transactionTimestamp := updateTransactionTimestamp(0)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Disks[0].IO).To(Equal(kubevirt.DriverIO("native-new")), "disk.io configuration must be preserved after mac allocation")
 
 				updateVm := multipleInterfacesVM.DeepCopy()
 				updateVm.Name = "newVM"
 				addDiskIO(updateVm, "native-update")
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, logger)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, &transactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Disks[0].IO).To(Equal(kubevirt.DriverIO("native-update")), "disk.io configuration must be preserved after mac allocation update")
 			})
@@ -320,68 +336,71 @@ var _ = Describe("Pool", func() {
 				poolManager := createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &vmConfigMap)
 				newVM := multipleInterfacesVM.DeepCopy()
 				newVM.Name = "newVM"
-				err := poolManager.AllocateVirtualMachineMac(newVM, logger)
+				transactionTimestamp := updateTransactionTimestamp(0)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{"02:00:00:00:00:00", "02:00:00:00:00:01"}, []string{})).To(Succeed(), "Failed to check macs in macMap")
+
+				By("Updating the vm with no mac allocated")
 				updateVm := multipleInterfacesVM.DeepCopy()
 				updateVm.Name = "newVM"
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, logger)
+				newTransactionTimestamp := updateTransactionTimestamp(1)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, &newTransactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &newTransactionTimestamp, []string{"02:00:00:00:00:00", "02:00:00:00:00:01"}, []string{})).To(Succeed(), "Failed to check macs in macMap")
 			})
 			It("should preserve mac addresses and allocate a requested one on update", func() {
 				poolManager := createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &vmConfigMap)
 				newVM := multipleInterfacesVM.DeepCopy()
 				newVM.Name = "newVM"
 
-				err := poolManager.AllocateVirtualMachineMac(newVM, logger)
+				transactionTimestamp := updateTransactionTimestamp(0)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{"02:00:00:00:00:00", "02:00:00:00:00:01"}, []string{})).To(Succeed(), "Failed to check macs in macMap")
 
+				By("Updating the vm with no mac allocated")
 				updateVm := multipleInterfacesVM.DeepCopy()
 				updateVm.Name = "newVM"
+				By("changing one of the macs")
 				updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress = "01:00:00:00:00:02"
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, logger)
+				newTransactionTimestamp := updateTransactionTimestamp(1)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, &newTransactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("01:00:00:00:00:02"))
-
-				_, exist := poolManager.macPoolMap["02:00:00:00:00:01"]
-				Expect(exist).To(BeFalse())
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &newTransactionTimestamp, []string{"02:00:00:00:00:00", "02:00:00:00:00:01", "01:00:00:00:00:02"}, []string{})).To(Succeed(), "Failed to check macs in macMap")
 			})
 			It("should allow to add a new interface on update", func() {
 				poolManager := createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &vmConfigMap)
 				newVM := multipleInterfacesVM.DeepCopy()
 				newVM.Name = "newVM"
 
-				err := poolManager.AllocateVirtualMachineMac(newVM, logger)
+				transactionTimestamp := updateTransactionTimestamp(0)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
-
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{"02:00:00:00:00:00", "02:00:00:00:00:01"}, []string{})).To(Succeed(), "Failed to check macs in macMap")
 				_, exist := poolManager.macPoolMap["02:00:00:00:00:02"]
 				Expect(exist).To(BeFalse())
 
-				updatedVM := multipleInterfacesVM.DeepCopy()
-				updatedVM.Name = "newVM"
+				updatedVM := newVM.DeepCopy()
 				updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces = append(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces, anotherMultusBridgeInterface)
 				updatedVM.Spec.Template.Spec.Networks = append(updatedVM.Spec.Template.Spec.Networks, anotherMultusNetwork)
-
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, logger)
+				NewTransactionTimestamp := updateTransactionTimestamp(1)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, &NewTransactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[2].MacAddress).To(Equal("02:00:00:00:00:02"))
-
-				_, exist = poolManager.macPoolMap["02:00:00:00:00:00"]
-				Expect(exist).To(BeTrue())
-				_, exist = poolManager.macPoolMap["02:00:00:00:00:01"]
-				Expect(exist).To(BeTrue())
-				_, exist = poolManager.macPoolMap["02:00:00:00:00:02"]
-				Expect(exist).To(BeTrue())
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &NewTransactionTimestamp, []string{"02:00:00:00:00:02"}, []string{"02:00:00:00:00:00", "02:00:00:00:00:01"})).To(Succeed(), "Failed to check macs in macMap")
 			})
 			It("should allow to remove an interface on update", func() {
 				poolManager := createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &vmConfigMap)
@@ -390,53 +409,182 @@ var _ = Describe("Pool", func() {
 				newVM.Spec.Template.Spec.Domain.Devices.Interfaces = append(newVM.Spec.Template.Spec.Domain.Devices.Interfaces, anotherMultusBridgeInterface)
 				newVM.Spec.Template.Spec.Networks = append(newVM.Spec.Template.Spec.Networks, anotherMultusNetwork)
 
-				err := poolManager.AllocateVirtualMachineMac(newVM, logger)
+				transactionTimestamp := updateTransactionTimestamp(0)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[2].MacAddress).To(Equal("02:00:00:00:00:02"))
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{"02:00:00:00:00:02", "02:00:00:00:00:00", "02:00:00:00:00:01"}, []string{})).To(Succeed(), "Failed to check macs in macMap")
 
 				updatedVM := multipleInterfacesVM.DeepCopy()
 				updatedVM.Name = "newVM"
-
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, logger)
+				updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress = newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress
+				updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress = newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress
+				NewTransactionTimestamp := updateTransactionTimestamp(1)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, &NewTransactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
-
-				_, exist := poolManager.macPoolMap["02:00:00:00:00:02"]
-				Expect(exist).To(BeFalse())
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &NewTransactionTimestamp, []string{"02:00:00:00:00:02"}, []string{"02:00:00:00:00:00", "02:00:00:00:00:01"})).To(Succeed(), "Failed to check macs in macMap")
 			})
 			It("should allow to remove and add an interface on update", func() {
 				poolManager := createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &vmConfigMap)
 				newVM := multipleInterfacesVM.DeepCopy()
 				newVM.Name = "newVM"
 
-				err := poolManager.AllocateVirtualMachineMac(newVM, logger)
+				transactionTimestamp := updateTransactionTimestamp(0)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{"02:00:00:00:00:00", "02:00:00:00:00:01"}, []string{})).To(Succeed(), "Failed to check macs in macMap")
 
+				By("Updating the vm with no mac allocated")
 				updatedVM := sampleVM.DeepCopy()
 				updatedVM.Name = "newVM"
-
+				By("adding another multus interface")
 				updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces = append(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces, anotherMultusBridgeInterface)
 				updatedVM.Spec.Template.Spec.Networks = append(updatedVM.Spec.Template.Spec.Networks, anotherMultusNetwork)
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, logger)
+				NewTransactionTimestamp := updateTransactionTimestamp(1)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, &NewTransactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:02"))
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].Name).To(Equal("another-multus"))
 
-				_, exist := poolManager.macPoolMap["02:00:00:00:00:01"]
-				Expect(exist).To(BeFalse())
+				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &NewTransactionTimestamp, []string{"02:00:00:00:00:00", "02:00:00:00:00:01", "02:00:00:00:00:02"}, []string{})).To(Succeed(), "Failed to check macs in macMap")
+			})
+		})
+		Context("creating a vm with mac address", func() {
+			var (
+				poolManager  *PoolManager
+				allocatedMac string
+			)
+			// in this context we will not use updateTransactionTimestamp() as we want to control the exact time of each timestamp
+			// Freeze time
+			now := time.Now()
+			vmCreationTimestamp := now
+			vmFirstUpdateTimestamp := now.Add(time.Duration(1) * time.Second)
+			vmSecondUpdateTimestamp := now.Add(time.Duration(2) * time.Second)
+			BeforeEach(func() {
+				poolManager = createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:02", &vmConfigMap)
+			})
+			var vm, vmFirstUpdate, vmSecondUpdate *kubevirt.VirtualMachine
+			var vmLastPersistedTransactionTimestampAnnotation *time.Time
+			BeforeEach(func() {
+				By("Creating a vm")
+				vm = masqueradeVM.DeepCopy()
+				vm.Name = "testVm"
+
+				err := poolManager.AllocateVirtualMachineMac(vm, &vmCreationTimestamp, logger)
+				Expect(err).ToNot(HaveOccurred())
+				allocatedMac = vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress
+				macEntry, exist := poolManager.macPoolMap[allocatedMac]
+				Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap")
+				Expect(macEntry.transactionTimestamp).To(Equal(&vmCreationTimestamp), "mac Entry should update transaction timestamp")
+
+				By("simulating the vm creation as persisted")
+				vmLastPersistedTransactionTimestampAnnotation = &vmCreationTimestamp
+
+				By("marking the vm mac as allocated")
+				err = poolManager.MarkVMAsReady(vm, vmLastPersistedTransactionTimestampAnnotation, log.WithName("fake-Reconcile"))
+				Expect(err).ToNot(HaveOccurred(), "should mark allocated macs as valid")
+				macEntry, exist = poolManager.macPoolMap[allocatedMac]
+				Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap")
+				Expect(macEntry.transactionTimestamp).To(BeNil(), "mac Entry should update transaction timestamp")
+			})
+			Context("and a first update is set to the vm after the vm creation persisted, removing the mac", func() {
+				BeforeEach(func() {
+					By("updating the vm, removing the interface")
+					vmFirstUpdate = vm.DeepCopy()
+					vmFirstUpdate.Spec.Template.Spec.Domain.Devices.Interfaces = vmFirstUpdate.Spec.Template.Spec.Domain.Devices.Interfaces[:0]
+
+					By("updating the vm, removing the interface")
+					err := poolManager.UpdateMacAddressesForVirtualMachine(vm, vmFirstUpdate, &vmFirstUpdateTimestamp, logger)
+					Expect(err).ToNot(HaveOccurred(), "should update vm with no error")
+					macEntry, exist := poolManager.macPoolMap[allocatedMac]
+					Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap after first update")
+					Expect(macEntry.transactionTimestamp).To(Equal(&vmFirstUpdateTimestamp), "mac Entry should update transaction timestamp")
+
+					By("simulating the vm first update as persisted")
+					vmLastPersistedTransactionTimestampAnnotation = &vmFirstUpdateTimestamp
+
+					By("marking the vm mac as allocated by controller reconcile")
+					err = poolManager.MarkVMAsReady(vmFirstUpdate, vmLastPersistedTransactionTimestampAnnotation, log.WithName("fake-Reconcile"))
+					Expect(err).ToNot(HaveOccurred(), "should not mark vm as ready with no errors")
+				})
+				It("should set the macs updated as ready", func() {
+					_, exist := poolManager.macPoolMap[allocatedMac]
+					Expect(exist).To(BeFalse(), "mac should be updated in the macPoolMap after first update persisted")
+				})
+
+				Context("and a second update is set before the first change update was persisted", func() {
+					BeforeEach(func() {
+						By("updating the vm, re-adding the interface")
+						vmSecondUpdate = vm.DeepCopy()
+						By("updating the vm, removing the interface")
+						err := poolManager.UpdateMacAddressesForVirtualMachine(vmFirstUpdate, vmSecondUpdate, &vmSecondUpdateTimestamp, logger)
+						Expect(err).ToNot(HaveOccurred(), "should update vm with no error")
+						macEntry, exist := poolManager.macPoolMap[allocatedMac]
+						Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap after first update")
+						Expect(macEntry.transactionTimestamp).To(Equal(&vmSecondUpdateTimestamp), "mac Entry should update transaction timestamp")
+					})
+					Context("and the first update's controller reconcile is set before second update is persisted", func() {
+						BeforeEach(func() {
+							By("simulating the vm first update as persisted")
+							vmLastPersistedTransactionTimestampAnnotation = &vmFirstUpdateTimestamp
+
+							By("marking the vm mac as allocated by controller reconcile")
+							err := poolManager.MarkVMAsReady(vmSecondUpdate, vmLastPersistedTransactionTimestampAnnotation, log.WithName("fake-Reconcile"))
+							Expect(err).ToNot(HaveOccurred(), "should not mark vm as ready with no errors")
+						})
+						It("Should keep the entry since the last persisted timestamp annotation is still prior to the mac's transaction timestamp", func() {
+							macEntry, exist := poolManager.macPoolMap[allocatedMac]
+							Expect(exist).To(BeTrue(), "mac should be in macMap until last update is persisted to make sure mac is safe from collisions from other updates")
+							Expect(macEntry.transactionTimestamp).To(Equal(&vmSecondUpdateTimestamp), "mac Entry should not change until change is persisted")
+						})
+					})
+					Context("and the first update's controller reconcile is set after the second update is persisted", func() {
+						BeforeEach(func() {
+							By("simulating the vm second update as persisted")
+							vmLastPersistedTransactionTimestampAnnotation = &vmSecondUpdateTimestamp
+
+							By("marking the vm mac as allocated by controller reconcile")
+							err := poolManager.MarkVMAsReady(vmSecondUpdate, vmLastPersistedTransactionTimestampAnnotation, log.WithName("fake-Reconcile"))
+							Expect(err).ToNot(HaveOccurred(), "should not mark vm as ready with no errors")
+						})
+						It("Should update the entry since the last persisted timestamp annotation is equal or later than the mac's transaction timestamp", func() {
+							macEntry, exist := poolManager.macPoolMap[allocatedMac]
+							Expect(exist).To(BeTrue(), "mac should be in macMap since the last persisted change includes this mac")
+							Expect(macEntry.transactionTimestamp).To(BeNil(), "mac Entry should change to ready after change persisted")
+						})
+					})
+					Context("and the first update's controller reconcile is set and the second update is rejected", func() {
+						BeforeEach(func() {
+							By("simulating the vm second update as persisted")
+							vmLastPersistedTransactionTimestampAnnotation = &vmFirstUpdateTimestamp
+
+							By("marking the vm mac as allocated by controller reconcile")
+							err := poolManager.MarkVMAsReady(vmSecondUpdate, vmLastPersistedTransactionTimestampAnnotation, log.WithName("fake-Reconcile"))
+							Expect(err).ToNot(HaveOccurred(), "should not mark vm as ready with no errors")
+						})
+						It("Should keep the entry until a newer change is persisted or until the entry goes stale and removed by handleStaleLegacyConfigMapEntries", func() {
+							macEntry, exist := poolManager.macPoolMap[allocatedMac]
+							Expect(exist).To(BeTrue(), "mac should be in macMap until last update is persisted to make sure mac is safe from collisions from other updates")
+							Expect(macEntry.transactionTimestamp).To(Equal(&vmSecondUpdateTimestamp), "mac Entry should not change")
+						})
+					})
+				})
 			})
 		})
 		Context("check create a vm with mac address allocation", func() {
 			var (
-				newVM        *kubevirt.VirtualMachine
-				poolManager  *PoolManager
-				allocatedMac string
+				newVM                *kubevirt.VirtualMachine
+				poolManager          *PoolManager
+				allocatedMac         string
+				expectedMacEntry     macEntry
+				transactionTimestamp time.Time
 			)
 			BeforeEach(func() {
 				poolManager = createPoolManager("02:00:00:00:00:00", "02:00:00:00:00:01", &vmConfigMap)
@@ -444,10 +592,16 @@ var _ = Describe("Pool", func() {
 				newVM.Name = "newVM"
 
 				By("Create a VM")
-				err := poolManager.AllocateVirtualMachineMac(newVM, logger)
+				transactionTimestamp = updateTransactionTimestamp(0)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
 				Expect(err).ToNot(HaveOccurred(), "should successfully  allocated macs")
 
 				allocatedMac = newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress
+				expectedMacEntry = macEntry{
+					transactionTimestamp: &transactionTimestamp,
+					instanceName:         VmNamespaced(newVM),
+					macInstanceKey:       newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].Name,
+				}
 			})
 			It("should set a mac in configmap with new mac", func() {
 				By("get configmap")
@@ -460,15 +614,25 @@ var _ = Describe("Pool", func() {
 				_, exist := configMap.Data[macAddressInConfigMapFormat]
 				Expect(exist).To(Equal(true), "should have an entry of the mac in the configmap")
 			})
-			It("should set a mac in pool cache in AllocationStatusWaitingForPod status", func() {
+			It("should set a mac in pool cache with updated transaction timestamp", func() {
 				Expect(poolManager.macPoolMap).To(HaveLen(1), "macPoolMap should hold the mac address waiting for approval")
-				Expect(poolManager.macPoolMap[allocatedMac]).To(Equal(AllocationStatusWaitingForPod), "macPoolMap's mac's status should be set to AllocationStatusWaitingForPod status")
+				Expect(poolManager.macPoolMap[allocatedMac]).To(Equal(expectedMacEntry), "macPoolMap's mac's entry should be as expected")
 			})
-			Context("and VM is marked as ready", func() {
+			Context("and VM is marked as ready by controller reconcile", func() {
+				var lastPersistedtransactionTimstamp *time.Time
 				BeforeEach(func() {
+					By("Assuming that the webhook chain was not rejected")
+					lastPersistedtransactionTimstamp = &transactionTimestamp
+
 					By("mark the vm as allocated")
-					err := poolManager.MarkVMAsReady(newVM, log.WithName("fake-Reconcile"))
+					err := poolManager.MarkVMAsReady(newVM, lastPersistedtransactionTimstamp, log.WithName("fake-Reconcile"))
 					Expect(err).ToNot(HaveOccurred(), "should mark allocated macs as valid")
+
+					expectedMacEntry = macEntry{
+						transactionTimestamp: nil,
+						instanceName:         VmNamespaced(newVM),
+						macInstanceKey:       newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].Name,
+					}
 				})
 				It("should successfully allocate the first mac in the range", func() {
 					By("check mac allocated as expected")
@@ -482,14 +646,14 @@ var _ = Describe("Pool", func() {
 				})
 				It("should properly update the pool cache after vm creation", func() {
 					By("check allocated pool is populated and set to AllocationStatusAllocated status")
-					Expect(poolManager.macPoolMap[allocatedMac]).To(Equal(AllocationStatusAllocated), "macPoolMap's mac's status should be set to AllocationStatusAllocated status")
+					Expect(poolManager.macPoolMap[allocatedMac]).To(Equal(expectedMacEntry), "updated macPoolMap's mac's entry should remove transaction timestamp")
 				})
 				It("should check no mac is inserted if the pool does not contain the mac address", func() {
 					By("deleting the mac from the pool")
 					delete(poolManager.macPoolMap, allocatedMac)
 
 					By("re-marking the vm as ready")
-					err := poolManager.MarkVMAsReady(newVM, log.WithName("fake-Reconcile"))
+					err := poolManager.MarkVMAsReady(newVM, lastPersistedtransactionTimstamp, log.WithName("fake-Reconcile"))
 					Expect(err).ToNot(HaveOccurred(), "should not return err if there are no macs to mark as ready")
 
 					By("checking the pool cache is not updated")
@@ -508,7 +672,6 @@ var _ = Describe("Pool", func() {
 
 			err := poolManager.AllocatePodMac(&newPod)
 			Expect(err).ToNot(HaveOccurred())
-
 			Expect(len(poolManager.macPoolMap)).To(Equal(2))
 			_, exist := poolManager.macPoolMap["02:00:00:00:00:00"]
 			Expect(exist).To(BeTrue())

--- a/pkg/pool-manager/transaction.go
+++ b/pkg/pool-manager/transaction.go
@@ -3,6 +3,7 @@ package pool_manager
 import (
 	"time"
 
+	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -32,4 +33,12 @@ func GetTransactionTimestampAnnotationFromVm(virtualMachine *kubevirt.VirtualMac
 
 func parseTransactionTimestamp(timeStampAnnotation string) (time.Time, error) {
 	return time.Parse(time.RFC3339Nano, timeStampAnnotation)
+}
+
+func (p *PoolManager) commitChangesToMacPoolMap(macsMapToCommit *macMap, vm *kubevirt.VirtualMachine, parentLogger logr.Logger) {
+	vmPersistedInterfaceList := getVirtualMachineInterfaces(vm)
+	parentLogger.Info("committing macs to macPoolMap according to the current vm interfaces", "macsMapToCommit", macsMapToCommit, "vmPersistedInterfaceList", vmPersistedInterfaceList)
+	for macAddress, _ := range *macsMapToCommit {
+		p.macPoolMap.alignMacEntryAccordingToVmInterface(macAddress, VmNamespaced(vm), vmPersistedInterfaceList)
+	}
 }

--- a/pkg/pool-manager/transaction.go
+++ b/pkg/pool-manager/transaction.go
@@ -1,0 +1,35 @@
+package pool_manager
+
+import (
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	kubevirt "kubevirt.io/client-go/api/v1"
+)
+
+func CreateTransactionTimestamp() time.Time {
+	return now()
+}
+
+func SetTransactionTimestampAnnotationToVm(virtualMachine *kubevirt.VirtualMachine, transactionTimestamp time.Time) {
+	timeStampAnnotationValue := transactionTimestamp.Format(time.RFC3339Nano)
+	virtualMachine.Annotations[TransactionTimestampAnnotation] = timeStampAnnotationValue
+	log.Info("added TransactionTimestamp Annotation", "ts", timeStampAnnotationValue)
+}
+
+func GetTransactionTimestampAnnotationFromVm(virtualMachine *kubevirt.VirtualMachine) (time.Time, error) {
+	timeStampAnnotationValue, exist := virtualMachine.GetAnnotations()[TransactionTimestampAnnotation]
+	if !exist {
+		return time.Time{}, apierrors.NewNotFound(schema.GroupResource{
+			Group:    "kubemacpool.io",
+			Resource: "transaction-timestamp",
+		}, timeStampAnnotationValue)
+	}
+	return parseTransactionTimestamp(timeStampAnnotationValue)
+}
+
+func parseTransactionTimestamp(timeStampAnnotation string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, timeStampAnnotation)
+}

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -34,33 +34,31 @@ import (
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 )
 
-func (p *PoolManager) AllocateVirtualMachineMac(virtualMachine *kubevirt.VirtualMachine, parentLogger logr.Logger) error {
+func (p *PoolManager) AllocateVirtualMachineMac(virtualMachine *kubevirt.VirtualMachine, transactionTimestamp *time.Time, parentLogger logr.Logger) error {
 	p.poolMutex.Lock()
 	defer p.poolMutex.Unlock()
 	logger := parentLogger.WithName("AllocateVirtualMachineMac")
-	logger.Info("data before allocation", "macmap", p.macPoolMap)
 
 	if len(virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces) == 0 {
 		logger.Info("no interfaces found for virtual machine, skipping mac allocation", "virtualMachine", virtualMachine)
 		return nil
 	}
 
-	if len(virtualMachine.Spec.Template.Spec.Networks) == 0 {
+	vmFullName := VmNamespaced(virtualMachine)
+	if len(getVirtualMachineNetworks(virtualMachine)) == 0 {
 		logger.Info("no networks found for virtual machine, skipping mac allocation",
-			"virtualMachineName", virtualMachine.Name,
-			"virtualMachineNamespace", virtualMachine.Namespace)
+			"vmFullName", vmFullName)
 		return nil
 	}
 
 	networks := map[string]kubevirt.Network{}
-	for _, network := range virtualMachine.Spec.Template.Spec.Networks {
+	for _, network := range getVirtualMachineNetworks(virtualMachine) {
 		networks[network.Name] = network
 	}
 
-	logger.V(1).Info("virtual machine data", "virtualMachineInterfaces", virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces)
-
+	logger.V(1).Info("data before update", "macPoolMap", p.macPoolMap, "requestInterfaces", virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces)
 	copyVM := virtualMachine.DeepCopy()
-	allocations := map[string]string{}
+	newAllocations := map[string]string{}
 	for idx, iface := range copyVM.Spec.Template.Spec.Domain.Devices.Interfaces {
 		if iface.Masquerade == nil && iface.Slirp == nil && networks[iface.Name].Multus == nil {
 			logger.Info("mac address can be set only for interface of type masquerade and slirp on the pod network")
@@ -68,169 +66,175 @@ func (p *PoolManager) AllocateVirtualMachineMac(virtualMachine *kubevirt.Virtual
 		}
 
 		if iface.MacAddress != "" {
-			if err := p.allocateRequestedVirtualMachineInterfaceMac(copyVM, iface, logger); err != nil {
-				p.revertAllocationOnVm(vmNamespaced(copyVM), allocations)
+			if err := p.allocateRequestedVirtualMachineInterfaceMac(vmFullName, iface, logger); err != nil {
+				p.revertAllocationOnVm(vmFullName, newAllocations)
 				return err
 			}
-			allocations[iface.Name] = iface.MacAddress
+			newAllocations[iface.Name] = iface.MacAddress
 		} else {
-			macAddr, err := p.allocateFromPoolForVirtualMachine(copyVM, logger)
+			macAddr, err := p.allocateFromPoolForVirtualMachine(vmFullName, iface, logger)
 			if err != nil {
-				p.revertAllocationOnVm(vmNamespaced(copyVM), allocations)
+				p.revertAllocationOnVm(vmFullName, newAllocations)
 				return err
 			}
 			copyVM.Spec.Template.Spec.Domain.Devices.Interfaces[idx].MacAddress = macAddr
-			allocations[iface.Name] = macAddr
+			newAllocations[iface.Name] = macAddr
 		}
 	}
 
-	err := p.AddMacToWaitingConfig(allocations, logger)
+	err := p.AddMacToWaitingConfig(newAllocations, logger)
 	if err != nil {
 		return err
 	}
 
-	logger.Info("data after allocation", "macmap", p.macPoolMap)
+	p.macPoolMap.updateMacTransactionTimestampForUpdatedMacs(vmFullName, transactionTimestamp, newAllocations)
 	virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces = copyVM.Spec.Template.Spec.Domain.Devices.Interfaces
+	logger.Info("data after allocation", "Allocations", newAllocations, "updated vm Interfaces", virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces)
 
 	return nil
 }
 
-func (p *PoolManager) ReleaseVirtualMachineMac(vm *kubevirt.VirtualMachine, parentLogger logr.Logger) error {
-	logger := parentLogger.WithName("ReleaseVirtualMachineMac")
+func (p *PoolManager) ReleaseAllVirtualMachineMacs(vm *kubevirt.VirtualMachine, parentLogger logr.Logger) error {
+	logger := parentLogger.WithName("ReleaseAllVirtualMachineMacs")
 
 	p.poolMutex.Lock()
 	defer p.poolMutex.Unlock()
-	logger.V(1).Info("data",
-		"macmap", p.macPoolMap,
-		"podmap", p.podToMacPoolMap,
-		"currentMac", p.currentMac.String())
-
-	if len(vm.Spec.Template.Spec.Domain.Devices.Interfaces) == 0 {
-		logger.Info("no interfaces found for virtual machine, skipping mac release")
-		return nil
+	logger.V(1).Info("data", "macmap", p.macPoolMap)
+	vmFullName := VmNamespaced(vm)
+	vmMacMap, err := p.macPoolMap.filterInByInstanceName(vmFullName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get VmMacMap for vm %s", vmFullName)
 	}
 
-	logger.V(1).Info("virtual machine data", "interfaces", vm.Spec.Template.Spec.Domain.Devices.Interfaces)
-	for _, iface := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
-		if iface.MacAddress != "" {
-			delete(p.macPoolMap, iface.MacAddress)
-			logger.Info("released mac from virtual machine",
-				"mac", iface.MacAddress)
-		}
+	for macAddress := range *vmMacMap {
+		delete(p.macPoolMap, macAddress)
 	}
 
-	logger.Info("released macs in virtua machine", "macmap", p.macPoolMap)
+	logger.Info("released macs in virtual machine", "macmap", p.macPoolMap)
 
 	return nil
 }
 
-func (p *PoolManager) UpdateMacAddressesForVirtualMachine(previousVirtualMachine, virtualMachine *kubevirt.VirtualMachine, parentLogger logr.Logger) error {
+func (p *PoolManager) UpdateMacAddressesForVirtualMachine(previousVirtualMachine, virtualMachine *kubevirt.VirtualMachine, transactionTimestamp *time.Time, parentLogger logr.Logger) error {
 	logger := parentLogger.WithName("UpdateMacAddressesForVirtualMachine")
-	logger.Info("data before allocation", "macmap", p.macPoolMap)
 	p.poolMutex.Lock()
 	if previousVirtualMachine == nil {
 		p.poolMutex.Unlock()
-		return p.AllocateVirtualMachineMac(virtualMachine, logger)
+		return p.AllocateVirtualMachineMac(virtualMachine, transactionTimestamp, logger)
 	}
-
 	defer p.poolMutex.Unlock()
-	// This map is for revert if the allocation failed
-	copyInterfacesMap := make(map[string]string)
+
+	currentInterfaces := getVirtualMachineInterfaces(previousVirtualMachine)
+	requestInterfaces := getVirtualMachineInterfaces(virtualMachine)
+	logger.V(1).Info("data before update", "macPoolMap", p.macPoolMap, "currentInterfaces", currentInterfaces, "requestInterfaces", requestInterfaces)
+
+	currentInterfacesMap := make(map[string]string)
 	// This map is for deltas
 	deltaInterfacesMap := make(map[string]string)
-	for _, iface := range previousVirtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces {
-		copyInterfacesMap[iface.Name] = iface.MacAddress
+	for _, iface := range currentInterfaces {
+		currentInterfacesMap[iface.Name] = iface.MacAddress
 		deltaInterfacesMap[iface.Name] = iface.MacAddress
 	}
 
+	vmFullName := VmNamespaced(virtualMachine)
 	copyVM := virtualMachine.DeepCopy()
 	newAllocations := map[string]string{}
 	releaseOldAllocations := map[string]string{}
-	for idx, iface := range virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces {
-		allocatedMacAddress, ifaceExist := copyInterfacesMap[iface.Name]
-		// The interface was configured before check if we need to update the mac or assign the existing one
-		if ifaceExist {
-			if iface.MacAddress == "" {
-				copyVM.Spec.Template.Spec.Domain.Devices.Interfaces[idx].MacAddress = allocatedMacAddress
-				newAllocations[iface.Name] = allocatedMacAddress
-			} else if iface.MacAddress != allocatedMacAddress {
+	for idx, requestIface := range requestInterfaces {
+		currentlyAllocatedMacAddress, ifaceExistsInCurrentInterfaces := currentInterfacesMap[requestIface.Name]
+		if ifaceExistsInCurrentInterfaces {
+			if requestIface.MacAddress == "" {
+				copyVM.Spec.Template.Spec.Domain.Devices.Interfaces[idx].MacAddress = currentlyAllocatedMacAddress
+				newAllocations[requestIface.Name] = currentlyAllocatedMacAddress
+			} else if requestIface.MacAddress != currentlyAllocatedMacAddress {
 				// Specific mac address was requested
-				err := p.allocateRequestedVirtualMachineInterfaceMac(copyVM, iface, logger)
+				err := p.allocateRequestedVirtualMachineInterfaceMac(vmFullName, requestIface, logger)
 				if err != nil {
-					p.revertAllocationOnVm(vmNamespaced(copyVM), newAllocations)
+					p.revertAllocationOnVm(vmFullName, newAllocations)
 					return err
 				}
-				releaseOldAllocations[iface.Name] = allocatedMacAddress
-				newAllocations[iface.Name] = iface.MacAddress
+				releaseOldAllocations[requestIface.Name] = currentlyAllocatedMacAddress
+				newAllocations[requestIface.Name] = requestIface.MacAddress
 			}
-			delete(deltaInterfacesMap, iface.Name)
+			delete(deltaInterfacesMap, requestIface.Name)
 
 		} else {
-			if iface.MacAddress != "" {
-				if err := p.allocateRequestedVirtualMachineInterfaceMac(copyVM, iface, logger); err != nil {
-					p.revertAllocationOnVm(vmNamespaced(copyVM), newAllocations)
+			if requestIface.MacAddress != "" {
+				if err := p.allocateRequestedVirtualMachineInterfaceMac(vmFullName, requestIface, logger); err != nil {
+					p.revertAllocationOnVm(vmFullName, newAllocations)
 					return err
 				}
-				newAllocations[iface.Name] = iface.MacAddress
+				newAllocations[requestIface.Name] = requestIface.MacAddress
 			} else {
-				macAddr, err := p.allocateFromPoolForVirtualMachine(copyVM, logger)
+				macAddr, err := p.allocateFromPoolForVirtualMachine(vmFullName, requestIface, logger)
 				if err != nil {
-					p.revertAllocationOnVm(vmNamespaced(copyVM), newAllocations)
+					p.revertAllocationOnVm(vmFullName, newAllocations)
 					return err
 				}
 				copyVM.Spec.Template.Spec.Domain.Devices.Interfaces[idx].MacAddress = macAddr
-				newAllocations[iface.Name] = macAddr
+				newAllocations[requestIface.Name] = macAddr
 			}
 		}
 	}
 
-	// Release delta interfaces
-	logger.V(1).Info("delta interfaces to release",
-		"interfaces Map", deltaInterfacesMap)
-	p.releaseMacAddressesFromInterfaceMap(deltaInterfacesMap)
+	logger.Info("updating updated mac's transaction timestamp", "newAllocations", newAllocations, "deltaInterfacesMap", deltaInterfacesMap, "releaseOldAllocations", releaseOldAllocations)
+	p.macPoolMap.updateMacTransactionTimestampForUpdatedMacs(vmFullName, transactionTimestamp, newAllocations)
+	p.macPoolMap.updateMacTransactionTimestampForUpdatedMacs(vmFullName, transactionTimestamp, deltaInterfacesMap)
+	p.macPoolMap.updateMacTransactionTimestampForUpdatedMacs(vmFullName, transactionTimestamp, releaseOldAllocations)
 
-	// Release old allocations
-	logger.V(1).Info("old interfaces to release",
-		"interfaces Map", releaseOldAllocations)
-	p.releaseMacAddressesFromInterfaceMap(releaseOldAllocations)
-
-	logger.Info("data after allocation", "macmap", p.macPoolMap)
-	virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces = copyVM.Spec.Template.Spec.Domain.Devices.Interfaces
+	virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces = getVirtualMachineInterfaces(copyVM)
+	logger.Info("data after update", "macmap", p.macPoolMap, "updated interfaces", getVirtualMachineInterfaces(virtualMachine))
 	return nil
 }
 
-func (p *PoolManager) allocateFromPoolForVirtualMachine(virtualMachine *kubevirt.VirtualMachine, parentLogger logr.Logger) (string, error) {
+func getVirtualMachineInterfaces(virtualMachine *kubevirt.VirtualMachine) []kubevirt.Interface {
+	return virtualMachine.Spec.Template.Spec.Domain.Devices.Interfaces
+}
+
+func getVirtualMachineNetworks(virtualMachine *kubevirt.VirtualMachine) []kubevirt.Network {
+	return virtualMachine.Spec.Template.Spec.Networks
+}
+
+func (p *PoolManager) allocateFromPoolForVirtualMachine(vmFullName string, iface kubevirt.Interface, parentLogger logr.Logger) (string, error) {
 	logger := parentLogger.WithName("allocateFromPoolForVirtualMachine")
 	macAddr, err := p.getFreeMac()
 	if err != nil {
 		return "", err
 	}
 
-	p.macPoolMap[macAddr.String()] = AllocationStatusWaitingForPod
-	logger.V(1).Info("mac from pool was allocated for virtual machine",
-		"allocatedMac", macAddr.String())
+	p.macPoolMap.createOrUpdateEntry(macAddr.String(), vmFullName, iface.Name)
+	logger.V(1).Info("mac from pool was allocated for virtual machine", "allocatedMac", macAddr.String())
 	return macAddr.String(), nil
 }
 
-func (p *PoolManager) allocateRequestedVirtualMachineInterfaceMac(virtualMachine *kubevirt.VirtualMachine, iface kubevirt.Interface, parentLogger logr.Logger) error {
+func (p *PoolManager) allocateRequestedVirtualMachineInterfaceMac(vmFullName string, iface kubevirt.Interface, parentLogger logr.Logger) error {
 	logger := parentLogger.WithName("allocateRequestedVirtualMachineInterfaceMac")
 	requestedMac := iface.MacAddress
 	if _, err := net.ParseMAC(requestedMac); err != nil {
 		return err
 	}
 
-	if _, exist := p.macPoolMap[requestedMac]; exist {
-		err := fmt.Errorf("failed to allocate requested mac address")
-		logger.Error(err, "mac address already allocated")
+	if macEntry, exist := p.macPoolMap[requestedMac]; exist {
+		if !macAlreadyBelongsToVmAndInterface(vmFullName, iface.Name, macEntry) {
+			err := fmt.Errorf("failed to allocate requested mac address")
+			logger.Error(err, "mac address already allocated")
 
-		return err
+			return err
+		}
 	}
 
-	p.macPoolMap[requestedMac] = AllocationStatusWaitingForPod
-	logger.V(1).Info("requested mac was allocated for virtual machine",
-		"requestedMap", requestedMac)
+	p.macPoolMap.createOrUpdateEntry(requestedMac, vmFullName, iface.Name)
+
+	logger.V(1).Info("requested mac was allocated for virtual machine", "requestedMap", requestedMac)
 
 	return nil
+}
+
+func macAlreadyBelongsToVmAndInterface(vmFullName, interfaceName string, macEntry macEntry) bool {
+	if macEntry.instanceName == vmFullName && macEntry.macInstanceKey == interfaceName {
+		return true
+	}
+	return false
 }
 
 func (p *PoolManager) initVirtualMachineMap() error {
@@ -343,16 +347,12 @@ func (p *PoolManager) isRelatedToKubevirt(pod *corev1.Pod) bool {
 	return false
 }
 
-func (p *PoolManager) releaseMacAddressesFromInterfaceMap(allocations map[string]string) {
-	for _, value := range allocations {
-		delete(p.macPoolMap, value)
-	}
-}
-
 // Revert allocation if one of the requested mac addresses fails to be allocated
 func (p *PoolManager) revertAllocationOnVm(vmName string, allocations map[string]string) {
 	log.V(1).Info("Revert vm allocation", "vmName", vmName, "allocations", allocations)
-	p.releaseMacAddressesFromInterfaceMap(allocations)
+	for _, macAddress := range allocations {
+		delete(p.macPoolMap, macAddress)
+	}
 }
 
 // This function return or creates a config map that contains mac address and the allocation time.
@@ -409,52 +409,28 @@ func (p *PoolManager) AddMacToWaitingConfig(allocations map[string]string, paren
 }
 
 // Remove all the mac addresses from the waiting configmap this mean the vm was saved in the etcd and pass validations
-func (p *PoolManager) MarkVMAsReady(vm *kubevirt.VirtualMachine, parentLogger logr.Logger) error {
+func (p *PoolManager) MarkVMAsReady(vm *kubevirt.VirtualMachine, latestPersistedTransactionTimeStamp *time.Time, parentLogger logr.Logger) error {
 	logger := parentLogger.WithName("MarkVMAsReady")
 
 	p.poolMutex.Lock()
 	defer p.poolMutex.Unlock()
+	vmFullName := VmNamespaced(vm)
 
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// refresh ConfigMaps instance
-		configMap, err := p.kubeClient.CoreV1().ConfigMaps(p.managerNamespace).Get(context.TODO(), names.WAITING_VMS_CONFIGMAP, metav1.GetOptions{})
-		if err != nil {
-			return errors.Wrap(err, "Failed to refresh manager's configmap instance")
-		}
-
-		if configMap.Data == nil {
-			logger.Info("the configMap is empty")
-			return nil
-		}
-
-		if len(vm.Spec.Template.Spec.Domain.Devices.Interfaces) == 0 {
-			logger.Info("interface list is empty")
-			return nil
-		}
-
-		logger.V(1).Info("set vm's mac to status allocated", "vm interfaces", vm.Spec.Template.Spec.Domain.Devices.Interfaces)
-		for _, vmInterface := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
-			if vmInterface.MacAddress != "" {
-				if _, exist := p.macPoolMap[vmInterface.MacAddress]; exist {
-					p.macPoolMap[vmInterface.MacAddress] = AllocationStatusAllocated
-				}
-				macAddress := strings.Replace(vmInterface.MacAddress, ":", "-", 5)
-				delete(configMap.Data, macAddress)
-			}
-		}
-		logger.V(1).Info("set virtual machine's macs as ready")
-
-		_, err = p.kubeClient.CoreV1().ConfigMaps(p.managerNamespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
-
-		return err
-	})
-
+	vmMacMap, err := p.macPoolMap.filterInByInstanceName(vmFullName)
 	if err != nil {
-		return errors.Wrap(err, "Failed to update manager's configmap with approved allocated macs")
+		return errors.Wrapf(err, "Failed to get VmMacMap for vm %s", vmFullName)
+	}
+	logger.Info("Macs currently set on vm", "vmMacMap", vmMacMap)
+
+	err = vmMacMap.filterMacsThatRequireCommit(latestPersistedTransactionTimeStamp, logger)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to filter macs that need commit on vm %s", vmFullName)
+	}
+	if len(*vmMacMap) != 0 {
+		p.commitChangesToMacPoolMap(vmMacMap, vm, logger)
 	}
 
 	logger.Info("marked virtual machine as ready", "macPoolMap", p.macPoolMap)
-
 	return nil
 }
 
@@ -534,7 +510,7 @@ func (p *PoolManager) IsNamespaceManaged(namespaceName string) (bool, error) {
 	return isNamespaceManaged, nil
 }
 
-func vmNamespaced(machine *kubevirt.VirtualMachine) string {
+func VmNamespaced(machine *kubevirt.VirtualMachine) string {
 	return fmt.Sprintf("%s/%s", machine.Namespace, machine.Name)
 }
 

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -537,3 +537,7 @@ func (p *PoolManager) IsNamespaceManaged(namespaceName string) (bool, error) {
 func vmNamespaced(machine *kubevirt.VirtualMachine) string {
 	return fmt.Sprintf("%s/%s", machine.Namespace, machine.Name)
 }
+
+func IsVirtualMachineDeletionInProgress(vm *kubevirt.VirtualMachine) bool {
+	return !vm.ObjectMeta.DeletionTimestamp.IsZero()
+}

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -511,7 +511,7 @@ func (p *PoolManager) IsNamespaceManaged(namespaceName string) (bool, error) {
 }
 
 func VmNamespaced(machine *kubevirt.VirtualMachine) string {
-	return fmt.Sprintf("%s/%s", machine.Namespace, machine.Name)
+	return fmt.Sprintf("vm/%s/%s", machine.Namespace, machine.Name)
 }
 
 func IsVirtualMachineDeletionInProgress(vm *kubevirt.VirtualMachine) bool {

--- a/pkg/webhook/pod/pod.go
+++ b/pkg/webhook/pod/pod.go
@@ -62,7 +62,9 @@ func (a *podAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 		pod.Annotations = map[string]string{}
 	}
 
-	log.V(1).Info("got a create pod event", "podName", pod.Name, "podNamespace", pod.Namespace)
+	transactionTimestamp := pool_manager.CreateTransactionTimestamp()
+	log.V(1).Info("got a create pod event", "podName", pod.Name, "podNamespace", pod.Namespace, "transactionTimestamp", transactionTimestamp)
+
 	err = a.poolManager.AllocatePodMac(pod)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/webhook/virtualmachine/virtualmachine.go
+++ b/pkg/webhook/virtualmachine/virtualmachine.go
@@ -65,8 +65,8 @@ func (a *virtualMachineAnnotator) Handle(ctx context.Context, req admission.Requ
 	}
 	originalVirtualMachine := virtualMachine.DeepCopy()
 
-	handleRequestId := rand.Int()
-	logger := log.WithName("Handle").WithValues("RequestId", handleRequestId, "virtualMachineName", virtualMachine.Name, "virtualMachineNamespace", virtualMachine.Namespace)
+	handleRequestId := rand.Intn(100000)
+	logger := log.WithName("Handle").WithValues("RequestId", handleRequestId, "virtualMachineFullName", pool_manager.VmNamespaced(virtualMachine))
 
 	if virtualMachine.Annotations == nil {
 		virtualMachine.Annotations = map[string]string{}

--- a/pkg/webhook/virtualmachine/virtualmachine.go
+++ b/pkg/webhook/virtualmachine/virtualmachine.go
@@ -161,7 +161,7 @@ func (a *virtualMachineAnnotator) mutateCreateVirtualMachinesFn(virtualMachine *
 		if apierrors.IsNotFound(err) {
 			if !pool_manager.IsVirtualMachineDeletionInProgress(virtualMachine) {
 				// If the object is not being deleted, then lets allocate macs and add the finalizer
-				err = a.poolManager.AllocateVirtualMachineMac(virtualMachine, logger)
+				err = a.poolManager.AllocateVirtualMachineMac(virtualMachine, &transactionTimestamp, logger)
 				if err != nil {
 					return errors.Wrap(err, "Failed to allocate mac to the vm object")
 				}
@@ -197,7 +197,7 @@ func (a *virtualMachineAnnotator) mutateUpdateVirtualMachinesFn(virtualMachine *
 		pool_manager.SetTransactionTimestampAnnotationToVm(virtualMachine, transactionTimestamp)
 
 		if isVirtualMachineInterfacesChanged(previousVirtualMachine, virtualMachine) {
-			return a.poolManager.UpdateMacAddressesForVirtualMachine(previousVirtualMachine, virtualMachine, logger)
+			return a.poolManager.UpdateMacAddressesForVirtualMachine(previousVirtualMachine, virtualMachine, &transactionTimestamp, logger)
 		}
 	}
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -240,6 +240,21 @@ func getVmFailCleanupWaitTime() time.Duration {
 	return 0
 }
 
+func checkKubemacpoolCrash() error {
+	kubemacpoolPods, err := getKubemacpoolPods()
+	if err != nil {
+		return err
+	}
+	for _, pod := range kubemacpoolPods.Items {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.RestartCount != 0 {
+				return errors.New(fmt.Sprintf("Kubemacpool container crashed %d times", containerStatus.RestartCount))
+			}
+		}
+	}
+	return nil
+}
+
 func changeManagerReplicas(numOfReplica int32) error {
 	By(fmt.Sprintf("updating deployment pod replicas to be %d", numOfReplica))
 	Eventually(func() error {

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -25,6 +25,7 @@ const pollingInterval = 5 * time.Second
 
 //TODO: the rfe_id was taken from kubernetes-nmstate we have to discover the rigth parameters here
 var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:component]Virtual Machines", func() {
+	restoreFailedWebhookChangesTimeout := time.Duration(0)
 	BeforeAll(func() {
 		result := testClient.KubeClient.ExtensionsV1beta1().RESTClient().
 			Post().
@@ -32,6 +33,11 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Body([]byte(fmt.Sprintf(linuxBridgeConfCRD, "linux-bridge", TestNamespace))).
 			Do(context.TODO())
 		Expect(result.Error()).NotTo(HaveOccurred(), "KubeCient should successfully respond to post request")
+
+		vmFailCleanupWaitTime := getVmFailCleanupWaitTime()
+		// since this test checks vmWaitingCleanupLook routine, we need to adjust the total timeout with the wait-time argument.
+		// we also add some extra timeout apart form wait-time to be sure that we catch the vm mac release.
+		restoreFailedWebhookChangesTimeout = vmFailCleanupWaitTime + time.Minute
 	})
 
 	BeforeEach(func() {
@@ -324,13 +330,6 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 			})
 			Context("and we re-apply a failed VM yaml", func() {
-				totalTimeout := time.Duration(0)
-				BeforeAll(func() {
-					vmFailCleanupWaitTime := getVmFailCleanupWaitTime()
-					// since this test checks vmWaitingCleanupLook routine, we nned to adjust the total timeout with the wait-time argument.
-					// we also add some extra timeout apart form wait-time to be sure that we catch the vm mac release.
-					totalTimeout = timeout + vmFailCleanupWaitTime
-				})
 				It("[test_id:2633]should allow to assign to the VM the same MAC addresses, with name as requested before and do not return an error", func() {
 					vm1 := CreateVmObject(TestNamespace, false,
 						[]kubevirtv1.Interface{newInterface("br1", "02:00:ff:ff:ff:ff")},
@@ -350,7 +349,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						}
 						return err
 
-					}, totalTimeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+					}, restoreFailedWebhookChangesTimeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
 				})
 				It("should allow to assign to the VM the same MAC addresses, different name as requested before and do not return an error", func() {
 					vm1 := CreateVmObject(TestNamespace, false,
@@ -372,7 +371,138 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						}
 						return err
 
-					}, totalTimeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+					}, restoreFailedWebhookChangesTimeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+				})
+			})
+			Context("and a vm is created with no interfaces", func() {
+				maxNumOfIfaces := 16
+				var vm *kubevirtv1.VirtualMachine
+				interfaces := []kubevirtv1.Interface{}
+				networks := []kubevirtv1.Network{}
+				BeforeEach(func() {
+					for numOfIfaces := 0; numOfIfaces < maxNumOfIfaces; numOfIfaces++ {
+						interfaces = append(interfaces, newInterface("br"+strconv.Itoa(numOfIfaces), fmt.Sprintf("02:00:00:00:00:%02X", numOfIfaces)))
+						networks = append(networks, newNetwork("br"+strconv.Itoa(numOfIfaces)))
+					}
+					vm = CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{}, []kubevirtv1.Network{})
+					By("Creating the vm with 0 interfaces")
+					err := testClient.VirtClient.Create(context.TODO(), vm)
+					Expect(err).ToNot(HaveOccurred(), "Should succeed creating the vm")
+				})
+				Context(fmt.Sprintf("and then sequentially updated from %d interfaces back to 0 with minimal time between requests", maxNumOfIfaces), func() {
+					BeforeEach(func() {
+						for numOfIfaces := maxNumOfIfaces; numOfIfaces >= 0; numOfIfaces-- {
+							By(fmt.Sprintf("updating the number of interfaces to %d", numOfIfaces))
+
+							err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+
+								err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)
+								Expect(err).ToNot(HaveOccurred())
+
+								vm.Spec.Template.Spec.Domain.Devices.Interfaces = interfaces[0:numOfIfaces]
+								vm.Spec.Template.Spec.Networks = networks[0:numOfIfaces]
+
+								return testClient.VirtClient.Update(context.TODO(), vm)
+							})
+
+							Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Should succeed updating the vm to %d interfaces", numOfIfaces))
+						}
+
+						By("Checking that the vm has 0 interface after the changes are made")
+						err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)
+						Expect(err).ToNot(HaveOccurred(), "Should succeed getting vm")
+						Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces).To(BeEmpty(), "Should Have no interfaces")
+					})
+					It("should be able to allocate the freed macs to new vms", func() {
+						By(fmt.Sprintf("Creating %d vms, each with a MAC interface used in the base vm", maxNumOfIfaces))
+						for ifaceIdx := 0; ifaceIdx < maxNumOfIfaces; ifaceIdx++ {
+							Eventually(func() error {
+								newVm := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{interfaces[ifaceIdx]}, []kubevirtv1.Network{networks[ifaceIdx]})
+								err := testClient.VirtClient.Create(context.TODO(), newVm)
+
+								if err != nil {
+									Expect(err).Should(MatchError("admission webhook \"mutatevirtualmachines.kubemacpool.io\" denied the request: Failed to create virtual machine allocation error: Failed to allocate mac to the vm object: failed to allocate requested mac address"), "Should only fail to allocate vm because the mac is already used")
+								}
+								return err
+
+							}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+						}
+					})
+				})
+				Context(fmt.Sprintf("and then sequentially updated from 0 to %d interfaces with minimal time between requests", maxNumOfIfaces), func() {
+					BeforeEach(func() {
+						for numOfIfaces := 1; numOfIfaces <= maxNumOfIfaces; numOfIfaces++ {
+							By(fmt.Sprintf("updating the number of interfaces to %d", numOfIfaces))
+							err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+
+								err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)
+								Expect(err).ToNot(HaveOccurred())
+
+								vm.Spec.Template.Spec.Domain.Devices.Interfaces = interfaces[0:numOfIfaces]
+								vm.Spec.Template.Spec.Networks = networks[0:numOfIfaces]
+
+								return testClient.VirtClient.Update(context.TODO(), vm)
+							})
+
+							Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Should succeed updating the vm to %d interfaces", numOfIfaces))
+						}
+
+						By(fmt.Sprintf("Checking that the vm has %d interface after the changes are made", maxNumOfIfaces))
+						err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)
+						Expect(err).ToNot(HaveOccurred(), "Should succeed getting vm")
+						Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces).To(HaveLen(maxNumOfIfaces), fmt.Sprintf("Should have %d interfaces", maxNumOfIfaces))
+					})
+					It("should not be able to allocate the occupied macs to new vms", func() {
+						By(fmt.Sprintf("Creating %d vms, each with a MAC interface used in the base vm", maxNumOfIfaces))
+						for ifaceIdx := 0; ifaceIdx < maxNumOfIfaces; ifaceIdx++ {
+							newVm := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{interfaces[ifaceIdx]}, []kubevirtv1.Network{networks[ifaceIdx]})
+							err := testClient.VirtClient.Create(context.TODO(), newVm)
+							Expect(err).To(HaveOccurred(), "Should fail creating the vm")
+						}
+					})
+				})
+			})
+			Context("and a VM's NIC is added just before an old update request with no NICs is made", func() {
+				var vm *kubevirtv1.VirtualMachine
+				var reusedMacAddress string
+				BeforeEach(func() {
+					By("Creating a vm with no NICs")
+					vm = CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{}, []kubevirtv1.Network{})
+					err := testClient.VirtClient.Create(context.TODO(), vm)
+					Expect(err).ToNot(HaveOccurred(), "Should succeed creating the vm")
+
+					By("Saving the vm instance to reuse it after resourceVersion has changed to cause a conflict error")
+					copyVm := vm.DeepCopy()
+
+					By("Adding a new NIC to the vm")
+					err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						err := testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)
+						Expect(err).ToNot(HaveOccurred())
+
+						vm.Spec.Template.Spec.Domain.Devices.Interfaces = []kubevirtv1.Interface{newInterface("br1", "")}
+						vm.Spec.Template.Spec.Networks = []kubevirtv1.Network{newNetwork("br1")}
+
+						return testClient.VirtClient.Update(context.TODO(), vm)
+					})
+
+					Expect(err).ToNot(HaveOccurred(), "Should succeed updating the vm")
+					reusedMacAddress = vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress
+					_, err = net.ParseMAC(reusedMacAddress)
+					Expect(err).ToNot(HaveOccurred(), "Should succeed parsing the vm mac")
+
+					By("Issuing the outdated vm request")
+					err = testClient.VirtClient.Update(context.TODO(), copyVm)
+					Expect(apierrors.IsConflict(err)).Should(Equal(true), "Should fail update on conflict")
+				})
+				It("should successfully reject the old request on conflict and should reject a new vm trying to allocate using this mac", func() {
+					By(fmt.Sprintf("waiting for cache to be restored after %v", restoreFailedWebhookChangesTimeout))
+					time.Sleep(restoreFailedWebhookChangesTimeout)
+
+					By("trying to reuse the mac in a new vm")
+					newVM := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br1", reusedMacAddress)},
+						[]kubevirtv1.Network{newNetwork("br1")})
+					err := testClient.VirtClient.Create(context.TODO(), newVM)
+					Expect(err).Should(MatchError("admission webhook \"mutatevirtualmachines.kubemacpool.io\" denied the request: Failed to create virtual machine allocation error: Failed to allocate mac to the vm object: failed to allocate requested mac address"), "Should fail to allocate vm because the mac is already used")
 				})
 			})
 			Context("and a VM's NIC is removed and a new VM is created with the same MAC", func() {
@@ -386,7 +516,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(net.ParseMAC(vm.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress)).ToNot(BeEmpty(), "Should successfully parse vm's second mac address")
 
 					reusedMacAddress := vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress
-					By("checking that a new VM cannot be created when the range is full")
+					By("checking that a new VM cannot be created when the mac is already occupied")
 					newVM := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br1", reusedMacAddress)},
 						[]kubevirtv1.Network{newNetwork("br1")})
 					err = testClient.VirtClient.Create(context.TODO(), newVM)
@@ -699,7 +829,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						Eventually(func() bool {
 							err = testClient.VirtClient.Get(context.TODO(), client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vm)
 							Expect(err).ToNot(HaveOccurred())
-							if vm.ObjectMeta.DeletionTimestamp.IsZero() {
+							if !pool_manager.IsVirtualMachineDeletionInProgress(vm) {
 								if len(vm.ObjectMeta.Finalizers) == 1 {
 									if strings.Compare(vm.ObjectMeta.Finalizers[0], pool_manager.RuntimeObjectFinalizerName) == 0 {
 										return true

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -78,7 +78,9 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			}, timeout, pollingInterval).Should(Equal(0), "failed to remove all vm objects")
 		})
-
+		AfterEach(func() {
+			Expect(checkKubemacpoolCrash()).To(Succeed(), "Kubemacpool should not crash during test")
+		})
 		Context("When Running with default opt-mode configuration", func() {
 			BeforeEach(func() {
 				By("Getting the current VM Opt-mode")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a major change in kubemacpool macpool structure and handling, to use timestamp and better handle the KMP webhook side effects. 

- **ci, Add now to macPool params**
Replaces time.Now() to use a configurable func var stored in macPool
interface.
Currently there is not difference in behavior due to this change, but in
the future this will allow us to run unit tests with mocked time.

- **webhook, Add kubemacpoolTransactionTimeStamp annotation**
Introduce a new annotation to the virtualMachine instance:
kubemacpool.io/transaction-timestamp. This annotation will hold the timestamp
when the webhook runs.
The annotation format will be RFC3339Nano which allows smaller granolarity and
also accepts the old RFC3339 format if parsing old timestamps.
This annotation will be added by the KMP webhook, and updated everytime
a change is made to the vm spec.

- **pool, Change macPoolMap to hold transaction timestamp**
In order to be able to properly update the macPoolMap, we expand it to
hold new parameters: the instance full name (vm/pod), macInstanceKey
name (interface name in vm case and network name in pod case), and
current transaction timestamp. The latter will replace the current
AllocationStatus field.
The transactionTimestamp is saved in *time.Time type, where nil means
that the entry is not penging change, similar to former allocated status.
This commit only inserts the new methods related to the new macEntry,
along with method's unit-tests in a new mac-pool-map module.

- **pool, Change vm Allocate functions to support new macMap**
This commit implements the new macEntry methods to functions allocating
the macs in vm webhook context and the macs setting the macs as ready on
the vm controller reconcile function.
In the webhook context, new macs are added to macPoolMap, and both
new/updated/deleted macs' entries get the latest transactionTimestamp.
These updated macs are later handled in the controller reconcile if
their transactionTimestamp is already due for update, compared to the
vm's new kubemacpoolTransactionTimestamp annotation.
Also expanded and added to relevant unit tests,
Added a function checkMacPoolMapEntries that assists with checking macs
are properly allocated in the macPoolMap.

- **pool, Change pod Allocate functions to support new macMap**
This commit implements the new macEntry methods to functions allocating
the macs in pod webhook context and the macs setting the macs as ready
on the pod controller reconcile function.
In the webhook context, new macs are added to macPoolMap, and both new
macs' entries get the latest transactionTimestamp. These updated macs
are later handled in the controller reconcile.
Since pods are immutable and cannot be updated, we do not need to set
any transaction timestamp annotation on the pod like we do on the vm.
In case the pod's name is not yet updated when KMP webhook is invoked,
then we give it a temp name to prevent duplications

- **configMap, switch from using configMap to using the macPoolMap**
As a result of expanding the macPoolMap, we can now discard using the
configMap and instead have vmWaitingCleanupLook goroutine go over the
macPoolMap to find stale entries.
For backwards compatibility, we still keep the configMap, and also keep
the legacy configMap cleaning mechanism, so that if during upgrade the
configMap is not empty, the mac's there will be incorporated to the
macPoolMap to prevent collisions.
Added e2e tests to check upgrade cases.
Also moved some of initVirtualMachineMap logic to a function
forEachVmInterfaceInClusterRunFunction in order to reuse it.

- **ci, Add e2e tests to check sequential vm updates**
Added e2e tests that run many updates on the same vm to make sure the
last change is the one that persists on the macPoolMap.
Also increase e2e timeout to 1h.

- **logs, reduce RequestId size**
To make logs a bit shorter, reduce unique webhook/controller RequestId
to be up to 100000.
**Special notes for your reviewer**:

**Release note**:

```release-note
Change macPoolMap to use transaction timestamps
```
