### PR TITLE
pod, Fix pod patching that causes the pod to error on creation

### DIFF
--- a/doc/pod-creation-example.md
+++ b/doc/pod-creation-example.md
@@ -76,6 +76,3 @@ k8s.v1.cni.cncf.io/networks: [{"name":"ovs-conf","namespace":"default","mac":"02
 
 MAC address can be also set manually by the user using the MAC field in the annotation.
 If the MAC is already in used the system will reject it even if the MAC address is outside of the range.
-
-**Note:** Due to a current open [issue](https://github.com/k8snetworkplumbingwg/kubemacpool/issues/273), creating the
-pod will result with a error.

--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -38,7 +38,7 @@ func (p *PoolManager) AllocatePodMac(pod *corev1.Pod) error {
 		"macmap", p.macPoolMap,
 		"currentMac", p.currentMac.String())
 
-	networkValue, ok := pod.Annotations[networksAnnotation]
+	networkValue, ok := pod.Annotations[NetworksAnnotation]
 	if !ok {
 		return nil
 	}
@@ -95,7 +95,7 @@ func (p *PoolManager) AllocatePodMac(pod *corev1.Pod) error {
 	if err != nil {
 		return err
 	}
-	pod.Annotations[networksAnnotation] = string(networkListJson)
+	pod.Annotations[NetworksAnnotation] = string(networkListJson)
 
 	return nil
 }
@@ -205,7 +205,7 @@ func (p *PoolManager) initPodMap() error {
 			continue
 		}
 
-		networkValue, ok := pod.Annotations[networksAnnotation]
+		networkValue, ok := pod.Annotations[NetworksAnnotation]
 		if !ok {
 			continue
 		}

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -38,7 +38,7 @@ const (
 	RangeStartEnv                  = "RANGE_START"
 	RangeEndEnv                    = "RANGE_END"
 	RuntimeObjectFinalizerName     = "k8s.v1.cni.cncf.io/kubeMacPool"
-	networksAnnotation             = "k8s.v1.cni.cncf.io/networks"
+	NetworksAnnotation             = "k8s.v1.cni.cncf.io/networks"
 	networksStatusAnnotation       = "k8s.v1.cni.cncf.io/networks-status"
 	TransactionTimestampAnnotation = "kubemacpool.io/transaction-timestamp"
 	mutatingWebhookConfigName      = "kubemacpool-mutator"

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -49,9 +49,9 @@ const (
 )
 
 var _ = Describe("Pool", func() {
-	beforeAllocationAnnotation := map[string]string{networksAnnotation: `[{ "name": "ovs-conf"}]`}
+	beforeAllocationAnnotation := map[string]string{NetworksAnnotation: `[{ "name": "ovs-conf"}]`}
 	afterAllocationAnnotation := func(namespace, macAddress string) map[string]string {
-		return map[string]string{networksAnnotation: `[{"name":"ovs-conf","namespace":"` + namespace + `","mac":"` + macAddress + `","cni-args":null}]`}
+		return map[string]string{NetworksAnnotation: `[{"name":"ovs-conf","namespace":"` + namespace + `","mac":"` + macAddress + `","cni-args":null}]`}
 	}
 	managedPodWithMacAllocated := v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podpod", Namespace: managedNamespaceName, Annotations: afterAllocationAnnotation(managedNamespaceName, "02:00:00:00:00:00")}}
 	unmanagedPodWithMacAllocated := v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "unmanagedPod", Namespace: notManagedNamespaceName, Annotations: afterAllocationAnnotation(notManagedNamespaceName, "02:00:00:00:00:FF")}}
@@ -760,7 +760,7 @@ var _ = Describe("Pool", func() {
 			Expect(poolManager.macPoolMap).To(HaveLen(2))
 			Expect(checkMacPoolMapEntries(poolManager.macPoolMap, nil, []string{preAllocatedPodMac, expectedAllocatedMac}, []string{})).To(Succeed(), "Failed to check macs in macMap")
 
-			Expect(newPod.Annotations[networksAnnotation]).To(Equal(afterAllocationAnnotation(managedNamespaceName, "02:00:00:00:00:01")[networksAnnotation]))
+			Expect(newPod.Annotations[NetworksAnnotation]).To(Equal(afterAllocationAnnotation(managedNamespaceName, "02:00:00:00:00:01")[NetworksAnnotation]))
 			expectedMacEntry := macEntry{
 				transactionTimestamp: nil,
 				instanceName:         podNamespaced(&newPod),
@@ -782,7 +782,7 @@ var _ = Describe("Pool", func() {
 
 			err := poolManager.AllocatePodMac(&newPod)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(newPod.Annotations[networksAnnotation]).To(Equal(afterAllocationAnnotation(managedNamespaceName, "02:00:00:00:00:00")[networksAnnotation]))
+			Expect(newPod.Annotations[NetworksAnnotation]).To(Equal(afterAllocationAnnotation(managedNamespaceName, "02:00:00:00:00:00")[NetworksAnnotation]))
 		})
 	})
 
@@ -798,14 +798,14 @@ var _ = Describe("Pool", func() {
 			table.DescribeTable("should allocate mac-address correspond to the one specified in the networks annotation",
 				func(networkRequestAnnotation string) {
 					pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "testPod", Namespace: "default"}}
-					pod.Annotations = map[string]string{networksAnnotation: fmt.Sprintf("%s", networkRequestAnnotation)}
+					pod.Annotations = map[string]string{NetworksAnnotation: fmt.Sprintf("%s", networkRequestAnnotation)}
 
 					By("Request specific mac-address by adding the address to the networks pod annotation")
 					err := poolManager.AllocatePodMac(&pod)
 					Expect(err).ToNot(HaveOccurred(), "should allocate mac address and ip address correspond to networks annotation")
 
 					By("Convert obtained networks annotation JSON to multus.NetworkSelectionElement array")
-					obtainedNetworksAnnotationJson := pod.Annotations[networksAnnotation]
+					obtainedNetworksAnnotationJson := pod.Annotations[NetworksAnnotation]
 					obtainedNetworksAnnotation := []multus.NetworkSelectionElement{}
 					err = json.Unmarshal([]byte(obtainedNetworksAnnotationJson), &obtainedNetworksAnnotation)
 					Expect(err).ToNot(HaveOccurred(), "should convert obtained annotation as json to multus.NetworkSelectionElement")
@@ -832,7 +832,7 @@ var _ = Describe("Pool", func() {
 			It("should fail to allocate requested mac-address, with ip-address request as string instead of string array", func() {
 				pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "testPod", Namespace: "default"}}
 				pod.Annotations = map[string]string{
-					networksAnnotation: `[{"name":"ovs-conf","namespace":"default","ips":"10.10.0.1","mac":"02:00:00:00:00:00"}]`}
+					NetworksAnnotation: `[{"name":"ovs-conf","namespace":"default","ips":"10.10.0.1","mac":"02:00:00:00:00:00"}]`}
 
 				By("Request specific mac-address by adding the address to the networks pod annotation")
 				err := poolManager.AllocatePodMac(&pod)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, a pod cannot be created when managed with Kubemacpool (Issue #273), due to
an error in the patching procees of the webhook.
Fixed by patching the annotation needed.

**Special notes for your reviewer**:

**Release note**:


```release-note
NONE
```
