### PR TITLE
consider opt-mode when inserting vms/pod from the cluster to macPoolMap

### DIFF
--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -80,12 +80,12 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 	logger := log.WithName("Reconcile").WithValues("podName", request.Name, "podNamespace", request.Namespace)
 
 	logger.V(1).Info("got a pod event in the controller")
-	instanceOptedIn, err := r.poolManager.IsPodInstanceOptedIn(request.Namespace)
+	instanceManaged, err := r.poolManager.IsPodManaged(request.Namespace)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to check opt-in selection for pod")
+		return reconcile.Result{}, errors.Wrap(err, "Failed to check if pod is managed")
 	}
-	if !instanceOptedIn {
-		logger.V(1).Info("pod is opted-out from kubemacpool")
+	if !instanceManaged {
+		logger.V(1).Info("pod is not managed by kubemacpool")
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/virtualmachine/virtualmachine_controller.go
+++ b/pkg/controller/virtualmachine/virtualmachine_controller.go
@@ -101,7 +101,7 @@ func (r *ReconcilePolicy) Reconcile(request reconcile.Request) (reconcile.Result
 	}
 
 	if !pool_manager.IsVirtualMachineDeletionInProgress(instance) {
-		vmShouldBeManaged, err := r.poolManager.IsNamespaceManaged(instance.GetNamespace())
+		vmShouldBeManaged, err := r.poolManager.IsVirtualMachineManaged(instance.GetNamespace())
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "Failed to check if vm is managed")
 		}

--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -258,9 +258,9 @@ func (p *PoolManager) revertAllocationOnPod(podFullName string, allocations map[
 	}
 }
 
-// Checks if the namespace of a pod instance is opted in for kubemacpool
-func (p *PoolManager) IsPodInstanceOptedIn(namespaceName string) (bool, error) {
-	return p.isNamespaceSelectorCompatibleWithOptModeLabel(namespaceName, "kubemacpool-mutator", "mutatepods.kubemacpool.io", OptInMode)
+// IsPodManaged checks if the namespace of a pod instance is opted in for kubemacpool
+func (p *PoolManager) IsPodManaged(namespaceName string) (bool, error) {
+	return p.IsNamespaceManaged(namespaceName, podsWebhookName)
 }
 
 func podNamespaced(pod *corev1.Pod) string {

--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -193,6 +193,14 @@ func (p *PoolManager) initPodMap() error {
 
 	for _, pod := range pods.Items {
 		log.V(1).Info("InitMaps for pod", "podName", pod.Name, "podNamespace", pod.Namespace)
+		instanceManaged, err := p.IsPodManaged(pod.GetNamespace())
+		if err != nil {
+			continue
+		}
+		if !instanceManaged {
+			continue
+		}
+
 		if pod.Annotations == nil {
 			continue
 		}

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -487,30 +487,17 @@ func (p *PoolManager) getvmInstance(vmFullName string) (*kubevirt.VirtualMachine
 	return vm, nil
 }
 
-// Checks if the namespace of the vm instance is managed by kubemacpool in terms of opt-mode
-func (p *PoolManager) IsNamespaceManaged(namespaceName string) (bool, error) {
-	mutatingWebhookConfigName := "kubemacpool-mutator"
-	webhookName := "mutatevirtualmachines.kubemacpool.io"
-	vmOptMode, err := p.getOptMode(mutatingWebhookConfigName, webhookName)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to get opt-Mode")
-	}
-
-	isNamespaceManaged, err := p.isNamespaceSelectorCompatibleWithOptModeLabel(namespaceName, mutatingWebhookConfigName, webhookName, vmOptMode)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to check if namespace is managed according to opt-mode")
-	}
-
-	log.V(1).Info("IsNamespaceManaged", "vmOptMode", vmOptMode, "namespaceName", namespaceName, "is namespace in the game", isNamespaceManaged)
-	return isNamespaceManaged, nil
-}
-
 func validateInterfaceSupported(iface kubevirt.Interface, networks map[string]kubevirt.Network) bool {
 	if iface.Masquerade == nil && iface.Slirp == nil && networks[iface.Name].Multus == nil {
 		log.Info("mac address can be set only for interface of type masquerade and slirp on the pod network")
 		return false
 	}
 	return true
+}
+
+// IsVirtualMachineManaged checks if the namespace of a VirtualMachine instance is managed by kubemacpool
+func (p *PoolManager) IsVirtualMachineManaged(namespaceName string) (bool, error) {
+	return p.IsNamespaceManaged(namespaceName, virtualMachnesWebhookName)
 }
 
 func VmNamespaced(machine *kubevirt.VirtualMachine) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
usually Kubemacpool handles only managed pods/vms according to the opt-mode. 
However there are corner cases (for example when initializing the macPoolMap for pods/vms) where we don't consider if the pods/vms are managed.
This PR addresses this issue to only handle managed instances.

- **opt-mode, generalize pods and vms to use the same opt-mode check**
Currently pod and vm handlers use slightly different functions to
determine if the pod/vm namespace is handled by kubemacpool according to
the opt-mode.
Aligned them to use the same function

- **cluster vm sweep, fix to only use managed vms**
When kubemacpool performs cluster sweeps for virtual machines (during
macPoolMap initalization for example), it needs to only consider the vms
from managed namespaces.
Moved vm macPoolMap initialization to a function initMacMapFromCluster
Fixed forEachVmInterfaceInClusterRunFunction function to only go over
managed vms.
Added e2e tests since unit test currently don't support vm instances

- **pod-init, init macPoolMap only insert managed pods**
currently during MacPoolMap initialization of pods, all pods are taken
into account,
Fixed to only use pods on managed namespaces.
Introduced unit tests with opt-out modes for pods and vms in order to
correctly initialize the macPoolMap.
Added pod macPoolMap init unit test

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
