### PR TITLE
webhook, Include metadata changes to kubemacpool TS update scenario

### DIFF
--- a/pkg/webhook/pod/pod.go
+++ b/pkg/webhook/pod/pod.go
@@ -75,12 +75,12 @@ func (a *podAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 
 // create jsonpatches only to changed caused by the kubemacpool webhook changes
 func patchPodChanges(originalPod, currentPod *corev1.Pod) admission.Response {
-	var kubemapcoolJsonPatches []jsonpatch.Operation
+	kubemapcoolJsonPatches := []jsonpatch.Operation{}
 
 	currentNetworkAnnotation := currentPod.GetAnnotations()[pool_manager.NetworksAnnotation]
 	originalPodNetworkAnnotation := originalPod.GetAnnotations()[pool_manager.NetworksAnnotation]
 	if originalPodNetworkAnnotation != currentNetworkAnnotation {
-		annotationPatch := jsonpatch.NewPatch("add", "/metadata/annotations", map[string]string{pool_manager.NetworksAnnotation: currentNetworkAnnotation})
+		annotationPatch := jsonpatch.NewPatch("replace", "/metadata/annotations", currentPod.GetAnnotations())
 		kubemapcoolJsonPatches = append(kubemapcoolJsonPatches, annotationPatch)
 	}
 

--- a/pkg/webhook/virtualmachine/virtualmachine.go
+++ b/pkg/webhook/virtualmachine/virtualmachine.go
@@ -98,13 +98,13 @@ func (a *virtualMachineAnnotator) Handle(ctx context.Context, req admission.Requ
 // create jsonpatches only to changed caused by the kubemacpool webhook changes
 func patchVMChanges(originalVirtualMachine, currentVirtualMachine *kubevirt.VirtualMachine, parentLogger logr.Logger) admission.Response {
 	logger := parentLogger.WithName("patchVMChanges")
-	var kubemapcoolJsonPatches []jsonpatch.Operation
+	kubemapcoolJsonPatches := []jsonpatch.Operation{}
 
 	if !pool_manager.IsVirtualMachineDeletionInProgress(currentVirtualMachine) {
 		originalTransactionTSString := originalVirtualMachine.GetAnnotations()[pool_manager.TransactionTimestampAnnotation]
 		currentTransactionTSString := currentVirtualMachine.GetAnnotations()[pool_manager.TransactionTimestampAnnotation]
 		if originalTransactionTSString != currentTransactionTSString {
-			transactionTimestampAnnotationPatch := jsonpatch.NewPatch("add", "/metadata/annotations", map[string]string{pool_manager.TransactionTimestampAnnotation: currentTransactionTSString})
+			transactionTimestampAnnotationPatch := jsonpatch.NewPatch("replace", "/metadata/annotations", currentVirtualMachine.GetAnnotations())
 			kubemapcoolJsonPatches = append(kubemapcoolJsonPatches, transactionTimestampAnnotationPatch)
 		}
 

--- a/pkg/webhook/virtualmachine/virtualmachine.go
+++ b/pkg/webhook/virtualmachine/virtualmachine.go
@@ -192,7 +192,7 @@ func (a *virtualMachineAnnotator) mutateUpdateVirtualMachinesFn(virtualMachine *
 		return err
 	}
 
-	if isVirtualMachineSpecChanged(previousVirtualMachine, virtualMachine) {
+	if isVirtualMachineChanged(previousVirtualMachine, virtualMachine) {
 		transactionTimestamp := pool_manager.CreateTransactionTimestamp()
 		pool_manager.SetTransactionTimestampAnnotationToVm(virtualMachine, transactionTimestamp)
 
@@ -204,11 +204,41 @@ func (a *virtualMachineAnnotator) mutateUpdateVirtualMachinesFn(virtualMachine *
 	return nil
 }
 
-// isVirtualMachineSpecChanged checks if the vm spec changed in this webhook update request.
-// we want to update the timestamp on every change, but not on metadata changes, as they change all the time,
-// which will cause a unneeded Timestamp update.
+func isVirtualMachineChanged(previousVirtualMachine, virtualMachine *kubevirt.VirtualMachine) bool {
+	if isVirtualMachineSpecChanged(previousVirtualMachine, virtualMachine) {
+		return true
+	}
+	if isVirtualMachineMetadataChanged(previousVirtualMachine, virtualMachine) {
+		return true
+	}
+	return false
+}
+
+// isVirtualMachineChanged checks if the vm spec changed in this webhook update request.
 func isVirtualMachineSpecChanged(previousVirtualMachine, virtualMachine *kubevirt.VirtualMachine) bool {
 	return !reflect.DeepEqual(previousVirtualMachine.Spec, virtualMachine.Spec)
+}
+
+// isVirtualMachineMetadataChanged checks if non-automatically generated metadata fields changed in this webhook
+// update request.
+func isVirtualMachineMetadataChanged(previousVirtualMachine, virtualMachine *kubevirt.VirtualMachine) bool {
+	if !reflect.DeepEqual(previousVirtualMachine.GetLabels(), virtualMachine.GetLabels()) {
+		return true
+	}
+	currentAnnotations := getAnnotationsWithoutTransactionTimestamp(virtualMachine)
+	previousAnnotations := getAnnotationsWithoutTransactionTimestamp(previousVirtualMachine)
+	if !reflect.DeepEqual(previousAnnotations, currentAnnotations) {
+		return true
+	}
+	return false
+}
+
+// getAnnotationsWithoutTransactionTimestamp get the vm's annotation, but excludes the changes made
+// on this webhook such as TransactionTimestampAnnotation.
+func getAnnotationsWithoutTransactionTimestamp(virtualMachine *kubevirt.VirtualMachine) map[string]string {
+	annotations := virtualMachine.GetAnnotations()
+	delete(annotations, pool_manager.TransactionTimestampAnnotation)
+	return annotations
 }
 
 // isVirtualMachineInterfacesChanged checks if the vm interfaces changed in this webhook update request.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds more scenarios where the kuemacpool TS annotation is updated, 
but also making sue we do not cause an update loop.
Also, it fixes a problem with the way annotations where patched in the webhook handlers.

- **webhook, vm, Include metadata changes to kubemacpool TS update scenario**
Currently, only vm spec changes in the cause the kubemacpool
TransactionTimestampAnnotation to be updated. In order to optimize
updating of the mac to be faster, we also include metadata changes like
Annotation and namespace updates.
We do not include the TransactionTimestampAnnotation itself when
checking for changes, to avoid an internal update loop.

- **webhook, Fix Patching of annotations**
Currently update of the annotation patch causes other existing
annotations to disappear, initiating a update loop with kubevirt trying
to add his annotation.
To avoid this, we move to patch the entire annotation field, similar to
how it is done in kubevirt[[1]](https://github.com/kubevirt/kubevirt/blob/master/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go#L68).

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
