### PR TITLE
apiextensions, bump apiextensions.k8s.io to v1

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -140,7 +140,7 @@ func (k *KubeMacPoolManager) Run(rangeStart, rangeEnd net.HardwareAddr) error {
 }
 
 func checkForKubevirt(kubeClient *kubernetes.Clientset) bool {
-	result := kubeClient.ExtensionsV1beta1().RESTClient().Get().RequestURI("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/virtualmachines.kubevirt.io").Do(context.TODO())
+	result := kubeClient.ExtensionsV1beta1().RESTClient().Get().RequestURI("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/virtualmachines.kubevirt.io").Do(context.TODO())
 	if result.Error() == nil {
 		return true
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps apiextensions.k8s.io to v1

**Special notes for your reviewer**:

**Release note**:

```release-note
bump apiextensions.k8s.io to v1
```
