### PR TITLE
Reduce wait-time to 5 min

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -63,7 +63,7 @@ spec:
         - /manager
         args:
           - "--v=production"
-          - "--wait-time=600"
+          - "--wait-time=300"
         image: quay.io/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -331,7 +331,7 @@ spec:
       containers:
       - args:
         - --v=production
-        - --wait-time=600
+        - --wait-time=300
         command:
         - /manager
         env:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -332,7 +332,7 @@ spec:
       containers:
       - args:
         - --v=debug
-        - --wait-time=600
+        - --wait-time=300
         command:
         - /manager
         env:

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -427,7 +427,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 								}
 								return err
 
-							}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+							}, restoreFailedWebhookChangesTimeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
 						}
 					})
 				})
@@ -547,7 +547,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						}
 						return err
 
-					}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+					}, restoreFailedWebhookChangesTimeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
 
 					Expect(len(newVM.Spec.Template.Spec.Domain.Devices.Interfaces) == 1).To(Equal(true), "new vm should be allocated with the now released mac address")
 				})
@@ -593,7 +593,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							}
 							return err
 
-						}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
+						}, restoreFailedWebhookChangesTimeout, pollingInterval).ShouldNot(HaveOccurred(), "failed to apply the new vm object")
 
 						Expect(len(newVM.Spec.Template.Spec.Domain.Devices.Interfaces) == 1).To(Equal(true), "new vm should be allocated with the now released mac address")
 					})
@@ -636,7 +636,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 								[]kubevirtv1.Network{newNetwork("br1")})
 							Eventually(func() error {
 								return testClient.VirtClient.Create(context.TODO(), vm1)
-							}, timeout, pollingInterval).ShouldNot(HaveOccurred(), "should succeed creating a vm with the now released mac address after stale mac restored")
+							}, restoreFailedWebhookChangesTimeout, pollingInterval).ShouldNot(HaveOccurred(), "should succeed creating a vm with the now released mac address after stale mac restored")
 						})
 					})
 				})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reduces kubemacpool's wait-time to 5 minutes, and adjusts tests accordingly to not be affected by webhook rejects.

- **reduce wait-time to 5 minutes**
currently if a webhook change is rejected then after wait-time
the kubemacpool goroutine will refresh the mac-entry after wait-time
according to what is set in the vm instance.
Reducing this value to 5 minutes, to allow quicker response time.

- **ci, extend test eventually timeout**
in tests that check webhook changes, we extend the timeout to ensure that
if the last webhook change was rejected, the mac entry will eventually get
refreshed with the persisted value.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
