### PR TITLE
cluster-up, increase kubevirt timeout

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -63,6 +63,6 @@ until ./cluster/kubectl.sh -n kubevirt get kv kubevirt; do
     sleep 1
 done
 
-./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 180s || (echo "KubeVirt not ready in time" && exit 1)
+./cluster/kubectl.sh wait -n kubevirt kv kubevirt --for condition=Available --timeout 360s || (echo "KubeVirt not ready in time" && exit 1)
 
 echo "Done"


### PR DESCRIPTION
**What this PR does / why we need it**:
sometimes automation tests fail on kubevirt not being ready.
increasing timeout to 360s, and by that aligning to [HCO](https://github.com/kubevirt/hyperconverged-cluster-operator/blob/c8c49f989ab8ff5415dae8c4f1063fc08ff76963/tests/travis-tests/test.sh#L9).

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
