### PR TITLE
bump cluster-up to follow kuvevirt v0.40

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -25,7 +25,7 @@ source ./cluster/cluster.sh
 CNAO_VERSION=v0.42.1
 
 #use kubevirt latest z stream release
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.37)
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.40)
 cluster::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the cluster-up script to deploy latest kubevirt v0.40 versions.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
