### PR TITLE
cluster-up, Bump CNAO version

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -22,7 +22,7 @@ function getLatestPatchVersion {
 }
 
 source ./cluster/cluster.sh
-CNAO_VERSION=v0.42.1
+CNAO_VERSION=v0.53.0
 
 #use kubevirt latest z stream release
 KUBEVIRT_VERSION=$(getLatestPatchVersion v0.40)


### PR DESCRIPTION
As part of cluster-up, CNAO is deployed.
Bump the version of it, since some deprecated api versions
were fixed since the latest bump.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
