### PR TITLE
WIP Add component label template

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: kubemacpool-system
 namePrefix: kubemacpool-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app.kubernetes.io/component: "{{ .ComponentName }}"
 
 # Each entry in this list must resolve to an existing
 # resource definition in YAML.  These are the resource


### PR DESCRIPTION
In order to allow CNAO to add component label
when bumping KMP version, add label template
to the KMP kustomization manifest.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
