### PR TITLE
[release-v0.20] Remove kmp limits

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -25,7 +25,7 @@ source ./cluster/kubevirtci.sh
 CNAO_VERSION=v0.42.1
 #use kubevirt latest z stream release
 
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.33)
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.34)
 kubevirtci::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -91,9 +91,6 @@ spec:
           - name: CERT_ROTATE_INTERVAL
             value: "4380h0m0s" # Half Year
         resources:
-          limits:
-            cpu: 300m
-            memory: 600Mi
           requests:
             cpu: 100m
             memory: 300Mi

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -310,9 +310,6 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 300m
-            memory: 600Mi
           requests:
             cpu: 100m
             memory: 300Mi

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -311,9 +311,6 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 300m
-            memory: 600Mi
           requests:
             cpu: 100m
             memory: 300Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the kubemacpool deployment memory limit, since we do not want to use limit memory on control-plane
components such as kubemacpool.
This commit also solves an issue found in BZ#1958108[0]

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1958108

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
