### PR TITLE
finalizer, remove kubemacpool finalizer

### DIFF
--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -375,7 +375,7 @@ var _ = Describe("Pool", func() {
 				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{"02:00:00:00:00:01"}, []string{"02:00:00:00:00:00"})).To(Succeed(), "Failed to check macs in macMap")
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:01"))
 
-				err = poolManager.ReleaseAllVirtualMachineMacs(&newVM, logger)
+				err = poolManager.ReleaseAllVirtualMachineMacs(VmNamespaced(&newVM), logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(poolManager.macPoolMap).To(HaveLen(1), "Should keep the pod mac in the macMap")
 				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{}, []string{"02:00:00:00:00:00"})).To(Succeed(), "Failed to check macs in macMap")
@@ -394,7 +394,7 @@ var _ = Describe("Pool", func() {
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:01"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:02"))
 
-				err = poolManager.ReleaseAllVirtualMachineMacs(newVM, logf.Log.WithName("VirtualMachine Controller"))
+				err = poolManager.ReleaseAllVirtualMachineMacs(VmNamespaced(newVM), logf.Log.WithName("VirtualMachine Controller"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(poolManager.macPoolMap).To(HaveLen(1), "Should keep the pod mac in the macMap")
 				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{}, []string{"02:00:00:00:00:00"})).To(Succeed(), "Failed to check macs in macMap")


### PR DESCRIPTION
**What this PR does / why we need it**:
we no longer need to keep the vm instance until kubemacpool has freed
the vm macs from the pool since we now store the vm-name in the macpool
mac entry.
Hence, we should remove the finalizer from the vm creation.
For backwards compatibility, we still remove the finalizer if it exists
when deleting the vm.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
