### PR TITLE
Relationship labels, Adapt to new kaw for secrets labeling

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -117,6 +117,7 @@ func runCertManager() {
 		CAOverlapInterval:   caOverlapInterval,
 		CertRotateInterval:  certRotateInterval,
 		CertOverlapInterval: certOverlapInterval,
+		ExtraLabels:         names.IncludeRelationshipLabels(nil),
 	}
 
 	certManager, err := certificate.NewManager(mgr.GetClient(), certOptions)

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -159,6 +159,22 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: COMPONENT
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['app.kubernetes.io/component']
+          - name: PART_OF
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['app.kubernetes.io/part-of']
+          - name: VERSION
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['app.kubernetes.io/version']
+          - name: MANAGED_BY
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['app.kubernetes.io/managed-by']
           - name: CA_ROTATE_INTERVAL
             value: "8760h0m0s" # One Year
           - name: CA_OVERLAP_INTERVAL

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -262,6 +262,22 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: COMPONENT
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: PART_OF
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/part-of']
+        - name: VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
+        - name: MANAGED_BY
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/managed-by']
         - name: CA_ROTATE_INTERVAL
           value: 8760h0m0s
         - name: CA_OVERLAP_INTERVAL

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -263,6 +263,22 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: COMPONENT
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: PART_OF
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/part-of']
+        - name: VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
+        - name: MANAGED_BY
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/managed-by']
         - name: CA_ROTATE_INTERVAL
           value: 8760h0m0s
         - name: CA_OVERLAP_INTERVAL

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.5
 	github.com/pkg/errors v0.9.1
-	github.com/qinqon/kube-admission-webhook v0.15.0
+	github.com/qinqon/kube-admission-webhook v0.16.0
 	gomodules.xyz/jsonpatch/v2 v2.1.0
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -708,8 +708,8 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
-github.com/qinqon/kube-admission-webhook v0.15.0 h1:uST8Yhl+dVWx1gkb/iam3harXpZK3NFkERpzj2HMyBM=
-github.com/qinqon/kube-admission-webhook v0.15.0/go.mod h1:eYJw+S+JSprEMLzGNmE0GFIlSrBQw0lAVES/ZjgM2FI=
+github.com/qinqon/kube-admission-webhook v0.16.0 h1:Ew1nn8Tmip4iB+xebFjNvgVyVp88g4Aj5IQY1d/CxQg=
+github.com/qinqon/kube-admission-webhook v0.16.0/go.mod h1:eYJw+S+JSprEMLzGNmE0GFIlSrBQw0lAVES/ZjgM2FI=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -1,5 +1,9 @@
 package names
 
+import (
+	"os"
+)
+
 const MANAGER_DEPLOYMENT = "kubemacpool-mac-controller-manager"
 
 const CERT_MANAGER_DEPLOYMENT = "kubemacpool-cert-manager"
@@ -17,3 +21,31 @@ const OPENSHIFT_RUNLABEL = "openshift.io/run-level"
 const WAITING_VMS_CONFIGMAP = "kubemacpool-vm-configmap"
 
 const WAIT_TIME_ARG = "wait-time"
+
+// Relationship labels
+const COMPONENT_LABEL_KEY = "app.kubernetes.io/component"
+const PART_OF_LABEL_KEY = "app.kubernetes.io/part-of"
+const VERSION_LABEL_KEY = "app.kubernetes.io/version"
+const MANAGED_BY_LABEL_KEY = "app.kubernetes.io/managed-by"
+
+func IncludeRelationshipLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	mapLabelKeys := map[string]string{
+		"COMPONENT":  COMPONENT_LABEL_KEY,
+		"PART_OF":    PART_OF_LABEL_KEY,
+		"VERSION":    VERSION_LABEL_KEY,
+		"MANAGED_BY": MANAGED_BY_LABEL_KEY,
+	}
+
+	for key, label := range mapLabelKeys {
+		envVar := os.Getenv(key)
+		if envVar != "" {
+			labels[label] = envVar
+		}
+	}
+
+	return labels
+}

--- a/pkg/names/names_suite_test.go
+++ b/pkg/names/names_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Names Suite")
+}

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -1,0 +1,90 @@
+package names
+
+import (
+	"os"
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IncludeRelationshipLabels", func() {
+	Context("When env vars don't exist", func() {
+		BeforeEach(func() {
+			os.Unsetenv("COMPONENT")
+			os.Unsetenv("PART_OF")
+			os.Unsetenv("VERSION")
+			os.Unsetenv("MANAGED_BY")
+		})
+
+		It("Should return empty map when input was nil map", func() {
+			labels := IncludeRelationshipLabels(nil)
+			Expect(labels).To(HaveLen(0))
+		})
+
+		It("Should return the same map when input was not nil", func() {
+			labelsBase := map[string]string{"foo": "bar"}
+			labels := IncludeRelationshipLabels(map[string]string{"foo": "bar"})
+			Expect(reflect.DeepEqual(labelsBase, labels)).To(Equal(true))
+		})
+	})
+
+	Context("When all the env vars are not empty", func() {
+		const expectedComponentLabel = "component_unit_tests"
+		const expectedPartOfLabel = "part_of_unit_tests"
+		const expectedVersionLabel = "version_of_unit_tests"
+		const expectedManagedByLabel = "managed_by_unit_tests"
+
+		BeforeEach(func() {
+			os.Setenv("COMPONENT", expectedComponentLabel)
+			os.Setenv("PART_OF", expectedPartOfLabel)
+			os.Setenv("VERSION", expectedVersionLabel)
+			os.Setenv("MANAGED_BY", expectedManagedByLabel)
+		})
+
+		It("Should return labels with all the values", func() {
+			labels := IncludeRelationshipLabels(map[string]string{"foo": "bar"})
+
+			Expect(labels["foo"]).To(Equal("bar"))
+			Expect(labels[COMPONENT_LABEL_KEY]).To(Equal(expectedComponentLabel))
+			Expect(labels[PART_OF_LABEL_KEY]).To(Equal(expectedPartOfLabel))
+			Expect(labels[VERSION_LABEL_KEY]).To(Equal(expectedVersionLabel))
+			Expect(labels[MANAGED_BY_LABEL_KEY]).To(Equal(expectedManagedByLabel))
+		})
+
+		It("Should update labels with the right values", func() {
+			labels := IncludeRelationshipLabels(map[string]string{"foo": "bar", VERSION_LABEL_KEY: "old_version"})
+
+			Expect(labels["foo"]).To(Equal("bar"))
+			Expect(labels[COMPONENT_LABEL_KEY]).To(Equal(expectedComponentLabel))
+			Expect(labels[PART_OF_LABEL_KEY]).To(Equal(expectedPartOfLabel))
+			Expect(labels[VERSION_LABEL_KEY]).To(Equal(expectedVersionLabel))
+			Expect(labels[MANAGED_BY_LABEL_KEY]).To(Equal(expectedManagedByLabel))
+		})
+	})
+
+	Context("When some of the env vars are not empty", func() {
+		const expectedComponentLabel = "component_unit_tests"
+		const expectedPartOfLabel = "part_of_unit_tests"
+
+		BeforeEach(func() {
+			os.Setenv("COMPONENT", expectedComponentLabel)
+			os.Setenv("PART_OF", expectedPartOfLabel)
+			os.Setenv("VERSION", "")
+			os.Unsetenv("MANAGED_BY")
+		})
+
+		It("Should return labels with the right values", func() {
+			labels := IncludeRelationshipLabels(map[string]string{"foo": "bar"})
+			Expect(labels["foo"]).To(Equal("bar"))
+			Expect(labels[COMPONENT_LABEL_KEY]).To(Equal(expectedComponentLabel))
+			Expect(labels[PART_OF_LABEL_KEY]).To(Equal(expectedPartOfLabel))
+
+			_, found := labels[VERSION_LABEL_KEY]
+			Expect(found).To(Equal(false))
+
+			_, found = labels[MANAGED_BY_LABEL_KEY]
+			Expect(found).To(Equal(false))
+		})
+	})
+})

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/manager.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/manager.go
@@ -47,7 +47,7 @@ type Manager struct {
 	// caCertDuration Options.CARotateInterval
 	caCertDuration time.Duration
 
-	// caCertDuration Options.CAOverlapInterval
+	// caOverlapDuration Options.CAOverlapInterval
 	caOverlapDuration time.Duration
 
 	// serviceCertDuration Options.CertRotateInterval
@@ -59,6 +59,9 @@ type Manager struct {
 	// log initialized log that containes the webhook configuration name and
 	// namespace so it's easy to debug.
 	log logr.Logger
+
+	// extraLabels Options.ExtraLabels
+	extraLabels map[string]string
 }
 
 // NewManager with create a certManager that generated a secret per service
@@ -97,6 +100,7 @@ func NewManager(
 		caOverlapDuration:      options.CAOverlapInterval,
 		serviceCertDuration:    options.CertRotateInterval,
 		serviceOverlapDuration: options.CertOverlapInterval,
+		extraLabels:            options.ExtraLabels,
 		log: logf.Log.WithName("certificate/Manager").
 			WithValues("webhookType", options.WebhookType, "webhookName", options.WebhookName),
 	}

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/options.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/options.go
@@ -40,6 +40,9 @@ type Options struct {
 	// CertOverlapInterval the duration of service certificates at bundle if
 	// not set it will default to CertRotateInterval
 	CertOverlapInterval time.Duration
+
+	// ExtraLabels extra labels that will be added to created secrets
+	ExtraLabels map[string]string
 }
 
 func (o *Options) validate() error {

--- a/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/secret.go
+++ b/vendor/github.com/qinqon/kube-admission-webhook/pkg/certificate/secret.go
@@ -110,6 +110,7 @@ func (m *Manager) applySecret(secretKey types.NamespacedName, secretType corev1.
 						Name:        secretKey.Name,
 						Namespace:   secretKey.Namespace,
 						Annotations: map[string]string{},
+						Labels:      m.extraLabels,
 					},
 					Type: secretType,
 				}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,7 +161,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/qinqon/kube-admission-webhook v0.15.0
+# github.com/qinqon/kube-admission-webhook v0.16.0
 ## explicit
 github.com/qinqon/kube-admission-webhook/pkg/certificate
 github.com/qinqon/kube-admission-webhook/pkg/certificate/triple


### PR DESCRIPTION
Bump Kaw to v0.16.0 in order to support relationship labels.

In order to have relationship (app.kubernetes.io/*)
on all deployed resources,
this commit adapts kubemacpool to use bumped kaw
which allows providing ExtraLabels field.
This way the secrets that are created by kaw
will be labeled with relationship labels.

```release-note
None
```
