### PR TITLE
[release-v0.26] control-plane, Add Priority class

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -110,6 +110,7 @@ spec:
           - name: tls-key-pair
             readOnly: true
             mountPath: /tmp/k8s-webhook-server/serving-certs/
+      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 5
       volumes:
         - name: tls-key-pair
@@ -167,6 +168,7 @@ spec:
             value: "4380h0m0s" # Half Year
           - name: CERT_OVERLAP_INTERVAL
             value: "24h0m0s" # One day
+      priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 5
 ---
 apiVersion: v1

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -273,6 +273,7 @@ spec:
         image: quay.io/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
 ---
@@ -365,6 +366,7 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair
           readOnly: true
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
       volumes:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -274,6 +274,7 @@ spec:
         image: registry:5000/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
 ---
@@ -366,6 +367,7 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair
           readOnly: true
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
       volumes:


### PR DESCRIPTION
Manual Cherry-pick of https://github.com/k8snetworkplumbingwg/kubemacpool/pull/315

Add system-cluster-critical to kubemacpool pods.
Since kmp pods aren't bound to a specific node,
yet those are important pods, assign system-cluster-critical
pc to them.
This will make the control plane less sensitive to preemption
than user workloads.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
