### PR TITLE
Update resources requests

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -91,7 +91,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 300Mi
+            memory: 100Mi
         ports:
         - containerPort: 8000
           name: webhook-server

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -149,6 +149,10 @@ spec:
         image: quay.io/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager
+        resources:
+          requests:
+            cpu: "5m"
+            memory: "20Mi"
         env:
           - name: RUN_CERT_MANAGER
             value: ""

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -289,6 +289,10 @@ spec:
         image: quay.io/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager
+        resources:
+          requests:
+            cpu: 5m
+            memory: 20Mi
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
@@ -377,7 +381,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 300Mi
+            memory: 100Mi
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -290,6 +290,10 @@ spec:
         image: registry:5000/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager
+        resources:
+          requests:
+            cpu: 5m
+            memory: 20Mi
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
@@ -378,7 +382,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 300Mi
+            memory: 100Mi
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair


### PR DESCRIPTION
Update `mac-controller-manager` minimum memory request according empiric measures,
in order to reduce idle usage and minimum required memory
for scheduling kubemacpool.

Update `cert-manager` cpu / memory requests according empiric use measures.

See https://bugzilla.redhat.com/show_bug.cgi?id=1935218
    
Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
