### PR TITLE
cert-manager, Update minimum CPU request

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -151,8 +151,8 @@ spec:
         name: manager
         resources:
           requests:
-            cpu: "5m"
-            memory: "20Mi"
+            cpu: "30m"
+            memory: "30Mi"
         env:
           - name: RUN_CERT_MANAGER
             value: ""

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -291,8 +291,8 @@ spec:
         name: manager
         resources:
           requests:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 30m
+            memory: 30Mi
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -292,8 +292,8 @@ spec:
         name: manager
         resources:
           requests:
-            cpu: 5m
-            memory: 20Mi
+            cpu: 30m
+            memory: 30Mi
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5


### PR DESCRIPTION
In order to allow the cert-manager to give faster SLA,
as the webhook (and handler) depends on it,
increase minimum CPU and memory requests.

See https://github.com/nmstate/kubernetes-nmstate/pull/781#discussion_r665255528

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
