### PR TITLE
metrics, Add kubevirt_kmp_duplicate_macs gauge

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -96,6 +96,9 @@ spec:
         - containerPort: 8000
           name: webhook-server
           protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         readinessProbe:
           httpGet:
             httpHeaders:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -368,6 +368,9 @@ spec:
         - containerPort: 8000
           name: webhook-server
           protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         readinessProbe:
           httpGet:
             httpHeaders:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -369,6 +369,9 @@ spec:
         - containerPort: 8000
           name: webhook-server
           protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         readinessProbe:
           httpGet:
             httpHeaders:

--- a/pkg/gauges/gauges.go
+++ b/pkg/gauges/gauges.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gauges
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// DuplicateMacGauge counts number of discovered duplicate mac addresses
+	DuplicateMacGauge = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "kubevirt_kmp_duplicate_macs",
+			Help: "Kubemacpool duplicate macs counter",
+		})
+)
+
+func init() {
+	metrics.Registry.MustRegister(DuplicateMacGauge)
+}

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -212,7 +212,8 @@ func (p *PoolManager) allocateRequestedVirtualMachineInterfaceMac(vmFullName str
 	if macEntry, exist := p.macPoolMap[requestedMac]; exist {
 		if !macAlreadyBelongsToVmAndInterface(vmFullName, iface.Name, macEntry) {
 			err := fmt.Errorf("failed to allocate requested mac address")
-			logger.Error(err, "mac address already allocated")
+			logger.Error(err, fmt.Sprintf("mac address %s already allocated to %s, %s, conflict with: %s, %s",
+				iface.MacAddress, macEntry.instanceName, macEntry.macInstanceKey, vmFullName, iface.Name))
 
 			return err
 		}

--- a/tests/kubectl/kubectl.go
+++ b/tests/kubectl/kubectl.go
@@ -1,0 +1,17 @@
+package kubectl
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+func Kubectl(command ...string) (string, string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("./cluster/kubectl.sh", command...)
+	cmd.Dir = ".."
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+

--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -11,12 +11,18 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	pool_manager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
+	"github.com/k8snetworkplumbingwg/kubemacpool/tests/kubectl"
+
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 )
 
@@ -270,6 +276,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					})
 				})
 			})
+
 			Context("and when restarting kubeMacPool and trying to create a VM with the same manually configured MAC as an older VM", func() {
 				It("[test_id:2179]should return an error because the MAC address is taken by the older VM", func() {
 					vm1 := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br1", "02:00:ff:ff:ff:ff")}, []kubevirtv1.Network{newNetwork("br1")})
@@ -879,6 +886,66 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					})
 				})
 			})
+
+			Context("and creating two VMs with same mac, one on unmanaged (opted out) namespace", func() {
+				var conflictingVM *kubevirtv1.VirtualMachine
+				BeforeEach(func() {
+					macAddress := "02:00:ff:ff:ff:ff"
+
+					By(fmt.Sprintf("Adding a vm with a Mac Address %s in the managed namespace", macAddress))
+					vm1 := CreateVmObject(TestNamespace, false, []kubevirtv1.Interface{newInterface("br1", macAddress)}, []kubevirtv1.Network{newNetwork("br1")})
+					err := testClient.VirtClient.Create(context.TODO(), vm1)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(net.ParseMAC(vm1.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress)).ToNot(BeEmpty(), "Should successfully parse mac address")
+
+					err = addLabelsToNamespace(OtherTestNamespace, map[string]string{vmNamespaceOptInLabel: "ignore"})
+					Expect(err).ToNot(HaveOccurred(), "should be able to add the namespace labels")
+
+					By(fmt.Sprintf("Adding a vm with the same Mac Address %s on the unmanaged namespace", macAddress))
+					conflictingVM = CreateVmObject(OtherTestNamespace, false, []kubevirtv1.Interface{newInterface("br1", macAddress)}, []kubevirtv1.Network{newNetwork("br1")})
+					err = testClient.VirtClient.Create(context.TODO(), conflictingVM)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(net.ParseMAC(conflictingVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress)).ToNot(BeEmpty(), "Should successfully parse mac address")
+				})
+
+				It("should detect duplicate macs gauge after restarting kubemacpool, and then mitigating that", func() {
+					By("moving the unmanaged namespace to be managed")
+					err := cleanNamespaceLabels(OtherTestNamespace)
+					Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
+
+					By("restarting Kubemacpool to check if there are duplicats macs in the managed namespaces")
+					err = initKubemacpoolParams()
+					Expect(err).ToNot(HaveOccurred())
+
+					metrics, _, err := getMetrics()
+					Expect(err).ToNot(HaveOccurred())
+
+					expectedMetric := "kubevirt_kmp_duplicate_macs"
+					expectedValue := "1"
+					metric := findMetric(metrics, expectedMetric)
+					Expect(metric).ToNot(BeEmpty(), fmt.Sprintf("metric %s does not appear in endpoint scrape", expectedMetric))
+					Expect(metric).To(Equal(fmt.Sprintf("%s %s", expectedMetric, expectedValue)),
+						fmt.Sprintf("metric %s does not have the expected value %s", expectedMetric, expectedValue))
+
+					By("mitigating the conflict by deleting the vm with the conflicting Mac Address")
+					err = testClient.VirtClient.Delete(context.TODO(), conflictingVM)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("restarting Kubemacpool")
+					err = initKubemacpoolParams()
+					Expect(err).ToNot(HaveOccurred())
+
+					By("verifying the conflict has been resolved")
+					metrics, _, err = getMetrics()
+					Expect(err).ToNot(HaveOccurred())
+
+					expectedValue = "0"
+					metric = findMetric(metrics, expectedMetric)
+					Expect(metric).ToNot(BeEmpty(), fmt.Sprintf("metric %s does not appear in endpoint scrape", expectedMetric))
+					Expect(metric).To(Equal(fmt.Sprintf("%s %s", expectedMetric, expectedValue)),
+						fmt.Sprintf("metric %s does not have the expected value %s", expectedMetric, expectedValue))
+				})
+			})
 		})
 	})
 })
@@ -940,4 +1007,41 @@ func deleteVMI(vm *kubevirtv1.VirtualMachine) {
 		Expect(err).ToNot(HaveOccurred(), "should success getting vm if is still there")
 		return false
 	}, timeout, pollingInterval).Should(BeTrue(), "should eventually fail getting vm with IsNotFound after vm deletion")
+}
+
+func getMetrics() (string, string, error) {
+	podList, err := getManagerPods()
+	if err != nil {
+		return "", "", err
+	}
+
+	stdout, stderr, err := kubectl.Kubectl("exec", "-n", managerNamespace, podList.Items[0].Name, "--",
+		"curl", "-L", "-k", "-s", "http://127.0.0.1:8080/metrics")
+
+	return stdout, stderr, err
+}
+
+func getManagerPods() (*v1.PodList, error) {
+	deployment, err := testClient.KubeClient.AppsV1().Deployments(managerNamespace).Get(context.TODO(), names.MANAGER_DEPLOYMENT, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	labelSelector := labels.Set(deployment.Spec.Selector.MatchLabels).String()
+	podList, err := testClient.KubeClient.CoreV1().Pods(managerNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+
+	return podList, err
+}
+
+func findMetric(metrics string, expectedMetric string) string {
+	for _, line := range strings.Split(metrics, "\n") {
+		if strings.HasPrefix(line, expectedMetric+" ") {
+			return line
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
kubevirt_kmp_duplicate_macs counts how many duplicate macs
were found upon kubemacpool init.

Additional changes:
Improve log in case of Mac Address duplicates in order to ease mitigation.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
