### PR TITLE
cluster-up, Bump CNAO and kubevirt to latest

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -22,10 +22,10 @@ function getLatestPatchVersion {
 }
 
 source ./cluster/cluster.sh
-CNAO_VERSION=v0.53.0
+CNAO_VERSION=v0.58.0
 
 #use kubevirt latest z stream release
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.40)
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.44)
 cluster::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Aligning to CNAO and kubevirt stable branches

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
