### PR TITLE
dryRun, Adapt VM Mac Address allocation to support dryRun

### DIFF
--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -108,7 +108,7 @@ func (r *ReconcilePolicy) Reconcile(ctx context.Context, request reconcile.Reque
 		return reconcile.Result{}, nil
 	}
 
-	err = r.poolManager.AllocatePodMac(instance)
+	err = r.poolManager.AllocatePodMac(instance, true)
 	if err != nil {
 		logger.Error(err, "failed to allocate mac for pod")
 	}

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -355,7 +355,7 @@ var _ = Describe("Pool", func() {
 			newVM.Name = "newVM"
 
 			transactionTimestamp := updateTransactionTimestamp(0)
-			err := poolManager.AllocateVirtualMachineMac(&newVM, &transactionTimestamp, logger)
+			err := poolManager.AllocateVirtualMachineMac(&newVM, &transactionTimestamp, true, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(poolManager.macPoolMap).To(BeEmpty(), "Should not allocate mac for unsupported bridge binding")
 		})
@@ -368,7 +368,7 @@ var _ = Describe("Pool", func() {
 				newVM := masqueradeVM
 				newVM.Name = "newVM"
 				transactionTimestamp := updateTransactionTimestamp(0)
-				err := poolManager.AllocateVirtualMachineMac(&newVM, &transactionTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(&newVM, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(poolManager.macPoolMap).To(HaveLen(2))
@@ -385,7 +385,7 @@ var _ = Describe("Pool", func() {
 				newVM.Name = "newVM"
 
 				transactionTimestamp := updateTransactionTimestamp(0)
-				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(poolManager.macPoolMap).To(HaveLen(3))
@@ -412,14 +412,14 @@ var _ = Describe("Pool", func() {
 
 				addDiskIO(newVM, "native-new")
 				transactionTimestamp := updateTransactionTimestamp(0)
-				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Disks[0].IO).To(Equal(kubevirt.DriverIO("native-new")), "disk.io configuration must be preserved after mac allocation")
 
 				updateVm := multipleInterfacesVM.DeepCopy()
 				updateVm.Name = "newVM"
 				addDiskIO(updateVm, "native-update")
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, &transactionTimestamp, logger)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Disks[0].IO).To(Equal(kubevirt.DriverIO("native-update")), "disk.io configuration must be preserved after mac allocation update")
 			})
@@ -428,7 +428,7 @@ var _ = Describe("Pool", func() {
 				newVM := multipleInterfacesVM.DeepCopy()
 				newVM.Name = "newVM"
 				transactionTimestamp := updateTransactionTimestamp(0)
-				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
@@ -438,7 +438,7 @@ var _ = Describe("Pool", func() {
 				updateVm := multipleInterfacesVM.DeepCopy()
 				updateVm.Name = "newVM"
 				newTransactionTimestamp := updateTransactionTimestamp(1)
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, &newTransactionTimestamp, logger)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, &newTransactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
@@ -450,7 +450,7 @@ var _ = Describe("Pool", func() {
 				newVM.Name = "newVM"
 
 				transactionTimestamp := updateTransactionTimestamp(0)
-				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
@@ -462,7 +462,7 @@ var _ = Describe("Pool", func() {
 				By("changing one of the macs")
 				updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress = "01:00:00:00:00:02"
 				newTransactionTimestamp := updateTransactionTimestamp(1)
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, &newTransactionTimestamp, logger)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updateVm, &newTransactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updateVm.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("01:00:00:00:00:02"))
@@ -474,7 +474,7 @@ var _ = Describe("Pool", func() {
 				newVM.Name = "newVM"
 
 				transactionTimestamp := updateTransactionTimestamp(0)
-				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
@@ -486,7 +486,7 @@ var _ = Describe("Pool", func() {
 				updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces = append(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces, anotherMultusBridgeInterface)
 				updatedVM.Spec.Template.Spec.Networks = append(updatedVM.Spec.Template.Spec.Networks, anotherMultusNetwork)
 				NewTransactionTimestamp := updateTransactionTimestamp(1)
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, &NewTransactionTimestamp, logger)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, &NewTransactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
@@ -501,7 +501,7 @@ var _ = Describe("Pool", func() {
 				newVM.Spec.Template.Spec.Networks = append(newVM.Spec.Template.Spec.Networks, anotherMultusNetwork)
 
 				transactionTimestamp := updateTransactionTimestamp(0)
-				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
@@ -513,7 +513,7 @@ var _ = Describe("Pool", func() {
 				updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress = newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress
 				updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress = newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress
 				NewTransactionTimestamp := updateTransactionTimestamp(1)
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, &NewTransactionTimestamp, logger)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, &NewTransactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
@@ -525,7 +525,7 @@ var _ = Describe("Pool", func() {
 				newVM.Name = "newVM"
 
 				transactionTimestamp := updateTransactionTimestamp(0)
-				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
@@ -538,7 +538,7 @@ var _ = Describe("Pool", func() {
 				updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces = append(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces, anotherMultusBridgeInterface)
 				updatedVM.Spec.Template.Spec.Networks = append(updatedVM.Spec.Template.Spec.Networks, anotherMultusNetwork)
 				NewTransactionTimestamp := updateTransactionTimestamp(1)
-				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, &NewTransactionTimestamp, logger)
+				err = poolManager.UpdateMacAddressesForVirtualMachine(newVM, updatedVM, &NewTransactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:02"))
@@ -568,7 +568,7 @@ var _ = Describe("Pool", func() {
 				vm = masqueradeVM.DeepCopy()
 				vm.Name = "testVm"
 
-				err := poolManager.AllocateVirtualMachineMac(vm, &vmCreationTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(vm, &vmCreationTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				allocatedMac = vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress
 				macEntry, exist := poolManager.macPoolMap[allocatedMac]
@@ -592,7 +592,7 @@ var _ = Describe("Pool", func() {
 					vmFirstUpdate.Spec.Template.Spec.Domain.Devices.Interfaces = vmFirstUpdate.Spec.Template.Spec.Domain.Devices.Interfaces[:0]
 
 					By("updating the vm, removing the interface")
-					err := poolManager.UpdateMacAddressesForVirtualMachine(vm, vmFirstUpdate, &vmFirstUpdateTimestamp, logger)
+					err := poolManager.UpdateMacAddressesForVirtualMachine(vm, vmFirstUpdate, &vmFirstUpdateTimestamp, true, logger)
 					Expect(err).ToNot(HaveOccurred(), "should update vm with no error")
 					macEntry, exist := poolManager.macPoolMap[allocatedMac]
 					Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap after first update")
@@ -615,7 +615,7 @@ var _ = Describe("Pool", func() {
 						By("updating the vm, re-adding the interface")
 						vmSecondUpdate = vm.DeepCopy()
 						By("updating the vm, removing the interface")
-						err := poolManager.UpdateMacAddressesForVirtualMachine(vmFirstUpdate, vmSecondUpdate, &vmSecondUpdateTimestamp, logger)
+						err := poolManager.UpdateMacAddressesForVirtualMachine(vmFirstUpdate, vmSecondUpdate, &vmSecondUpdateTimestamp, true, logger)
 						Expect(err).ToNot(HaveOccurred(), "should update vm with no error")
 						macEntry, exist := poolManager.macPoolMap[allocatedMac]
 						Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap after first update")
@@ -684,7 +684,7 @@ var _ = Describe("Pool", func() {
 
 				By("Create a VM")
 				transactionTimestamp = updateTransactionTimestamp(0)
-				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, logger)
+				err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred(), "should successfully  allocated macs")
 
 				allocatedMac = newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -706,6 +706,26 @@ var _ = Describe("Pool", func() {
 				Expect(poolManager.macPoolMap).To(HaveLen(1), "macPoolMap should hold the mac address waiting for approval")
 				Expect(poolManager.macPoolMap[allocatedMac]).To(Equal(expectedMacEntry), "macPoolMap's mac's entry should be as expected")
 			})
+			Context("and creating a dry run VM", func() {
+				var macPoolMapCopy macMap
+				BeforeEach(func() {
+					macPoolMapCopy = macMap{}
+					for key, value := range poolManager.macPoolMap {
+						macPoolMapCopy[key] = value
+					}
+
+					newVMDryRun := masqueradeVM.DeepCopy()
+					newVMDryRun.Name = "newVMDryRun"
+
+					By("Create a dry run VM")
+					transactionTimestamp = updateTransactionTimestamp(0)
+					err := poolManager.AllocateVirtualMachineMac(newVM, &transactionTimestamp, false, logger)
+					Expect(err).ToNot(HaveOccurred(), "should successfully create dry run VM")
+				})
+				It("should not storage the dry run mac in the mac pool", func() {
+					Expect(poolManager.macPoolMap).To(Equal(macPoolMapCopy), "macPoolMap should left unchanged")
+				})
+			})
 			Context("and VM is marked as ready by controller reconcile", func() {
 				var lastPersistedtransactionTimstamp *time.Time
 				BeforeEach(func() {

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -778,7 +778,7 @@ var _ = Describe("Pool", func() {
 			newPod.Name = "newPod"
 			newPod.Annotations = beforeAllocationAnnotation
 
-			err := poolManager.AllocatePodMac(&newPod)
+			err := poolManager.AllocatePodMac(&newPod, true)
 			Expect(err).ToNot(HaveOccurred())
 			preAllocatedPodMac := "02:00:00:00:00:00"
 			expectedAllocatedMac := "02:00:00:00:00:01"
@@ -805,7 +805,7 @@ var _ = Describe("Pool", func() {
 			newPod := managedPodWithMacAllocated
 			newPod.Name = "newPod"
 
-			err := poolManager.AllocatePodMac(&newPod)
+			err := poolManager.AllocatePodMac(&newPod, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newPod.Annotations[NetworksAnnotation]).To(Equal(afterAllocationAnnotation(managedNamespaceName, "02:00:00:00:00:00")[NetworksAnnotation]))
 		})
@@ -826,7 +826,7 @@ var _ = Describe("Pool", func() {
 					pod.Annotations = map[string]string{NetworksAnnotation: fmt.Sprintf("%s", networkRequestAnnotation)}
 
 					By("Request specific mac-address by adding the address to the networks pod annotation")
-					err := poolManager.AllocatePodMac(&pod)
+					err := poolManager.AllocatePodMac(&pod, true)
 					Expect(err).ToNot(HaveOccurred(), "should allocate mac address and ip address correspond to networks annotation")
 
 					By("Convert obtained networks annotation JSON to multus.NetworkSelectionElement array")
@@ -860,7 +860,7 @@ var _ = Describe("Pool", func() {
 					NetworksAnnotation: `[{"name":"ovs-conf","namespace":"default","ips":"10.10.0.1","mac":"02:00:00:00:00:00"}]`}
 
 				By("Request specific mac-address by adding the address to the networks pod annotation")
-				err := poolManager.AllocatePodMac(&pod)
+				err := poolManager.AllocatePodMac(&pod, true)
 				Expect(err).To(HaveOccurred(), "should fail to allocate mac address due to bad annotation format")
 			})
 		})

--- a/pkg/webhook/pod/pod.go
+++ b/pkg/webhook/pod/pod.go
@@ -60,14 +60,13 @@ func (a *podAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 		pod.Annotations = map[string]string{}
 	}
 
-	if req.DryRun == nil || *req.DryRun == false {
-		transactionTimestamp := pool_manager.CreateTransactionTimestamp()
-		log.V(1).Info("got a create pod event", "podName", pod.Name, "podNamespace", pod.Namespace, "transactionTimestamp", transactionTimestamp)
+	isNotDryRun := (req.DryRun == nil || *req.DryRun == false)
+	transactionTimestamp := pool_manager.CreateTransactionTimestamp()
+	log.V(1).Info("got a create pod event", "podName", pod.Name, "podNamespace", pod.Namespace, "transactionTimestamp", transactionTimestamp)
 
-		err = a.poolManager.AllocatePodMac(pod)
-		if err != nil {
-			return admission.Errored(http.StatusInternalServerError, err)
-		}
+	err = a.poolManager.AllocatePodMac(pod, isNotDryRun)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
 	// admission.PatchResponse generates a Response containing patches.


### PR DESCRIPTION
In case of "server" ("All" when used by controller runtime) dryRun, 
we do want to return an updated server response, 
which allocates Mac Address, but without doing side effects.
Fix the flow to support it.
    
Note that the Mac pool head is changed, so calling twice dryRun
won't yield the same Mac Address in the response.
It is needed because in case there are multiple Mac Addresses in
the same request, we should not give the same Mac even on dryRun,
hence the mac pool head should be updated.

```release-note
None
```
