### PR TITLE
kubectl, Support different cluster root directory

### DIFF
--- a/tests/kubectl/kubectl.go
+++ b/tests/kubectl/kubectl.go
@@ -2,16 +2,24 @@ package kubectl
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 )
 
 func Kubectl(command ...string) (string, string, error) {
 	var stdout, stderr bytes.Buffer
 	cmd := exec.Command("./cluster/kubectl.sh", command...)
-	cmd.Dir = ".."
+	cmd.Dir = getClusterRootDirectory()
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
 	err := cmd.Run()
 	return stdout.String(), stderr.String(), err
 }
 
+func getClusterRootDirectory() string {
+	dir, found := os.LookupEnv("CLUSTER_ROOT_DIRECTORY")
+	if !found {
+		return ".."
+	}
+	return dir
+}


### PR DESCRIPTION
In order to support CNAO testing of kubemacpool e2e,
add an env var, that allows using different cluster root directory,
because when CNAO deploys the cluster, it is created on CNAO directory
but the kmp tests are running from a temp kmp folder that
doesn't have the cluster metadata.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
