### PR TITLE
Update provider k8s-1.21

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -6,7 +6,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.19'
+    export KUBEVIRT_PROVIDER='k8s-1.21'
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.19'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.21'}
 export KUBEVIRTCI_TAG='2108251059-2c2862b'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates provider k8s-1.21, and also updates some cluster folder infra.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
