### PR TITLE
[release-v0.21] kubevirt, bump kubevirt version to follow v0.36

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -25,7 +25,7 @@ source ./cluster/kubevirtci.sh
 CNAO_VERSION=v0.42.1
 #use kubevirt latest z stream release
 
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.34)
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.36)
 kubevirtci::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
release-v0.21 branch should follow kubevirt v0.36 branch


**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
