### PR TITLE
[release-v0.26] kubevirt, bump kubevirt version to follow v0.41

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -25,7 +25,7 @@ source ./cluster/cluster.sh
 CNAO_VERSION=v0.42.1
 
 #use kubevirt latest z stream release
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.37)
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.41)
 cluster::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This branch should follow kubevirt v0.41 branch

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
