### PR TITLE
Revert "metrics: Use https instead of http (#346)"

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -23,7 +23,6 @@ function getLatestPatchVersion {
 
 source ./cluster/cluster.sh
 CNAO_VERSION=v0.58.0
-export KUBEVIRT_DEPLOY_PROMETHEUS=true
 
 #use kubevirt latest z stream release
 KUBEVIRT_VERSION=$(getLatestPatchVersion v0.44)

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -96,6 +96,9 @@ spec:
         - containerPort: 8000
           name: webhook-server
           protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         readinessProbe:
           httpGet:
             httpHeaders:
@@ -110,22 +113,6 @@ spec:
           - name: tls-key-pair
             readOnly: true
             mountPath: /tmp/k8s-webhook-server/serving-certs/
-      - args:
-        - --logtostderr
-        - --secure-listen-address=:8443
-        - --upstream=http://127.0.0.1:8080
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: metrics
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 5
       volumes:

--- a/config/default/rbac/rbac_role.yaml
+++ b/config/default/rbac/rbac_role.yaml
@@ -97,15 +97,3 @@ rules:
     - namespaces
   verbs:
     - get
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -183,18 +183,6 @@ rules:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -380,6 +368,9 @@ spec:
         - containerPort: 8000
           name: webhook-server
           protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         readinessProbe:
           httpGet:
             httpHeaders:
@@ -398,22 +389,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair
           readOnly: true
-      - args:
-        - --logtostderr
-        - --secure-listen-address=:8443
-        - --upstream=http://127.0.0.1:8080
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: metrics
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -184,18 +184,6 @@ rules:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -381,6 +369,9 @@ spec:
         - containerPort: 8000
           name: webhook-server
           protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         readinessProbe:
           httpGet:
             httpHeaders:
@@ -399,22 +390,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair
           readOnly: true
-      - args:
-        - --logtostderr
-        - --secure-listen-address=:8443
-        - --upstream=http://127.0.0.1:8080
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: metrics
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5


### PR DESCRIPTION
This reverts commit 653c5e6bd3cf824b2aa2e5a92cd438ff2b21066b.

**What this PR does / why we need it**:
Reverting until we have a D/S solution for the rbac-proxy image

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
