### PR TITLE
metrics: Use https instead of http

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -23,6 +23,7 @@ function getLatestPatchVersion {
 
 source ./cluster/cluster.sh
 CNAO_VERSION=v0.58.0
+export KUBEVIRT_DEPLOY_PROMETHEUS=true
 
 #use kubevirt latest z stream release
 KUBEVIRT_VERSION=$(getLatestPatchVersion v0.44)

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -96,9 +96,6 @@ spec:
         - containerPort: 8000
           name: webhook-server
           protocol: TCP
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
         readinessProbe:
           httpGet:
             httpHeaders:
@@ -113,6 +110,22 @@ spec:
           - name: tls-key-pair
             readOnly: true
             mountPath: /tmp/k8s-webhook-server/serving-certs/
+      - args:
+        - --logtostderr
+        - --secure-listen-address=:8443
+        - --upstream=http://127.0.0.1:8080
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 5
       volumes:

--- a/config/default/rbac/rbac_role.yaml
+++ b/config/default/rbac/rbac_role.yaml
@@ -97,3 +97,15 @@ rules:
     - namespaces
   verbs:
     - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -183,6 +183,18 @@ rules:
   - namespaces
   verbs:
   - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -368,9 +380,6 @@ spec:
         - containerPort: 8000
           name: webhook-server
           protocol: TCP
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
         readinessProbe:
           httpGet:
             httpHeaders:
@@ -389,6 +398,22 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair
           readOnly: true
+      - args:
+        - --logtostderr
+        - --secure-listen-address=:8443
+        - --upstream=http://127.0.0.1:8080
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -184,6 +184,18 @@ rules:
   - namespaces
   verbs:
   - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -369,9 +381,6 @@ spec:
         - containerPort: 8000
           name: webhook-server
           protocol: TCP
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
         readinessProbe:
           httpGet:
             httpHeaders:
@@ -390,6 +399,22 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair
           readOnly: true
+      - args:
+        - --logtostderr
+        - --secure-listen-address=:8443
+        - --upstream=http://127.0.0.1:8080
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5


### PR DESCRIPTION
**What this PR does / why we need it**:

KMP uses controller runtime which creates an http
end point for /metrics.
In order to support https, we deploy rbac-proxy container
in the same pod of KMP.
The new container exposes https end point,
and connects internally to the http end point.

It is self signed, and protected with rbac rules.

Signed-off-by: Or Shoval <oshoval@redhat.com>

**Special notes for your reviewer**:
CNAO will parameterize the kube-rbac-proxy image url, so we will able
to consume it on D/S.
See please https://github.com/kubevirt/cluster-network-addons-operator/pull/1144

**Release note**:
```release-note
None
```
