### PR TITLE
unit tests: Add make check

### DIFF
--- a/automation/check-patch.unit-test.sh
+++ b/automation/check-patch.unit-test.sh
@@ -11,6 +11,7 @@ main() {
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
 
     make all
+    make check
     make test
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to detect that we don't miss updating files,
with make generate, add make check to the unit tests job.

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```