### PR TITLE
ci, Bump CNAO and Kubevirt releases

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -22,11 +22,11 @@ function getLatestPatchVersion {
 }
 
 source ./cluster/cluster.sh
-CNAO_VERSION=v0.58.0
+CNAO_VERSION=v0.76.1
 export KUBEVIRT_DEPLOY_PROMETHEUS=true
 
 #use kubevirt latest z stream release
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.44)
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.56)
 cluster::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps KMP devepement and test env  to run with latest stable CNAO and Kubevirt releases.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
