### PR TITLE
manager, Reduce toleration in case of node reboot

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -45,6 +45,15 @@ spec:
       annotations:
         description: KubeMacPool manages MAC allocation to Pods and VMs
     spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -419,6 +419,15 @@ spec:
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
+      tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 60
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 60
       volumes:
       - name: tls-key-pair
         secret:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -420,6 +420,15 @@ spec:
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       terminationGracePeriodSeconds: 5
+      tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 60
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 60
       volumes:
       - name: tls-key-pair
         secret:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if the node upon which KMP-manager deployment runs reboots,
the KMP pod is evicted only 5 minutes (default) after the node is unreachable.
Since KMP-manager deployment is is essential for VM create/update
service-ability, reducing this eviction to 1 minute. This is done by
altering the tolerations config [0]

This means that if the node is not available/ready for more than 1
minute, the pod will evict and will try to reschedule using the
configured affinity.

[0] https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions

**Special notes for your reviewer**:

**Release note**:

```release-note
Reduce Kubemacpool-manager node eviction timeout
```
