### PR TITLE
psa: Adapt manifest to comply with "restricted"

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -6,7 +6,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.23'
+    export KUBEVIRT_PROVIDER='k8s-1.25'
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.23'}
-export KUBEVIRTCI_TAG='2207242237-3a5c590'
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
+export KUBEVIRTCI_TAG='2211090805-fa031f8'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    pod-security.kubernetes.io/enforce: "restricted"
     control-plane: mac-controller-manager
     # in case mutatepods is set to opt-out mode,
     # make sure that KubeMacPool pods are also opted-out
@@ -67,12 +68,22 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 1
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
         args:
           - "--v=production"
           - "--wait-time=300"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         image: quay.io/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager
@@ -123,6 +134,11 @@ spec:
         - --logtostderr
         - --secure-listen-address=:8443
         - --upstream=http://127.0.0.1:8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         image: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
@@ -166,11 +182,21 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
         args:
           - "--v=production"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         image: quay.io/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
         name: manager

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: mac-controller-manager
+    pod-security.kubernetes.io/enforce: restricted
   name: kubemacpool-system
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -307,8 +308,18 @@ spec:
           requests:
             cpu: 30m
             memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       priorityClassName: system-cluster-critical
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 5
 ---
 apiVersion: apps/v1
@@ -396,6 +407,11 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair
@@ -415,9 +431,19 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 5
       tolerations:
       - effect: NoExecute

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     control-plane: mac-controller-manager
     mutatepods.kubemacpool.io: ignore
+    pod-security.kubernetes.io/enforce: restricted
   name: kubemacpool-system
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -308,8 +309,18 @@ spec:
           requests:
             cpu: 30m
             memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       priorityClassName: system-cluster-critical
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 5
 ---
 apiVersion: apps/v1
@@ -397,6 +408,11 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs/
           name: tls-key-pair
@@ -416,9 +432,19 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: system-cluster-critical
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 107
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 5
       tolerations:
       - effect: NoExecute


### PR DESCRIPTION
**What this PR does / why we need it**:
We have to comply with the new Pod Security Admission from kubernetes v1.25, this change bump k8s to 1.25 to mark namespaces as "restricted" and fix manifests comply with it.


```release-note
Adapt to k8s 1.25 Pod Security Admission with "restricted" enforcement
```
