### PR TITLE
makefile, Dockerfile: Move to multi stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build
+_kubevirtci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Build controller-manager
+ARG GO_VERSION
+FROM docker.io/library/golang:$GO_VERSION AS builder
+
+WORKDIR $GOPATH/src/github.com/k8snetworkplumbingwg/kubemacpool
+COPY . .
+RUN GOFLAGS=-mod=vendor GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /manager $GOPATH/src/github.com/k8snetworkplumbingwg/kubemacpool/cmd/manager
+
+# Copy the controller-manager into a thin image
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+COPY --from=builder /manager /
+CMD ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -83,12 +83,9 @@ generate: generate-go generate-deploy generate-test generate-external
 check: $(GO)
 	./hack/check.sh
 
-manager: $(GO)
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -o $(BIN_DIR)/manager github.com/k8snetworkplumbingwg/kubemacpool/cmd/manager
-
 # Build the docker image
-container: manager
-	$(OCI_BIN) build build/ -t ${REGISTRY}/${IMG}:${IMAGE_TAG}
+container:
+	$(OCI_BIN) build --build-arg GO_VERSION=$(GO_VERSION) . -t ${REGISTRY}/${IMG}:${IMAGE_TAG}
 
 # Push the docker image
 docker-push:
@@ -128,7 +125,6 @@ vendor: $(GO)
 	fmt \
 	vet \
 	check \
-	manager \
 	container \
 	push \
 	cluster-up \

--- a/build/.dockerignore
+++ b/build/.dockerignore
@@ -1,2 +1,0 @@
-_output/bin/go
-_output/bin/go*

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,0 @@
-# Copy the controller-manager into a thin image
-FROM registry.access.redhat.com/ubi8/ubi-minimal
-COPY _output/bin/manager /
-ENTRYPOINT ["/manager"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.3


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the controller manager is built locally and copied to the Dockerfile.
Move to multi-stage docker build.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
