### PR TITLE
go.mod: Bump go to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.3


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps go to 1.18 as centos9 will not support go 1.17.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
