### PR TITLE
config: Remove RunasUser field

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -70,7 +70,6 @@ spec:
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true
-        runAsUser: 107
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -327,7 +327,6 @@ spec:
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true
-        runAsUser: 107
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 5

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -328,7 +328,6 @@ spec:
       restartPolicy: Always
       securityContext:
         runAsNonRoot: true
-        runAsUser: 107
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 5


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is removing the RunasUser value from the kubemacpool manifests.
Using the specific value for runAsUser produces an invalid value error.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
