### PR TITLE
manifests: Remove control-plane label from namespace

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   labels:
     pod-security.kubernetes.io/enforce: "restricted"
-    control-plane: mac-controller-manager
     # in case mutatepods is set to opt-out mode,
     # make sure that KubeMacPool pods are also opted-out
     # to prevent dead-lock.

--- a/config/default/mutatepods_opt_out_patch.yaml
+++ b/config/default/mutatepods_opt_out_patch.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: mac-controller-manager
     mutatepods.kubemacpool.io: ignore
   name: system
 ---

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: mac-controller-manager
     pod-security.kubernetes.io/enforce: restricted
   name: kubemacpool-system
 ---

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: mac-controller-manager
     mutatepods.kubemacpool.io: ignore
     pod-security.kubernetes.io/enforce: restricted
   name: kubemacpool-system

--- a/config/test/mutatepods_opt_mode_patch.yaml
+++ b/config/test/mutatepods_opt_mode_patch.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: mac-controller-manager
     mutatepods.kubemacpool.io: ignore
   name: system
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
Following https://github.com/kubevirt/cluster-network-addons-operator/pull/1145/files#r796372158
We don't need this label on KMP, and it require busy work on CNAO (see linked issue below).
Hence remove it from the namespace.

Note: the 2nd commit is manual removing from the files, where `make generate` didn't remove from.

**Special notes for your reviewer**:
See first bullet at https://github.com/kubevirt/cluster-network-addons-operator/issues/1567

**Release note**:
```release-note
None
```
