### PR TITLE
Fix duplicate check with different mac format

### DIFF
--- a/pkg/pool-manager/macentry_test.go
+++ b/pkg/pool-manager/macentry_test.go
@@ -21,33 +21,33 @@ var _ = Describe("mac-entry", func() {
 		newTimestamp := now.Add(time.Second)
 		BeforeEach(func() {
 			poolManager.waitTime = waitTimeSeconds
-			poolManager.macPoolMap = map[string]macEntry{
-				"02:00:00:00:00:00": macEntry{
+			poolManager.macPoolMap = map[macKey]macEntry{
+				NewMacKey("02:00:00:00:00:00"): macEntry{
 					instanceName:         "vm/default/vm0",
 					macInstanceKey:       "validInterface",
 					transactionTimestamp: &currentTimestamp,
 				},
-				"02:00:00:00:00:01": macEntry{
+				NewMacKey("02:00:00:00:00:01"): macEntry{
 					instanceName:         "vm/ns0/vm1",
 					macInstanceKey:       "staleInterface",
 					transactionTimestamp: &staleTimestamp,
 				},
-				"02:00:00:00:00:02": macEntry{
+				NewMacKey("02:00:00:00:00:02"): macEntry{
 					instanceName:         "vm/ns2/vm2",
 					macInstanceKey:       "validInterface",
 					transactionTimestamp: &currentTimestamp,
 				},
-				"02:00:00:00:00:03": macEntry{
+				NewMacKey("02:00:00:00:00:03"): macEntry{
 					instanceName:         "vm/ns3-4/vm3-4",
 					macInstanceKey:       "staleInterface",
 					transactionTimestamp: &staleTimestamp,
 				},
-				"02:00:00:00:00:04": macEntry{
+				NewMacKey("02:00:00:00:00:04"): macEntry{
 					instanceName:         "vm/ns3-4/vm3-4",
 					macInstanceKey:       "validInterface",
 					transactionTimestamp: &currentTimestamp,
 				},
-				"02:00:00:00:00:05": macEntry{
+				NewMacKey("02:00:00:00:00:05"): macEntry{
 					instanceName:         "vm/default/vm0",
 					macInstanceKey:       "validInterface",
 					transactionTimestamp: nil,
@@ -61,7 +61,7 @@ var _ = Describe("mac-entry", func() {
 		}
 		DescribeTable("and performing hasExpiredTransaction on macPoolMap entry",
 			func(i *hasExpiredTransactionParams) {
-				entry := poolManager.macPoolMap[i.macAddress]
+				entry := poolManager.macPoolMap[NewMacKey(i.macAddress)]
 				isStale, err := entry.hasExpiredTransaction(poolManager.waitTime)
 				Expect(err).ToNot(HaveOccurred(), "hasExpiredTransaction should not return error")
 				Expect(isStale).To(Equal(i.shouldSucceed), fmt.Sprintf("mac entry %s staleness status is not as expected", i.macAddress))
@@ -104,7 +104,7 @@ var _ = Describe("mac-entry", func() {
 		}
 		DescribeTable("and performing hasPendingTransaction on macPoolMap entry",
 			func(i *hasPendingTransactionParams) {
-				entry := poolManager.macPoolMap[i.macAddress]
+				entry := poolManager.macPoolMap[NewMacKey(i.macAddress)]
 				hasPendingTransaction := entry.hasPendingTransaction()
 				Expect(hasPendingTransaction).To(Equal(i.shouldSucceed), fmt.Sprintf("mac entry %s update required status is not as expected", i.macAddress))
 			},
@@ -147,7 +147,7 @@ var _ = Describe("mac-entry", func() {
 		}
 		DescribeTable("and performing hasReadyTransaction on macPoolMap",
 			func(i *hasReadyTransactionParams) {
-				entry := poolManager.macPoolMap[i.macAddress]
+				entry := poolManager.macPoolMap[NewMacKey(i.macAddress)]
 				isUpdated := entry.hasReadyTransaction(i.latestPersistedTimestamp)
 				Expect(isUpdated).To(Equal(i.expectedEntryReadiness), fmt.Sprintf("should get expected readiness on mac %s", i.macAddress))
 			},

--- a/pkg/pool-manager/mackey.go
+++ b/pkg/pool-manager/mackey.go
@@ -1,0 +1,22 @@
+package pool_manager
+
+import "net"
+
+type macKey struct {
+	normalizedMacAddress string
+}
+
+// NewMacKey creates a macKey struct containing a mac string
+// that can be used for different mac string format comparison.
+// It uses net.ParseMAC function to parse the given macAddress
+// and then stores its String() value.
+// The given macAddress MUST have already been validated.
+func NewMacKey(macAddress string) macKey {
+	// we can ignore the error here since the string value has already been validated
+	hwMacAddress, _ := net.ParseMAC(macAddress)
+	return macKey{normalizedMacAddress: hwMacAddress.String()}
+}
+
+func (m macKey) String() string {
+	return m.normalizedMacAddress
+}

--- a/pkg/pool-manager/mackey_test.go
+++ b/pkg/pool-manager/mackey_test.go
@@ -1,0 +1,24 @@
+package pool_manager
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MacKey", func() {
+	DescribeTable("String should return the normalized MAC address",
+		func(input string, expected string) {
+			macKey := NewMacKey(input)
+			Expect(macKey.String()).To(Equal(expected))
+		},
+		Entry("colon-separated EUI-48 input", "00:00:5e:00:53:01", "00:00:5e:00:53:01"),
+		Entry("colon-separated EUI-64 input", "02:00:5e:10:00:00:00:01", "02:00:5e:10:00:00:00:01"),
+		Entry("colon-separated 20-octet IP input", "00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01", "00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01"),
+		Entry("hyphen-separated EUI-48 input", "00-00-5e-00-53-01", "00:00:5e:00:53:01"),
+		Entry("hyphen-separated EUI-64 input", "02-00-5e-10-00-00-00-01", "02:00:5e:10:00:00:00:01"),
+		Entry("hyphen-separated 20-octet IP input", "00-00-00-00-fe-80-00-00-00-00-00-00-02-00-5e-10-00-00-00-01", "00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01"),
+		Entry("period-separated EUI-48 input", "0000.5e00.5301", "00:00:5e:00:53:01"),
+		Entry("period-separated EUI-64 input", "0200.5e10.0000.0001", "02:00:5e:10:00:00:00:01"),
+		Entry("period-separated 20-octet IP input", "0000.0000.fe80.0000.0000.0000.0200.5e10.0000.0001", "00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01"),
+	)
+})

--- a/pkg/pool-manager/macpoolmap.go
+++ b/pkg/pool-manager/macpoolmap.go
@@ -13,12 +13,12 @@ import (
 func (m *macMap) clearMacTransactionFromMacEntry(macAddress string) {
 	macEntry, exist := m.findByMacAddress(macAddress)
 	if exist {
-		(*m)[macAddress] = macEntry.resetTransaction()
+		(*m)[NewMacKey(macAddress)] = macEntry.resetTransaction()
 	}
 }
 
 func (m macMap) findByMacAddress(macAddress string) (macEntry, bool) {
-	macEntry, exist := m[macAddress]
+	macEntry, exist := m[NewMacKey(macAddress)]
 	return macEntry, exist
 }
 
@@ -40,7 +40,7 @@ func (m macMap) findByMacAddressAndInstanceName(macAddress, instanceFullName str
 
 // removeMacEntry deletes a macEntry from macPoolMap
 func (m *macMap) removeMacEntry(macAddress string) {
-	delete(*m, macAddress)
+	delete(*m, NewMacKey(macAddress))
 }
 
 // filterInByInstanceName creates a subset map from macPoolMap, holding only macs that belongs to a specific instance (pod/vm)
@@ -56,7 +56,7 @@ func (m macMap) filterInByInstanceName(instanceName string) (*macMap, error) {
 }
 
 func (m *macMap) createOrUpdateEntry(macAddress, instanceFullName, macInstanceKey string) {
-	(*m)[macAddress] = macEntry{
+	(*m)[NewMacKey(macAddress)] = macEntry{
 		instanceName:         instanceFullName,
 		macInstanceKey:       macInstanceKey,
 		transactionTimestamp: nil,
@@ -70,7 +70,7 @@ func (m *macMap) updateMacTransactionTimestampForUpdatedMacs(instanceFullName st
 		if err != nil {
 			return err
 		}
-		(*m)[macAddress] = entry.setTransaction(transactionTimestamp)
+		(*m)[NewMacKey(macAddress)] = entry.setTransaction(transactionTimestamp)
 	}
 	return nil
 }
@@ -98,7 +98,7 @@ func (m *macMap) alignMacEntryAccordingToVmInterface(macAddress, instanceFullNam
 	logger := log.WithName("alignMacEntryAccordingToVmInterface")
 	macEntry, _ := m.findByMacAddress(macAddress)
 	for _, iface := range vmInterfaces {
-		if iface.MacAddress == macAddress {
+		if NewMacKey(iface.MacAddress).String() == macAddress {
 			if iface.Name == macEntry.macInstanceKey {
 				logger.Info("marked mac as allocated", "macAddress", macAddress)
 				m.clearMacTransactionFromMacEntry(macAddress)

--- a/pkg/pool-manager/macpoolmap_test.go
+++ b/pkg/pool-manager/macpoolmap_test.go
@@ -24,32 +24,32 @@ var _ = Describe("mac-pool-map", func() {
 		BeforeEach(func() {
 			poolManager.waitTime = waitTimeSeconds
 			poolManager.macPoolMap = macMap{
-				"02:00:00:00:00:00": macEntry{
+				NewMacKey("02:00:00:00:00:00"): macEntry{
 					instanceName:         "vm/default/vm0",
 					macInstanceKey:       "validInterface",
 					transactionTimestamp: &currentTimestamp,
 				},
-				"02:00:00:00:00:01": macEntry{
+				NewMacKey("02:00:00:00:00:01"): macEntry{
 					instanceName:         "vm/ns0/vm1",
 					macInstanceKey:       "staleInterface",
 					transactionTimestamp: &staleTimestamp,
 				},
-				"02:00:00:00:00:02": macEntry{
+				NewMacKey("02:00:00:00:00:02"): macEntry{
 					instanceName:         "vm/ns2/vm2",
 					macInstanceKey:       "validInterface",
 					transactionTimestamp: &currentTimestamp,
 				},
-				"02:00:00:00:00:03": macEntry{
+				NewMacKey("02:00:00:00:00:03"): macEntry{
 					instanceName:         "vm/ns3-4/vm3-4",
 					macInstanceKey:       "staleInterface",
 					transactionTimestamp: &staleTimestamp,
 				},
-				"02:00:00:00:00:04": macEntry{
+				NewMacKey("02:00:00:00:00:04"): macEntry{
 					instanceName:         "vm/ns3-4/vm3-4",
 					macInstanceKey:       "validInterface",
 					transactionTimestamp: &currentTimestamp,
 				},
-				"02:00:00:00:00:05": macEntry{
+				NewMacKey("02:00:00:00:00:05"): macEntry{
 					instanceName:         "vm/default/vm0",
 					macInstanceKey:       "validInterface",
 					transactionTimestamp: nil,
@@ -76,12 +76,12 @@ var _ = Describe("mac-pool-map", func() {
 				&filterInByInstanceNameParams{
 					vmName: "vm/default/vm0",
 					expectedVmMacMap: &macMap{
-						"02:00:00:00:00:00": macEntry{
+						NewMacKey("02:00:00:00:00:00"): macEntry{
 							instanceName:         "vm/default/vm0",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: &currentTimestamp,
 						},
-						"02:00:00:00:00:05": macEntry{
+						NewMacKey("02:00:00:00:00:05"): macEntry{
 							instanceName:         "vm/default/vm0",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: nil,
@@ -92,7 +92,7 @@ var _ = Describe("mac-pool-map", func() {
 				&filterInByInstanceNameParams{
 					vmName: "vm/ns0/vm1",
 					expectedVmMacMap: &macMap{
-						"02:00:00:00:00:01": macEntry{
+						NewMacKey("02:00:00:00:00:01"): macEntry{
 							instanceName:         "vm/ns0/vm1",
 							macInstanceKey:       "staleInterface",
 							transactionTimestamp: &staleTimestamp,
@@ -103,7 +103,7 @@ var _ = Describe("mac-pool-map", func() {
 				&filterInByInstanceNameParams{
 					vmName: "vm/ns2/vm2",
 					expectedVmMacMap: &macMap{
-						"02:00:00:00:00:02": macEntry{
+						NewMacKey("02:00:00:00:00:02"): macEntry{
 							instanceName:         "vm/ns2/vm2",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: &currentTimestamp,
@@ -114,12 +114,12 @@ var _ = Describe("mac-pool-map", func() {
 				&filterInByInstanceNameParams{
 					vmName: "vm/ns3-4/vm3-4",
 					expectedVmMacMap: &macMap{
-						"02:00:00:00:00:03": macEntry{
+						NewMacKey("02:00:00:00:00:03"): macEntry{
 							instanceName:         "vm/ns3-4/vm3-4",
 							macInstanceKey:       "staleInterface",
 							transactionTimestamp: &staleTimestamp,
 						},
-						"02:00:00:00:00:04": macEntry{
+						NewMacKey("02:00:00:00:00:04"): macEntry{
 							instanceName:         "vm/ns3-4/vm3-4",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: &currentTimestamp,
@@ -138,7 +138,7 @@ var _ = Describe("mac-pool-map", func() {
 		DescribeTable("and performing alignMacEntryAccordingToVmInterface on macPoolMap entry",
 			func(a *alignMacEntryAccordingToVmInterfaceParams) {
 				poolManager.macPoolMap.alignMacEntryAccordingToVmInterface(a.macAddress, a.vmName, a.vmInterfaces)
-				macEntry, exist := poolManager.macPoolMap[a.macAddress]
+				macEntry, exist := poolManager.macPoolMap[NewMacKey(a.macAddress)]
 				Expect(exist).To(Equal(a.expectedExist))
 				Expect(macEntry).To(Equal(a.expectedMacEntry), "should align mac entry according to current interface")
 			},
@@ -189,8 +189,8 @@ var _ = Describe("mac-pool-map", func() {
 					Expect(err).ToNot(HaveOccurred(), "should not fail updating macEntry")
 
 					for _, macAddress := range u.updatedInterfaceMap {
-						Expect(poolManager.macPoolMap[macAddress].transactionTimestamp).To(Equal(u.transactionTimestamp))
-						Expect(poolManager.macPoolMap[macAddress].instanceName).To(Equal(u.vmName))
+						Expect(poolManager.macPoolMap[NewMacKey(macAddress)].transactionTimestamp).To(Equal(u.transactionTimestamp))
+						Expect(poolManager.macPoolMap[NewMacKey(macAddress)].instanceName).To(Equal(u.vmName))
 					}
 				}
 			},
@@ -229,7 +229,7 @@ var _ = Describe("mac-pool-map", func() {
 		}
 		DescribeTable("and performing clearMacTransactionFromMacEntry on macPoolMap entry",
 			func(c *clearMacTransactionFromMacEntryParams) {
-				macPoolMapCopy := map[string]macEntry{}
+				macPoolMapCopy := map[macKey]macEntry{}
 				for macAddress, macEntry := range poolManager.macPoolMap {
 					macPoolMapCopy[macAddress] = macEntry
 				}
@@ -238,7 +238,7 @@ var _ = Describe("mac-pool-map", func() {
 				for macAddress, originalMacEntry := range macPoolMapCopy {
 					updatedMacEntry, exist := poolManager.macPoolMap[macAddress]
 					Expect(exist).To(BeTrue(), fmt.Sprintf("mac %s's entry should not be deleted from macPoolMap after running clearMacTransactionFromMacEntry", macAddress))
-					if macAddress == c.macAddress {
+					if macAddress.String() == c.macAddress {
 						expectedMacEntry := macEntry{
 							instanceName:         originalMacEntry.instanceName,
 							macInstanceKey:       originalMacEntry.macInstanceKey,
@@ -327,7 +327,7 @@ var _ = Describe("mac-pool-map", func() {
 
 		It("Should remove mac entry when running removeMacEntry", func() {
 			for macAddress := range poolManager.macPoolMap {
-				poolManager.macPoolMap.removeMacEntry(macAddress)
+				poolManager.macPoolMap.removeMacEntry(macAddress.String())
 				_, exist := poolManager.macPoolMap[macAddress]
 				Expect(exist).To(BeFalse(), "mac entry should be deleted by removeMacEntry")
 			}
@@ -342,7 +342,7 @@ var _ = Describe("mac-pool-map", func() {
 		DescribeTable("and adding a new mac to macPoolMap",
 			func(c *createOrUpdateInMacPoolMapParams) {
 				poolManager.macPoolMap.createOrUpdateEntry(c.macAddress, c.vmName, c.interfaceName)
-				updatedMacEntry, exist := poolManager.macPoolMap[c.macAddress]
+				updatedMacEntry, exist := poolManager.macPoolMap[NewMacKey(c.macAddress)]
 				Expect(exist).To(BeTrue(), "mac entry should exist after added/updated")
 				expectedMacEntry := macEntry{
 					instanceName:         c.vmName,
@@ -379,12 +379,12 @@ var _ = Describe("mac-pool-map", func() {
 				&filterMacsThatRequireCommitParams{
 					latestPersistedTimestamp: &timestampBeforeCurrentTimestamp,
 					expectedMacMap: macMap{
-						"02:00:00:00:00:01": macEntry{
+						NewMacKey("02:00:00:00:00:01"): macEntry{
 							instanceName:         "vm/ns0/vm1",
 							macInstanceKey:       "staleInterface",
 							transactionTimestamp: &staleTimestamp,
 						},
-						"02:00:00:00:00:03": macEntry{
+						NewMacKey("02:00:00:00:00:03"): macEntry{
 							instanceName:         "vm/ns3-4/vm3-4",
 							macInstanceKey:       "staleInterface",
 							transactionTimestamp: &staleTimestamp,
@@ -395,27 +395,27 @@ var _ = Describe("mac-pool-map", func() {
 				&filterMacsThatRequireCommitParams{
 					latestPersistedTimestamp: &currentTimestamp,
 					expectedMacMap: macMap{
-						"02:00:00:00:00:00": macEntry{
+						NewMacKey("02:00:00:00:00:00"): macEntry{
 							instanceName:         "vm/default/vm0",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: &currentTimestamp,
 						},
-						"02:00:00:00:00:01": macEntry{
+						NewMacKey("02:00:00:00:00:01"): macEntry{
 							instanceName:         "vm/ns0/vm1",
 							macInstanceKey:       "staleInterface",
 							transactionTimestamp: &staleTimestamp,
 						},
-						"02:00:00:00:00:02": macEntry{
+						NewMacKey("02:00:00:00:00:02"): macEntry{
 							instanceName:         "vm/ns2/vm2",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: &currentTimestamp,
 						},
-						"02:00:00:00:00:03": macEntry{
+						NewMacKey("02:00:00:00:00:03"): macEntry{
 							instanceName:         "vm/ns3-4/vm3-4",
 							macInstanceKey:       "staleInterface",
 							transactionTimestamp: &staleTimestamp,
 						},
-						"02:00:00:00:00:04": macEntry{
+						NewMacKey("02:00:00:00:00:04"): macEntry{
 							instanceName:         "vm/ns3-4/vm3-4",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: &currentTimestamp,
@@ -426,27 +426,27 @@ var _ = Describe("mac-pool-map", func() {
 				&filterMacsThatRequireCommitParams{
 					latestPersistedTimestamp: &newTimestamp,
 					expectedMacMap: macMap{
-						"02:00:00:00:00:00": macEntry{
+						NewMacKey("02:00:00:00:00:00"): macEntry{
 							instanceName:         "vm/default/vm0",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: &currentTimestamp,
 						},
-						"02:00:00:00:00:01": macEntry{
+						NewMacKey("02:00:00:00:00:01"): macEntry{
 							instanceName:         "vm/ns0/vm1",
 							macInstanceKey:       "staleInterface",
 							transactionTimestamp: &staleTimestamp,
 						},
-						"02:00:00:00:00:02": macEntry{
+						NewMacKey("02:00:00:00:00:02"): macEntry{
 							instanceName:         "vm/ns2/vm2",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: &currentTimestamp,
 						},
-						"02:00:00:00:00:03": macEntry{
+						NewMacKey("02:00:00:00:00:03"): macEntry{
 							instanceName:         "vm/ns3-4/vm3-4",
 							macInstanceKey:       "staleInterface",
 							transactionTimestamp: &staleTimestamp,
 						},
-						"02:00:00:00:00:04": macEntry{
+						NewMacKey("02:00:00:00:00:04"): macEntry{
 							instanceName:         "vm/ns3-4/vm3-4",
 							macInstanceKey:       "validInterface",
 							transactionTimestamp: &currentTimestamp,

--- a/pkg/pool-manager/migratelegacyconfigmap.go
+++ b/pkg/pool-manager/migratelegacyconfigmap.go
@@ -2,7 +2,6 @@ package pool_manager
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -51,8 +50,7 @@ func (p *PoolManager) migrateMacsFromConfigMap(waitingMacData map[string]string)
 		return nil
 	}
 	var recreatedMacs []string
-	for macAddressDashes, transactionTimestampString := range waitingMacData {
-		macAddress := strings.Replace(macAddressDashes, "-", ":", 5)
+	for macAddress, transactionTimestampString := range waitingMacData {
 		if _, exist := p.macPoolMap.findByMacAddress(macAddress); !exist {
 			// configMap timestamps are in RFC3339 format, but it is also applicable in the new RFC3339Nano format
 			transactionTimestamp, err := parseTransactionTimestamp(transactionTimestampString)
@@ -71,7 +69,7 @@ func (p *PoolManager) migrateMacsFromConfigMap(waitingMacData map[string]string)
 // createOrUpdateDummyEntryWithTimestamp adds/updates a Dummy entry in the macPollMap. Since the transaction timestamp,
 // is migrated we also copy the timestamp, to signal that the transaction is still pending.
 func (m *macMap) createOrUpdateDummyEntryWithTimestamp(macAddress string, timestamp *time.Time) {
-	(*m)[macAddress] = macEntry{
+	(*m)[NewMacKey(macAddress)] = macEntry{
 		instanceName:         tempVmName,
 		macInstanceKey:       tempVmInterface,
 		transactionTimestamp: timestamp,

--- a/pkg/pool-manager/migratelegacyconfigmap_test.go
+++ b/pkg/pool-manager/migratelegacyconfigmap_test.go
@@ -78,7 +78,7 @@ var _ = Describe("migrate legacy vm configMap", func() {
 					By("checking entries migrated to macPoolMap")
 					Expect(poolManager.macPoolMap).To(HaveLen(len(i.expectedMacsInMacPoolMap)))
 					for _, macAddress := range i.expectedMacsInMacPoolMap {
-						macEntry, exist := poolManager.macPoolMap[macAddress]
+						macEntry, exist := poolManager.macPoolMap[NewMacKey(macAddress)]
 						Expect(exist).To(BeTrue(), "mac should be migrated to macPoolMap")
 						Expect(macEntry.isDummyEntry()).To(BeTrue(), "mac entry should be marked as Dummy")
 						expectedTimestamp, err := time.Parse(time.RFC3339Nano, timestamp)

--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -304,7 +304,7 @@ func (p *PoolManager) revertAllocationOnPod(podFullName string, allocations map[
 
 	log.V(1).Info("Revert vm allocation", "podFullName", podFullName, "allocations", allocations)
 	for _, macAddress := range allocations {
-		delete(p.macPoolMap, macAddress)
+		p.macPoolMap.removeMacEntry(macAddress)
 	}
 }
 

--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -147,7 +147,7 @@ func (p *PoolManager) allocatePodRequestedMac(network *multus.NetworkSelectionEl
 		}
 		return nil
 	}
-	if macEntry, exist := p.macPoolMap[requestedMac]; exist {
+	if macEntry, exist := p.macPoolMap[NewMacKey(requestedMac)]; exist {
 		if !macAlreadyBelongsToPodAndNetwork(podFullName, network.Name, macEntry) {
 			err := fmt.Errorf("failed to allocate requested mac address")
 			log.Error(err, "mac address already allocated")

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -138,9 +138,9 @@ var _ = Describe("Pool", func() {
 		return poolManager
 	}
 
-	checkMacPoolMapEntries := func(macPoolMap map[string]macEntry, updatedTransactionTimestamp *time.Time, updatedMacs, notUpdatedMacs []string) error {
+	checkMacPoolMapEntries := func(macPoolMap map[macKey]macEntry, updatedTransactionTimestamp *time.Time, updatedMacs, notUpdatedMacs []string) error {
 		for _, macAddress := range updatedMacs {
-			macEntry, exist := macPoolMap[macAddress]
+			macEntry, exist := macPoolMap[NewMacKey(macAddress)]
 			if !exist {
 				return errors.New(fmt.Sprintf("mac %s should exist in macPoolMap %v", macAddress, macPoolMap))
 			}
@@ -149,7 +149,7 @@ var _ = Describe("Pool", func() {
 			}
 		}
 		for _, macAddress := range notUpdatedMacs {
-			macEntry, exist := macPoolMap[macAddress]
+			macEntry, exist := macPoolMap[NewMacKey(macAddress)]
 			if !exist {
 				return errors.New(fmt.Sprintf("mac %s should exist in macPoolMap %v", macAddress, macPoolMap))
 			}
@@ -283,7 +283,7 @@ var _ = Describe("Pool", func() {
 				})
 				It("Should initialize the macPoolmap only with macs on the mananged pods", func() {
 					Expect(poolManager.macPoolMap).To(HaveLen(1))
-					entry, exist := poolManager.macPoolMap["02:00:00:00:00:00"]
+					entry, exist := poolManager.macPoolMap[NewMacKey("02:00:00:00:00:00")]
 					Expect(exist).To(BeTrue(), "should include the mac allocated by the managed pod")
 					expectMacEntry := macEntry{
 						instanceName:         fmt.Sprintf("pod/%s/%s", managedPodWithMacAllocated.Namespace, managedPodWithMacAllocated.Name),
@@ -518,7 +518,7 @@ var _ = Describe("Pool", func() {
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).To(Equal("02:00:00:00:00:00"))
 				Expect(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[1].MacAddress).To(Equal("02:00:00:00:00:01"))
 				Expect(checkMacPoolMapEntries(poolManager.macPoolMap, &transactionTimestamp, []string{"02:00:00:00:00:00", "02:00:00:00:00:01"}, []string{})).To(Succeed(), "Failed to check macs in macMap")
-				_, exist := poolManager.macPoolMap["02:00:00:00:00:02"]
+				_, exist := poolManager.macPoolMap[NewMacKey("02:00:00:00:00:02")]
 				Expect(exist).To(BeFalse())
 
 				updatedVM := newVM.DeepCopy()
@@ -610,7 +610,7 @@ var _ = Describe("Pool", func() {
 				err := poolManager.AllocateVirtualMachineMac(vm, &vmCreationTimestamp, true, logger)
 				Expect(err).ToNot(HaveOccurred())
 				allocatedMac = vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress
-				macEntry, exist := poolManager.macPoolMap[allocatedMac]
+				macEntry, exist := poolManager.macPoolMap[NewMacKey(allocatedMac)]
 				Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap")
 				Expect(macEntry.transactionTimestamp).To(Equal(&vmCreationTimestamp), "mac Entry should update transaction timestamp")
 
@@ -620,7 +620,7 @@ var _ = Describe("Pool", func() {
 				By("marking the vm mac as allocated")
 				err = poolManager.MarkVMAsReady(vm, vmLastPersistedTransactionTimestampAnnotation, log.WithName("fake-Reconcile"))
 				Expect(err).ToNot(HaveOccurred(), "should mark allocated macs as valid")
-				macEntry, exist = poolManager.macPoolMap[allocatedMac]
+				macEntry, exist = poolManager.macPoolMap[NewMacKey(allocatedMac)]
 				Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap")
 				Expect(macEntry.transactionTimestamp).To(BeNil(), "mac Entry should update transaction timestamp")
 			})
@@ -633,7 +633,7 @@ var _ = Describe("Pool", func() {
 					By("updating the vm, removing the interface")
 					err := poolManager.UpdateMacAddressesForVirtualMachine(vm, vmFirstUpdate, &vmFirstUpdateTimestamp, true, logger)
 					Expect(err).ToNot(HaveOccurred(), "should update vm with no error")
-					macEntry, exist := poolManager.macPoolMap[allocatedMac]
+					macEntry, exist := poolManager.macPoolMap[NewMacKey(allocatedMac)]
 					Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap after first update")
 					Expect(macEntry.transactionTimestamp).To(Equal(&vmFirstUpdateTimestamp), "mac Entry should update transaction timestamp")
 
@@ -645,7 +645,7 @@ var _ = Describe("Pool", func() {
 					Expect(err).ToNot(HaveOccurred(), "should not mark vm as ready with no errors")
 				})
 				It("should set the macs updated as ready", func() {
-					_, exist := poolManager.macPoolMap[allocatedMac]
+					_, exist := poolManager.macPoolMap[NewMacKey(allocatedMac)]
 					Expect(exist).To(BeFalse(), "mac should be updated in the macPoolMap after first update persisted")
 				})
 
@@ -656,7 +656,7 @@ var _ = Describe("Pool", func() {
 						By("updating the vm, removing the interface")
 						err := poolManager.UpdateMacAddressesForVirtualMachine(vmFirstUpdate, vmSecondUpdate, &vmSecondUpdateTimestamp, true, logger)
 						Expect(err).ToNot(HaveOccurred(), "should update vm with no error")
-						macEntry, exist := poolManager.macPoolMap[allocatedMac]
+						macEntry, exist := poolManager.macPoolMap[NewMacKey(allocatedMac)]
 						Expect(exist).To(BeTrue(), "mac should be updated in the macPoolMap after first update")
 						Expect(macEntry.transactionTimestamp).To(Equal(&vmSecondUpdateTimestamp), "mac Entry should update transaction timestamp")
 					})
@@ -670,7 +670,7 @@ var _ = Describe("Pool", func() {
 							Expect(err).ToNot(HaveOccurred(), "should not mark vm as ready with no errors")
 						})
 						It("Should keep the entry since the last persisted timestamp annotation is still prior to the mac's transaction timestamp", func() {
-							macEntry, exist := poolManager.macPoolMap[allocatedMac]
+							macEntry, exist := poolManager.macPoolMap[NewMacKey(allocatedMac)]
 							Expect(exist).To(BeTrue(), "mac should be in macMap until last update is persisted to make sure mac is safe from collisions from other updates")
 							Expect(macEntry.transactionTimestamp).To(Equal(&vmSecondUpdateTimestamp), "mac Entry should not change until change is persisted")
 						})
@@ -685,7 +685,7 @@ var _ = Describe("Pool", func() {
 							Expect(err).ToNot(HaveOccurred(), "should not mark vm as ready with no errors")
 						})
 						It("Should update the entry since the last persisted timestamp annotation is equal or later than the mac's transaction timestamp", func() {
-							macEntry, exist := poolManager.macPoolMap[allocatedMac]
+							macEntry, exist := poolManager.macPoolMap[NewMacKey(allocatedMac)]
 							Expect(exist).To(BeTrue(), "mac should be in macMap since the last persisted change includes this mac")
 							Expect(macEntry.transactionTimestamp).To(BeNil(), "mac Entry should change to ready after change persisted")
 						})
@@ -700,7 +700,7 @@ var _ = Describe("Pool", func() {
 							Expect(err).ToNot(HaveOccurred(), "should not mark vm as ready with no errors")
 						})
 						It("Should keep the entry until a newer change is persisted or until the entry goes stale and removed by handleStaleLegacyConfigMapEntries", func() {
-							macEntry, exist := poolManager.macPoolMap[allocatedMac]
+							macEntry, exist := poolManager.macPoolMap[NewMacKey(allocatedMac)]
 							Expect(exist).To(BeTrue(), "mac should be in macMap until last update is persisted to make sure mac is safe from collisions from other updates")
 							Expect(macEntry.transactionTimestamp).To(Equal(&vmSecondUpdateTimestamp), "mac Entry should not change")
 						})
@@ -744,7 +744,7 @@ var _ = Describe("Pool", func() {
 			})
 			It("should set a mac in pool cache with updated transaction timestamp", func() {
 				Expect(poolManager.macPoolMap).To(HaveLen(1), "macPoolMap should hold the mac address waiting for approval")
-				Expect(poolManager.macPoolMap[allocatedMac]).To(Equal(expectedMacEntry), "macPoolMap's mac's entry should be as expected")
+				Expect(poolManager.macPoolMap[NewMacKey(allocatedMac)]).To(Equal(expectedMacEntry), "macPoolMap's mac's entry should be as expected")
 			})
 			Context("and creating a dry run VM", func() {
 				var macPoolMapCopy macMap
@@ -795,11 +795,11 @@ var _ = Describe("Pool", func() {
 				})
 				It("should properly update the pool cache after vm creation", func() {
 					By("check allocated pool is populated and set to AllocationStatusAllocated status")
-					Expect(poolManager.macPoolMap[allocatedMac]).To(Equal(expectedMacEntry), "updated macPoolMap's mac's entry should remove transaction timestamp")
+					Expect(poolManager.macPoolMap[NewMacKey(allocatedMac)]).To(Equal(expectedMacEntry), "updated macPoolMap's mac's entry should remove transaction timestamp")
 				})
 				It("should check no mac is inserted if the pool does not contain the mac address", func() {
 					By("deleting the mac from the pool")
-					delete(poolManager.macPoolMap, allocatedMac)
+					delete(poolManager.macPoolMap, NewMacKey(allocatedMac))
 
 					By("re-marking the vm as ready")
 					err := poolManager.MarkVMAsReady(newVM, lastPersistedtransactionTimstamp, log.WithName("fake-Reconcile"))
@@ -832,13 +832,13 @@ var _ = Describe("Pool", func() {
 				instanceName:         podNamespaced(&newPod),
 				macInstanceKey:       "ovs-conf",
 			}
-			Expect(poolManager.macPoolMap[expectedAllocatedMac]).To(Equal(expectedMacEntry))
+			Expect(poolManager.macPoolMap[NewMacKey(expectedAllocatedMac)]).To(Equal(expectedMacEntry))
 
 			err = poolManager.ReleaseAllPodMacs(podNamespaced(&newPod))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(poolManager.macPoolMap).To(HaveLen(1))
 			Expect(checkMacPoolMapEntries(poolManager.macPoolMap, nil, []string{preAllocatedPodMac}, []string{})).To(Succeed(), "Failed to check macs in macMap")
-			_, exist := poolManager.macPoolMap[expectedAllocatedMac]
+			_, exist := poolManager.macPoolMap[NewMacKey(expectedAllocatedMac)]
 			Expect(exist).To(BeFalse())
 		})
 		It("should allocate requested mac when empty", func() {

--- a/pkg/pool-manager/transaction.go
+++ b/pkg/pool-manager/transaction.go
@@ -39,6 +39,6 @@ func (p *PoolManager) commitChangesToMacPoolMap(macsMapToCommit *macMap, vm *kub
 	vmPersistedInterfaceList := getVirtualMachineInterfaces(vm)
 	parentLogger.Info("committing macs to macPoolMap according to the current vm interfaces", "macsMapToCommit", macsMapToCommit, "vmPersistedInterfaceList", vmPersistedInterfaceList)
 	for macAddress, _ := range *macsMapToCommit {
-		p.macPoolMap.alignMacEntryAccordingToVmInterface(macAddress, VmNamespaced(vm), vmPersistedInterfaceList)
+		p.macPoolMap.alignMacEntryAccordingToVmInterface(macAddress.String(), VmNamespaced(vm), vmPersistedInterfaceList)
 	}
 }

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -431,7 +431,7 @@ func (p *PoolManager) revertAllocationOnVm(vmName string, allocations map[string
 
 	log.V(1).Info("Revert vm allocation", "vmName", vmName, "allocations", allocations)
 	for _, macAddress := range allocations {
-		delete(p.macPoolMap, macAddress)
+		p.macPoolMap.removeMacEntry(macAddress)
 	}
 }
 


### PR DESCRIPTION
A macAddress can be specified with different separators:
 - ":" e.g. "02:00:00:00:ff:ff"
 - "-" e.g. "02-00-00-00-ff-ff"
 - "." e.g. "0200.0000.ffff"

Currently, the duplicate mac check works only if the two compared mac address use the same separator.
The duplicate check is made looking at the existence of key of the macMap. The keys of the mapMap are the macAddress string.

With this commit, a `macKey` struct is introduced. The latter stores the normalized string of the macAddress and can be used as unique key and identifier of a macAddress.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:
Fixes https://issues.redhat.com/browse/CNV-30974

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix duplicate check with different mac address separator
```
