### PR TITLE
[release-0.33] cluster-up: Fix kubevirt deploy

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -16,16 +16,11 @@
 
 set -ex pipefail
 
-function getLatestPatchVersion {
-  local major_minors=$1
-  curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep .tag_name | grep ${major_minors} | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs
-}
-
 source ./cluster/cluster.sh
 CNAO_VERSION=v0.58.0
 
-#use kubevirt latest z stream release
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.44)
+#use kubevirt latest z stream release for v0.44
+KUBEVIRT_VERSION=v0.44.3
 cluster::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
The logic to get latest z stream is outdated for v0.44 as the release file 
doesnt have full history for old versions. 
Fetch manually the latest z stream for the used version.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
