### PR TITLE
cluster-up: Bump kubevirt major version to v1.1

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -26,7 +26,7 @@ CNAO_VERSION=v0.76.1
 export KUBEVIRT_DEPLOY_PROMETHEUS=true
 
 #use kubevirt latest z stream release
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.56)
+KUBEVIRT_VERSION=$(getLatestPatchVersion v1.1)
 cluster::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the kubevirt major and minor version deployed on cluster-up

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
