### PR TITLE
[release-0.40] cluster-up: Bump kubevirt major-minor version to v0.59

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -26,7 +26,7 @@ CNAO_VERSION=v0.76.1
 export KUBEVIRT_DEPLOY_PROMETHEUS=true
 
 #use kubevirt latest z stream release
-KUBEVIRT_VERSION=$(getLatestPatchVersion v0.56)
+KUBEVIRT_VERSION=$(getLatestPatchVersion v0.59)
 cluster::install
 
 if [[ "$KUBEVIRT_PROVIDER" != external ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the kubevirt major and minor version deployed on cluster-up

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
