### PR TITLE
[release-0.40] vendor, Bump go.mod go version to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
-go 1.17
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the go version on the go.mod file, because the current go version (1.18) is [breaking](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/k8snetworkplumbingwg_kubemacpool/418/pull-kubemacpool-unit-test-v0.40/1779370301017034752) our CI.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
