### PR TITLE
cluster: Allow kubevirtci tag overriding

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
-export KUBEVIRTCI_TAG='2211021552-8cca8c0'
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2211021552-8cca8c0}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/hack/bump-kubevirtci.sh
+++ b/hack/bump-kubevirtci.sh
@@ -3,6 +3,6 @@
 KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 [[ ${#KUBEVIRTCI_TAG} != "18" ]] && echo "error getting KUBEVIRTCI_TAG" && exit 1
 
-sed -i "s/export KUBEVIRTCI_TAG=.*/export KUBEVIRTCI_TAG='${KUBEVIRTCI_TAG}'/g" cluster/cluster.sh
+sed -i "s/\(KUBEVIRTCI_TAG:-\)[^}]*/\1${KUBEVIRTCI_TAG}/" cluster/cluster.sh
 
 git --no-pager diff cluster/cluster.sh | grep KUBEVIRTCI_TAG || true


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
It is helpful either manually or for example
when used from CNAO, to use same tag of the cluster that CNAO deployed.
Otherwise a kubevirtci tag mismatch can cause failures once running 
KMP e2e tests from CNAO.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
