### PR TITLE
Bump dev dependencies

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -6,7 +6,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.25'
+    export KUBEVIRT_PROVIDER='k8s-1.30'
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}
 

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.30'}
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2408151028-a0ad3359}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.25'}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2211021552-8cca8c0}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2408151028-a0ad3359}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
-go 1.21.9
+go 1.22.0
 
 require (
 	github.com/go-logr/logr v1.2.4


### PR DESCRIPTION
This PR bumps kubevirtci tag and provider to latest, and also bumps golang to `1.22.0`. 

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
