### PR TITLE
feat: use multi arch supported image for kube-rbac-proxy.

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -145,7 +145,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.15.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.1
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -312,7 +312,7 @@ spec:
         - --logtostderr
         - --secure-listen-address=:8443
         - --upstream=http://127.0.0.1:8080
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.15.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.1
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -313,7 +313,7 @@ spec:
         - --logtostderr
         - --secure-listen-address=:8443
         - --upstream=http://127.0.0.1:8080
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.15.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.1
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:


### PR DESCRIPTION
The origin-kube-rbac-proxy image is not compatible with the s390x architecture. This change deploys an image that is multi arch supported.

**What this PR does / why we need it**:
The origin-kube-rbac-proxy image is not compatible with the s390x architecture.
This change deploys an image that is multi arch supported(https://quay.io/repository/brancz/kube-rbac-proxy/manifest/sha256:e6a323504999b2a4d2a6bf94f8580a050378eba0900fd31335cf9df5787d9a9b).

**Special notes for your reviewer**:
proposed image(https://quay.io/repository/brancz/kube-rbac-proxy/manifest/sha256:e6a323504999b2a4d2a6bf94f8580a050378eba0900fd31335cf9df5787d9a9b) is built from parent repo of https://github.com/openshift/kube-rbac-proxy.

**Release note**:
```release-note
None
```
