### PR TITLE
docs: Remove VM Running API usage

### DIFF
--- a/doc/simple-vm.yaml
+++ b/doc/simple-vm.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   name: simplevm
 spec:
-  running: false
+  runStrategy: Halted
   template:
     spec:
       domain:

--- a/doc/vm-creation-example.md
+++ b/doc/vm-creation-example.md
@@ -43,7 +43,7 @@ kind: VirtualMachine
 metadata:
   name: samplevm
 spec:
-  running: false
+  runStrategy: Halted
   template:
     spec:
       domain:


### PR DESCRIPTION
**What this PR does / why we need it**:
The VM Running API is deprecated.
This PR replaces running API with RunStrategy API.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
