### PR TITLE
Refactor Pool-manager tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	github.com/go-logr/logr v1.2.4
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20221215110210-ad3f3381681f
 	github.com/onsi/ginkgo/v2 v2.9.4
 	github.com/onsi/gomega v1.27.6
 	github.com/pkg/errors v0.9.1
@@ -52,7 +53,6 @@ require (
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20221215110210-ad3f3381681f // indirect
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect

--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -28,6 +28,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 )
 
 const tempPodName = "tempPodName"
@@ -40,7 +42,7 @@ func (p *PoolManager) AllocatePodMac(pod *corev1.Pod, isNotDryRun bool) error {
 		"macmap", p.macPoolMap,
 		"currentMac", p.currentMac.String())
 
-	networkValue, ok := pod.Annotations[NetworksAnnotation]
+	networkValue, ok := pod.Annotations[networkv1.NetworkAttachmentAnnot]
 	if !ok {
 		return nil
 	}
@@ -49,7 +51,7 @@ func (p *PoolManager) AllocatePodMac(pod *corev1.Pod, isNotDryRun bool) error {
 	// we want to connect the allocated mac from the webhook to a pod object in the podToMacPoolMap
 	// run it before multus added the status annotation
 	// this mean the pod is not ready
-	if _, ok := pod.Annotations[networksStatusAnnotation]; ok {
+	if _, ok := pod.Annotations[networkv1.NetworkStatusAnnot]; ok {
 		return nil
 	}
 
@@ -97,7 +99,7 @@ func (p *PoolManager) AllocatePodMac(pod *corev1.Pod, isNotDryRun bool) error {
 	if err != nil {
 		return err
 	}
-	pod.Annotations[NetworksAnnotation] = string(networkListJson)
+	pod.Annotations[networkv1.NetworkAttachmentAnnot] = string(networkListJson)
 
 	return nil
 }
@@ -238,7 +240,7 @@ func (p *PoolManager) initPodMap() error {
 				continue
 			}
 
-			networkValue, ok := pod.Annotations[NetworksAnnotation]
+			networkValue, ok := pod.Annotations[networkv1.NetworkAttachmentAnnot]
 			if !ok {
 				continue
 			}

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -40,8 +40,6 @@ const (
 	RangeStartEnv                  = "RANGE_START"
 	RangeEndEnv                    = "RANGE_END"
 	RuntimeObjectFinalizerName     = "k8s.v1.cni.cncf.io/kubeMacPool"
-	NetworksAnnotation             = "k8s.v1.cni.cncf.io/networks"
-	networksStatusAnnotation       = "k8s.v1.cni.cncf.io/networks-status"
 	TransactionTimestampAnnotation = "kubemacpool.io/transaction-timestamp"
 	mutatingWebhookConfigName      = "kubemacpool-mutator"
 	virtualMachnesWebhookName      = "mutatevirtualmachines.kubemacpool.io"

--- a/pkg/webhook/pod/pod.go
+++ b/pkg/webhook/pod/pod.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
 	pool_manager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -78,8 +80,8 @@ func (a *podAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 func patchPodChanges(originalPod, currentPod *corev1.Pod) admission.Response {
 	kubemapcoolJsonPatches := []jsonpatch.Operation{}
 
-	currentNetworkAnnotation := currentPod.GetAnnotations()[pool_manager.NetworksAnnotation]
-	originalPodNetworkAnnotation := originalPod.GetAnnotations()[pool_manager.NetworksAnnotation]
+	currentNetworkAnnotation := currentPod.GetAnnotations()[networkv1.NetworkAttachmentAnnot]
+	originalPodNetworkAnnotation := originalPod.GetAnnotations()[networkv1.NetworkAttachmentAnnot]
 	if originalPodNetworkAnnotation != currentNetworkAnnotation {
 		annotationPatch := jsonpatch.NewOperation("replace", "/metadata/annotations", currentPod.GetAnnotations())
 		kubemapcoolJsonPatches = append(kubemapcoolJsonPatches, annotationPatch)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does refactor chores on the pool-manager library.
- Add check for macpool deleted MACs
- Move closure functions to regular functions
- Use multus consts
- Give meaningful names to const MACs

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
