### PR TITLE
feat: Add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["main", "release-0.45"],
+  "prConcurrentLimit": 3,
+  "lockFileMaintenance": {
+    "enabled": false
+  },
+  "postUpdateOptions": ["gomodTidy"],
+  "labels": ["release-note-none"],
+  "extends": [":gitSignOff"],
+  "packageRules": [
+    {
+      "groupName": "all dependencies",
+      "groupSlug": "all",
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "assigneesFromCodeOwners": true,
+  "separateMajorMinor": true,
+  "ignorePaths": [
+    "**/vendor/**"
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Renovate is a tool for bumping dependencies

Renovate will be used only for security patches for main and release-0.45 branch

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
