### PR TITLE
hack/check: Add vendor update

### DIFF
--- a/hack/check.sh
+++ b/hack/check.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-make container generate generate-deploy generate-test
+make vendor container generate generate-deploy generate-test
 if [[ -n "$(git status --porcelain)" ]] ; then
     echo "It seems like you need to run `make generate`. Please run it and commit the changes"
     git status --porcelain


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a vendor check.
Adding vendor update before porcelin check will make sure vendors are up to date.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
