### PR TITLE
[release-0.44] vendor: Bump go1.22.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/k8snetworkplumbingwg/kubemacpool
 
 go 1.22.0
 
+toolchain go1.22.11
+
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/onsi/ginkgo/v2 v2.9.4


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps to go1.22.11

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
