### PR TITLE
renovate: Fix supported stable branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["release-0.45", "release-0.44", "release-0.43", "release-0.42", "release-0.41", "release-0.40" ,"main"],
+  "baseBranches": ["release-0.45", "release-0.44", "release-0.43", "release-0.42", "release-0.41", "release-0.39" ,"main"],
   "prConcurrentLimit": 3,
   "lockFileMaintenance": {
     "enabled": false


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR fixes supported branches on renovate: release-0.40 is not supported while release-0.39 is supported.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
