### PR TITLE
cluster/up: Maximize kubevirt releases pagination per page

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -18,7 +18,7 @@ set -ex pipefail
 
 function getLatestPatchVersion {
   local major_minors=$1
-  curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep .tag_name | grep ${major_minors} | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs
+  curl -s https://api.github.com/repos/kubevirt/kubevirt/releases?per_page=100 | grep .tag_name | grep ${major_minors} | sort -V | tail -1 | awk -F':' '{print $2}' | sed 's/,//' | xargs
 }
 
 source ./cluster/cluster.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
getLatestPatchVersion gets the kubevirt x.y version, and returns the latest z releases of kubevirt using github API. 
The default amount of releases outputted by github API is 30.
In order to allow fetching older kubevirt versions, expanding the list of kubevirt releaeses to the maximum pagination allowed [0]

[0] https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#changing-the-number-of-items-per-page

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
