### PR TITLE
[release-0.42] go.mod, Makefile: Set go version to 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ KUSTOMIZE := GOFLAGS=-mod=mod $(GO) run sigs.k8s.io/kustomize/kustomize/v4@v4.5.
 CONTROLLER_GEN := GOFLAGS=-mod=mod $(GO) run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
 GOFMT := GOFLAGS=-mod=mod $(GO)fmt
 VET := GOFLAGS=-mod=mod $(GO) vet
-DEEPCOPY_GEN := GOFLAGS=-mod=mod $(GO) install k8s.io/code-generator/cmd/deepcopy-gen@latest
+DEEPCOPY_GEN := GOFLAGS=-mod=mod $(GO) install k8s.io/code-generator/cmd/deepcopy-gen@v0.29.15
 GO_VERSION = $(shell hack/go-version.sh)
 
 E2E_TEST_EXTRA_ARGS ?=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the go.mod version to 1.20

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
