### PR TITLE
[release-0.45] Makefile: Enforce max allowed version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ cluster-clean:
 bump-kubevirtci:
 	./hack/bump-kubevirtci.sh
 
+check-go-version:
+	./hack/check-go-version.sh
+
 vendor: $(GO)
 	$(GO) mod tidy -compat=$(GO_VERSION)
 	$(GO) mod vendor
@@ -133,4 +136,5 @@ vendor: $(GO)
 	push \
 	cluster-up \
 	cluster-down \
-	cluster-sync
+	cluster-sync \
+	check-go-version

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
+// allowed_go 1.22
 go 1.22.0
 
 require (

--- a/hack/check-go-version.sh
+++ b/hack/check-go-version.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+allowed_go_version=$(grep allowed_go go.mod | awk '{print $3}')
+if [ -z "$allowed_go_version" ]; then
+  echo "Error: go.mod Go allowed version not found" >&2
+  exit 1
+fi
+
+current_go_version=$(awk '/^go [0-9]+\./ {print $2}' go.mod | awk -F. '{print $1"."$2}')
+current_go_toolchain_version=$(grep '^toolchain' go.mod | awk '{print $2}' | sed 's/go//' | awk -F. '{print $1"."$2}' || echo "")
+
+if [ "$current_go_version" != "$allowed_go_version" ]; then
+    echo "Error: go.mod Go version $current_go_version different than allowed version allowed_go_version" >&2
+    exit 1
+fi
+
+if [ -n "$current_go_toolchain_version" ]; then
+    if [ "$current_go_toolchain_version" != "$allowed_go_version" ]; then
+        echo "Error: Go toolchain version $current_go_toolchain_version different than allowed version allowed_go_version" >&2
+        exit 1
+    fi
+fi

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-make vendor container generate generate-deploy generate-test
+make vendor check-go-version container generate generate-deploy generate-test
 if [[ -n "$(git status --porcelain)" ]] ; then
     echo "It seems like you need to run `make generate`. Please run it and commit the changes"
     git status --porcelain


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to protect us from bumping either manually or by Renovate bot,
go toolchain / lang higher than allowed for stable branches, guard was added to Makefile.

The guard check should be run only after make vendor is finished.

Notes:
- The guard checks only x.y versions when doing the coparison
- currently the mac version is static. this could change once there is a proper API for it.
- both go version and toolchain (if exist) are checked

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
