### PR TITLE
[release-0.39] Makefile: Enforce allowed go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ cluster-clean:
 bump-kubevirtci:
 	./hack/bump-kubevirtci.sh
 
+check-go-version:
+	./hack/check-go-version.sh
+
 vendor: $(GO)
 	$(GO) mod tidy
 	$(GO) mod vendor
@@ -144,4 +147,5 @@ tools: $(GO)
 	cluster-up \
 	cluster-down \
 	cluster-sync \
-	tools
+	tools \
+	check-go-version

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
+// allowed_go 1.19
 go 1.19
 
 require (

--- a/hack/check-go-version.sh
+++ b/hack/check-go-version.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+allowed_go_version=$(grep -E '^//\s*allowed_go' go.mod | awk '{print $3}')
+if [ -z "$allowed_go_version" ]; then
+  echo "ERROR: allowed_go comment not found in go.mod"
+  exit 1
+fi
+if [ "$allowed_go_version" = "any" ]; then
+  echo "Overriding go version check: allowed_go is set to '$allowed_go_version'"
+  exit 0
+fi
+
+current_go_version=$(awk '/^go [0-9]+\./ {print $2}' go.mod | awk -F. '{print $1"."$2}')
+current_go_toolchain_version=$(grep '^toolchain' go.mod | awk '{print $2}' | sed 's/go//' | awk -F. '{print $1"."$2}' || echo "")
+
+if [ "$current_go_version" != "$allowed_go_version" ]; then
+  echo "Error: go.mod Go version $current_go_version different than allowed version allowed_go_version" >&2
+  exit 1
+fi
+
+if [ -n "$current_go_toolchain_version" ]; then
+  if [ "$current_go_toolchain_version" != "$allowed_go_version" ]; then
+	echo "Error: Go toolchain version $current_go_toolchain_version different than allowed version allowed_go_version" >&2
+	exit 1
+  fi
+fi

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-make vendor container generate generate-deploy generate-test
+make vendor check-go-version container generate generate-deploy generate-test
 if [[ -n "$(git status --porcelain)" ]] ; then
     echo "It seems like you need to run `make generate`. Please run it and commit the changes"
     git status --porcelain


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to protect from unintentionally bumping go version (either manually or by Renovate bot),
check if go toolchain / lang differs from allowed (relevant for stable branches, main branch will override using `any` value. This guard check was added to Makefile.

The guard check should be run only after make vendor is finished.

Notes:
* The guard checks only x.y versions when doing the comparison
* currently the mac version is static. this could change once there is a proper API for it.
* both go version and toolchain (if exist) are checked

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
