### PR TITLE
tests, e2e: Log failed test.

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -2,6 +2,7 @@
 
 teardown() {
     make cluster-down
+    cp ${E2E_LOGS}/*.log $ARTIFACTS || true
     cp $(find . -name "*junit*.xml") $ARTIFACTS || true
 }
 

--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -10,7 +10,8 @@ rm -rf $tmp_dir
 mkdir -p $tmp_dir
 
 export TMP_PROJECT_PATH=$tmp_dir/kubemacpool
-export ARTIFACTS=${ARTIFACTS-$TMP_PROJECT_PATH}
+export E2E_LOGS=${TMP_PROJECT_PATH}/tests/_out
+export ARTIFACTS=${ARTIFACTS-$TMP_PROJECT_PATH/artifacts}
 mkdir -p $ARTIFACTS
 
 rsync -rt --links --filter=':- .gitignore' $(pwd)/ $TMP_PROJECT_PATH

--- a/tests/reporter/writers.go
+++ b/tests/reporter/writers.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+import (
+	"fmt"
+	"os"
+)
+
+func LogToFile(topic, logBody, artifactDir string, failureCount int) error {
+	fileName := fmt.Sprintf(artifactDir+"%d_%s.log", failureCount, topic)
+	file, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("Error creating log file %v, err %w\n", fileName, err)
+	}
+	defer file.Close()
+
+	if _, err = fmt.Fprint(file, logBody); err != nil {
+		fmt.Printf("Error writing log %s to file, err %v\n", fileName, err)
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
currently e2e test prints the logs to the screen.
This PR is moving the logs to be written to artifacts.


See [log artifacts example](https://gcsweb.ci.kubevirt.io/gcs/kubevirt-prow/pr-logs/pull/k8snetworkplumbingwg_kubemacpool/535/pull-kubemacpool-e2e-k8s/1917123323125305344/artifacts/)

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
