### PR TITLE
[release-0.47] go.mod: Set allowed go version on stable branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
-// allowed_go any
+// allowed_go 1.23
 go 1.23.0
 
 toolchain go1.23.4


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the allowed go to 1.23 on the `release-0.47` stable branch

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
