### PR TITLE
manifests: Add readyness and liveness probes

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -37,6 +37,5 @@ resources:
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
-
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -132,6 +132,16 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: Content-Type
+              value: application/json
+            path: /healthz
+            port: webhook-server
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 20
         volumeMounts:
           - name: tls-key-pair
             readOnly: true
@@ -141,6 +151,7 @@ spec:
         - --logtostderr
         - --secure-listen-address=:8443
         - --upstream=http://127.0.0.1:8080
+        - --proxy-endpoints-port=8643
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -153,11 +164,28 @@ spec:
         - containerPort: 8443
           name: metrics
           protocol: TCP
+        - containerPort: 8643
+          name: proxy
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
             memory: 20Mi
         terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          httpGet:
+            scheme: HTTPS
+            port: proxy
+            path: healthz
+        livenessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          httpGet:
+            scheme: HTTPS
+            port: proxy
+            path: healthz
       priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 5
       volumes:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -283,6 +283,16 @@ spec:
           value: v1
         image: quay.io/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: Content-Type
+              value: application/json
+            path: /healthz
+            port: webhook-server
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 20
         name: manager
         ports:
         - containerPort: 8000
@@ -316,13 +326,31 @@ spec:
         - --logtostderr
         - --secure-listen-address=:8443
         - --upstream=http://127.0.0.1:8080
+        - --proxy-endpoints-port=8643
         image: quay.io/brancz/kube-rbac-proxy:v0.18.1
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: healthz
+            port: proxy
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 20
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
           name: metrics
           protocol: TCP
+        - containerPort: 8643
+          name: proxy
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: healthz
+            port: proxy
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           requests:
             cpu: 10m

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -284,6 +284,16 @@ spec:
           value: v1
         image: registry:5000/kubevirt/kubemacpool:latest
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: Content-Type
+              value: application/json
+            path: /healthz
+            port: webhook-server
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 20
         name: manager
         ports:
         - containerPort: 8000
@@ -317,13 +327,31 @@ spec:
         - --logtostderr
         - --secure-listen-address=:8443
         - --upstream=http://127.0.0.1:8080
+        - --proxy-endpoints-port=8643
         image: quay.io/brancz/kube-rbac-proxy:v0.18.1
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: healthz
+            port: proxy
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 20
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
           name: metrics
           protocol: TCP
+        - containerPort: 8643
+          name: proxy
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: healthz
+            port: proxy
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           requests:
             cpu: 10m

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -67,6 +67,7 @@ func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) er
 	})
 
 	s.Register("/readyz", healthz.CheckHandler{Checker: healthz.Ping})
+	s.Register("/healthz", healthz.CheckHandler{Checker: healthz.Ping})
 
 	for _, f := range AddToWebhookFuncs {
 		if err := f(s, poolManager, mgr.GetScheme(), mgr.GetClient()); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This add the readiness and liveness probes to the kubemacpool deployment containers

**Special notes for your reviewer**:
cert-manager is skip since that's not really a part of kubemacpool

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add readiness and liveness probe to all the kubemacpool containers
```
