### PR TITLE
Add NetworkPolicies

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -49,6 +49,9 @@ done
 
 ./cluster/kubectl.sh apply -f $config_dir/kubemacpool.yaml
 
+# Ensure the project network-polices are valid by installing an additional deny-all network policy affecting kubemacpool pods
+./hack/install-deny-all-net-pol.sh
+
 pods_ready_wait() {
   if [[ "$KUBEVIRT_PROVIDER" != external ]]; then
     echo "Waiting for non-kubemacpool containers to be ready ..."

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,7 +28,12 @@ resources:
 - rbac/rbac_role.yaml
 - rbac/rbac_role_binding.yaml
 - manager/manager.yaml
-#- ../rbac/auth_proxy_service.yaml
+# provide network-policy in case the env has restrictive network-policy in place
+- network-policy/allow-egress-dns.yaml
+- network-policy/allow-egress-kube-apiserver.yaml
+- network-policy/allow-ingress-to-kmp-service.yaml
+
+  #- ../rbac/auth_proxy_service.yaml
 #- ../rbac/auth_proxy_role.yaml
 #- ../rbac/auth_proxy_role_binding.yaml
   # If you want your controller-manager to expose the /metrics

--- a/config/default/network-policy/allow-egress-dns.yaml
+++ b/config/default/network-policy/allow-egress-dns.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-dns
+spec:
+  podSelector:
+    matchLabels:
+      app: kubemacpool
+  policyTypes:
+  - Egress
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
+      ports:
+        - protocol: TCP
+          port: dns-tcp
+        - protocol: UDP
+          port: dns

--- a/config/default/network-policy/allow-egress-kube-apiserver.yaml
+++ b/config/default/network-policy/allow-egress-kube-apiserver.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-api-server
+spec:
+  podSelector:
+    matchLabels:
+      app: kubemacpool
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443

--- a/config/default/network-policy/allow-ingress-to-kmp-service.yaml
+++ b/config/default/network-policy/allow-ingress-to-kmp-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-kubemacpool-service
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: mac-controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8000

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -356,6 +356,63 @@ spec:
         secret:
           secretName: kubemacpool-service
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-egress-to-api-server
+  namespace: kubemacpool-system
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: kubemacpool
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-egress-to-dns
+  namespace: kubemacpool-system
+spec:
+  egress:
+  - ports:
+    - port: dns-tcp
+      protocol: TCP
+    - port: dns
+      protocol: UDP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+  podSelector:
+    matchLabels:
+      app: kubemacpool
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-ingress-to-kubemacpool-service
+  namespace: kubemacpool-system
+spec:
+  ingress:
+  - ports:
+    - port: 8000
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: mac-controller-manager
+  policyTypes:
+  - Ingress
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -357,6 +357,63 @@ spec:
         secret:
           secretName: kubemacpool-service
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-egress-to-api-server
+  namespace: kubemacpool-system
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: kubemacpool
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-egress-to-dns
+  namespace: kubemacpool-system
+spec:
+  egress:
+  - ports:
+    - port: dns-tcp
+      protocol: TCP
+    - port: dns
+      protocol: UDP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+  podSelector:
+    matchLabels:
+      app: kubemacpool
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-ingress-to-kubemacpool-service
+  namespace: kubemacpool-system
+spec:
+  ingress:
+  - ports:
+    - port: 8000
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: mac-controller-manager
+  policyTypes:
+  - Ingress
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/hack/install-deny-all-net-pol.sh
+++ b/hack/install-deny-all-net-pol.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -ex
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script install deny-all NetworkPolicy that affects kubemacpool namespace.
+
+readonly ns="$(./cluster/kubectl.sh get pod -l app=kubemacpool -A -o=custom-columns=NS:.metadata.namespace --no-headers | head -1)"
+[[ -z "${ns}" ]] && echo "FATAL: kubemacpool pods not found. Make sure kubemacpool is installed" && exit 1
+
+readonly np_name="deny-all"
+./cluster/kubectl.sh -n "${ns}" get networkpolicy "${np_name}" &> /dev/null ||
+  cat <<EOF | ./cluster/kubectl.sh -n "${ns}" create -f -
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${np_name}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress: []
+  egress: []
+EOF

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -92,6 +92,10 @@ func dumpKubemacpoolLogs(failureCount int) {
 	if err := logEndpoints(managerNamespace, names.WEBHOOK_SERVICE, failureCount); err != nil {
 		fmt.Println(err)
 	}
+
+	if err := logNetworkPolicies(managerNamespace, failureCount); err != nil {
+		fmt.Println(err)
+	}
 }
 
 func logPodContainersLogs(podName string, containers []corev1.Container, failureCount int) error {
@@ -175,5 +179,24 @@ func logPods(podsNamespace string, failureCount int) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func logNetworkPolicies(namespace string, failureCount int) error {
+	npList, err := testClient.VirtClient.NetworkingV1().NetworkPolicies(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	bytes, err := json.MarshalIndent(*npList, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	err = reporter.LogToFile(fmt.Sprintf("network-policies"), string(bytes), artifactDir, failureCount)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
In a scenario where a cluster networking has been hardened and futures
a default deny-all network policy that affects kubemacpool namespace,
kubemacpool will not be able to operate properly.

This PR introduce network-policies for kubemacpool allowing kubemacpool to operate,
complying with restrictions in form of deny all network-policy.

**Special notes for your reviewer**:
In order to have coverage for the introduced network-policies, and additional deny-all network-policies is installed as part of the cluster-sync flow.
Having a deny-all network-policy installed, allow the introduced network-policies to be tested in a development and test environments, locally and CI.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
config: Introduce network-policies to enable kubemacpool operate in restricted env
```
