### PR TITLE
Network policies: Allow ingress to metrics endpoint

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -32,6 +32,7 @@ resources:
 - network-policy/allow-egress-dns.yaml
 - network-policy/allow-egress-kube-apiserver.yaml
 - network-policy/allow-ingress-to-kmp-service.yaml
+- network-policy/allow-ingress-to-metrics-endpoint.yaml
 
   #- ../rbac/auth_proxy_service.yaml
 #- ../rbac/auth_proxy_role.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -31,7 +31,7 @@ resources:
 # provide network-policy in case the env has restrictive network-policy in place
 - network-policy/allow-egress-dns.yaml
 - network-policy/allow-egress-kube-apiserver.yaml
-- network-policy/allow-ingress-to-kmp-service.yaml
+- network-policy/allow-ingress-to-webhook.yaml
 - network-policy/allow-ingress-to-metrics-endpoint.yaml
 
   #- ../rbac/auth_proxy_service.yaml

--- a/config/default/network-policy/allow-ingress-to-metrics-endpoint.yaml
+++ b/config/default/network-policy/allow-ingress-to-metrics-endpoint.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-metrics-endpoint
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: mac-controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8443

--- a/config/default/network-policy/allow-ingress-to-webhook.yaml
+++ b/config/default/network-policy/allow-ingress-to-webhook.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-ingress-to-kubemacpool-service
+  name: allow-ingress-to-webhook
 spec:
   podSelector:
     matchLabels:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -428,12 +428,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: kubemacpool-allow-ingress-to-kubemacpool-service
+  name: kubemacpool-allow-ingress-to-metrics-endpoint
   namespace: kubemacpool-system
 spec:
   ingress:
   - ports:
-    - port: 8000
+    - port: 8443
       protocol: TCP
   podSelector:
     matchLabels:
@@ -444,12 +444,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: kubemacpool-allow-ingress-to-metrics-endpoint
+  name: kubemacpool-allow-ingress-to-webhook
   namespace: kubemacpool-system
 spec:
   ingress:
   - ports:
-    - port: 8443
+    - port: 8000
       protocol: TCP
   podSelector:
     matchLabels:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -441,6 +441,22 @@ spec:
   policyTypes:
   - Ingress
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-ingress-to-metrics-endpoint
+  namespace: kubemacpool-system
+spec:
+  ingress:
+  - ports:
+    - port: 8443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: mac-controller-manager
+  policyTypes:
+  - Ingress
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -442,6 +442,22 @@ spec:
   policyTypes:
   - Ingress
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubemacpool-allow-ingress-to-metrics-endpoint
+  namespace: kubemacpool-system
+spec:
+  ingress:
+  - ports:
+    - port: 8443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: mac-controller-manager
+  policyTypes:
+  - Ingress
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -429,12 +429,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: kubemacpool-allow-ingress-to-kubemacpool-service
+  name: kubemacpool-allow-ingress-to-metrics-endpoint
   namespace: kubemacpool-system
 spec:
   ingress:
   - ports:
-    - port: 8000
+    - port: 8443
       protocol: TCP
   podSelector:
     matchLabels:
@@ -445,12 +445,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: kubemacpool-allow-ingress-to-metrics-endpoint
+  name: kubemacpool-allow-ingress-to-webhook
   namespace: kubemacpool-system
 spec:
   ingress:
   - ports:
-    - port: 8443
+    - port: 8000
       protocol: TCP
   podSelector:
     matchLabels:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
When CNAO deploy kubemacpool, we see failures when prometheus stack fail to fire events that related to kubemacpool:
- When KMP detects duplicate macs, it doesn't fire KubeMacPoolDuplicateMacsFound 
- When CNAO deploy KMP it fire KubemacpoolDown, but kubemacpool pods are healthy.
Adding network-policy to allow ingress to kubemacpool metrics endpoint solve the issue, which was missing from the original PR #541 

This PR adds network-policy to allow ingress traffic to kubemacpool's metrics endpoint.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
