### PR TITLE
pod-pool: skip if pod has no multus network

### DIFF
--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -228,20 +228,21 @@ func (p *PoolManager) initPodMap() error {
 	err := p.paginatePodsWithLimit(100, func(pods *corev1.PodList) error {
 		for _, pod := range pods.Items {
 			log.V(1).Info("InitMaps for pod", "podName", pod.Name, "podNamespace", pod.Namespace)
-			instanceManaged, err := p.IsPodManaged(pod.GetNamespace())
-			if err != nil {
-				continue
-			}
-			if !instanceManaged {
-				continue
-			}
-
 			if pod.Annotations == nil {
 				continue
 			}
 
 			networkValue, ok := pod.Annotations[networkv1.NetworkAttachmentAnnot]
 			if !ok {
+				continue
+			}
+
+			instanceManaged, err := p.IsPodManaged(pod.GetNamespace())
+			if err != nil {
+				continue
+			}
+
+			if !instanceManaged {
 				continue
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This change make the pod initial looping faster by first checking if pods has no multus network (that's going to be 99% of the cases).


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
make kubemacpool readiness faster by checking first multus network annotation existence.
```
