### PR TITLE
pool-manager: Refactor full ip pool e2e tests to unit test

### DIFF
--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -109,7 +109,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  RANGE_END: 02:00:00:00:00:0F
+  RANGE_END: 02:FF:FF:FF:FF:FF
   RANGE_START: "02:00:00:00:00:00"
 kind: ConfigMap
 metadata:

--- a/config/test/kustomization.yaml
+++ b/config/test/kustomization.yaml
@@ -21,11 +21,6 @@ patches:
       kind: Deployment
       name: kubemacpool-cert-manager
       namespace: kubemacpool-system
-  - path: manager_range_patch.yaml
-    target:
-      kind: ConfigMap
-      name: mac-range-config
-      namespace: kubemacpool-system
 patchesStrategicMerge:
   - mutatevirtualmachines_opt_mode_patch.yaml
   - mutatepods_opt_mode_patch.yaml

--- a/config/test/manager_range_patch.yaml
+++ b/config/test/manager_range_patch.yaml
@@ -1,5 +1,0 @@
-[
-{"op": "replace",
- "path": "/data/RANGE_END",
- "value": "02:00:00:00:00:0F"}
-]

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -178,7 +178,7 @@ func GetMacPoolSize(rangeStart, rangeEnd net.HardwareAddr) (int64, error) {
 }
 
 func (p *PoolManager) getFreeMac() (net.HardwareAddr, error) {
-	// this look will ensure that we check all the range
+	// this loop will ensure that we check all the range
 	// first iteration from current mac to last mac in the range
 	// second iteration from first mac in the range to the latest one
 	for idx := 0; idx <= 1; idx++ {

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -72,6 +72,7 @@ const (
 	OptOutMode OptMode = "Opt-out"
 )
 
+var ErrFull = errors.New("the range is full")
 type macEntry struct {
 	instanceName         string
 	macInstanceKey       string // for vms, it holds the interface Name, for pods, it holds the network Name
@@ -211,7 +212,7 @@ func (p *PoolManager) getFreeMac() (net.HardwareAddr, error) {
 		copy(p.currentMac, p.rangeStart)
 	}
 
-	return nil, fmt.Errorf("the range is full")
+	return nil, ErrFull
 }
 
 func checkCast(mac net.HardwareAddr) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
The scenario of full mac pool is not easy to recreate in a cluster with
a big range, and it could be easily replaced by a unit test.
This PR is 
- removing e2e tests that check same KMP functionality with full ip pool scenario.
- introducing a unit test to check full ip pool scenario.
- removing the range patch reducing the MAC range in tests manifest to the original size

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
