### PR TITLE
go.mod: Set go to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,7 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
-// allowed_go any
-go 1.23.0
-
-toolchain go1.23.4
+// allowed_go 1.24
+go 1.24.0
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -123,7 +123,7 @@ func logService(serviceNamespace, serviceName string, failureCount int) error {
 		return err
 	}
 
-	err = reporter.LogToFile(fmt.Sprintf("service"+serviceName), string(byteString), artifactDir, failureCount)
+	err = reporter.LogToFile(fmt.Sprintf("service_%s", serviceName), string(byteString), artifactDir, failureCount)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func logEndpoints(endpointNamespace, endpointName string, failureCount int) erro
 		return err
 	}
 
-	err = reporter.LogToFile(fmt.Sprintf("endpoint_"+endpointName), string(byteString), artifactDir, failureCount)
+	err = reporter.LogToFile(fmt.Sprintf("endpoint_%s", endpointName), string(byteString), artifactDir, failureCount)
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func logPods(podsNamespace string, failureCount int) error {
 			errs = append(errs, err)
 			continue
 		}
-		err = reporter.LogToFile(fmt.Sprintf("pod_"+pod.Name), string(byteString), artifactDir, failureCount)
+		err = reporter.LogToFile(fmt.Sprintf("pod_%s", pod.Name), string(byteString), artifactDir, failureCount)
 		if err != nil {
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets go version to 1.24 including the go version guard.

**Special notes for your reviewer**:

**Release note**:

```release-note
set go to 1.24
```
