### PR TITLE
Optimize init map

### DIFF
--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -131,7 +131,7 @@ spec:
             port: webhook-server
             scheme: HTTPS
           initialDelaySeconds: 10
-          periodSeconds: 10
+          periodSeconds: 180
         livenessProbe:
           httpGet:
             httpHeaders:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -307,7 +307,7 @@ spec:
             port: webhook-server
             scheme: HTTPS
           initialDelaySeconds: 10
-          periodSeconds: 10
+          periodSeconds: 180
         resources:
           requests:
             cpu: 100m

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -308,7 +308,7 @@ spec:
             port: webhook-server
             scheme: HTTPS
           initialDelaySeconds: 10
-          periodSeconds: 10
+          periodSeconds: 180
         resources:
           requests:
             cpu: 100m

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -142,6 +142,27 @@ func (p *PoolManager) Start() error {
 	return nil
 }
 
+// getManagedNamespaces pre-computes which namespaces are managed by kubemacpool for a specific webhook
+func (p *PoolManager) getManagedNamespaces(webhookName string) ([]string, error) {
+	log.V(1).Info("computing managed namespaces for initialization", "webhookName", webhookName)
+
+	namespaces := &v1.NamespaceList{}
+	err := p.kubeClient.List(context.TODO(), namespaces)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list namespaces for webhook %s", webhookName)
+	}
+
+	var managedNamespaces []string
+	for _, ns := range namespaces.Items {
+		if managed, err := p.IsNamespaceManaged(ns.Name, webhookName); err == nil && managed {
+			managedNamespaces = append(managedNamespaces, ns.Name)
+		}
+	}
+
+	log.Info("computed managed namespaces", "webhookName", webhookName, "count", len(managedNamespaces), "namespaces", managedNamespaces)
+	return managedNamespaces, nil
+}
+
 func (p *PoolManager) InitMaps() error {
 	err := p.initPodMap()
 	if err != nil {

--- a/pkg/pool-manager/virtualmachine_pool.go
+++ b/pkg/pool-manager/virtualmachine_pool.go
@@ -314,15 +314,36 @@ func (p *PoolManager) initMacMapFromCluster(parentLogger logr.Logger) error {
 	return nil
 }
 
-// paginateVmsWithLimit performs a vm list request with pagination, to limit the amount of vms received at a time
-// and prevent taking too much memory.
-func (p *PoolManager) paginateVmsWithLimit(limit int64, vmsFunc func(pods *kubevirt.VirtualMachineList) error) error {
+// paginateVmsInManagedNamespaces performs VM list requests with pagination, but only for managed namespaces
+func (p *PoolManager) paginateVmsInManagedNamespaces(limit int64, vmsFunc func(vms *kubevirt.VirtualMachineList) error) error {
+	managedNamespaces, err := p.getManagedNamespaces(virtualMachnesWebhookName)
+	if err != nil {
+		return errors.Wrap(err, "failed to get managed namespaces for VMs")
+	}
+
+	if len(managedNamespaces) == 0 {
+		log.Info("no managed namespaces found for VMs, skipping VM initialization")
+		return nil
+	}
+
+	for _, namespace := range managedNamespaces {
+		log.V(1).Info("processing VMs in managed namespace", "namespace", namespace)
+		err := p.paginateVmsInNamespace(namespace, limit, vmsFunc)
+		if err != nil {
+			return errors.Wrapf(err, "failed to process VMs in namespace %s", namespace)
+		}
+	}
+
+	return nil
+}
+
+// paginateVmsInNamespace performs VM list request with pagination for a specific namespace
+func (p *PoolManager) paginateVmsInNamespace(namespace string, limit int64, vmsFunc func(vms *kubevirt.VirtualMachineList) error) error {
 	continueFlag := ""
 	for {
-		// Using a unstructured object.
 		vms := &kubevirt.VirtualMachineList{}
 		err := p.kubeClient.List(context.TODO(), vms, &client.ListOptions{
-			Namespace: metav1.NamespaceAll,
+			Namespace: namespace,
 			Limit:     limit,
 			Continue:  continueFlag,
 		})
@@ -336,7 +357,7 @@ func (p *PoolManager) paginateVmsWithLimit(limit int64, vmsFunc func(pods *kubev
 		}
 
 		continueFlag = vms.GetContinue()
-		log.V(1).Info("limit vms list", "vms len", len(vms.Items), "remaining", vms.GetRemainingItemCount(), "continue", continueFlag)
+		log.V(1).Info("limit vms list in namespace", "namespace", namespace, "vms len", len(vms.Items), "remaining", vms.GetRemainingItemCount(), "continue", continueFlag)
 		if continueFlag == "" {
 			break
 		}
@@ -347,18 +368,9 @@ func (p *PoolManager) paginateVmsWithLimit(limit int64, vmsFunc func(pods *kubev
 // forEachManagedVmInterfaceInClusterRunFunction gets all the macs from all the supported interfaces in all the managed cluster vms, and runs
 // a function vmInterfacesFunc on it
 func (p *PoolManager) forEachManagedVmInterfaceInClusterRunFunction(vmInterfacesFunc func(vmFullName string, iface kubevirt.Interface, networks map[string]kubevirt.Network) error) error {
-	err := p.paginateVmsWithLimit(100, func(vms *kubevirt.VirtualMachineList) error {
+	err := p.paginateVmsInManagedNamespaces(100, func(vms *kubevirt.VirtualMachineList) error {
 		logger := log.WithName("forEachManagedVmInterfaceInClusterRunFunction")
 		for _, vm := range vms.Items {
-			vmNamespace := vm.GetNamespace()
-			isNamespaceManaged, err := p.IsVirtualMachineManaged(vmNamespace)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("failed to check if namespace %s is managed in current opt-mode", vmNamespace))
-			}
-			if !isNamespaceManaged {
-				logger.V(1).Info("skipping vm in loop iteration, namespace not managed", "vmNamespace", vmNamespace)
-				continue
-			}
 			vmFullName := VmNamespaced(&vm)
 			vmInterfaces := getVirtualMachineInterfaces(&vm)
 			vmNetworks := getVirtualMachineNetworks(&vm)
@@ -393,7 +405,7 @@ func (p *PoolManager) forEachManagedVmInterfaceInClusterRunFunction(vmInterfaces
 		return nil
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed iterating over all cluster vms")
+		return errors.Wrap(err, "failed iterating over VMs in managed namespaces")
 	}
 	return nil
 }


### PR DESCRIPTION
Currently, initMap is taking a lot of time and API calls, that make startup time on big clusters (10k VMs) too long.
This PR is optimizing the InitMap by reading the supported namespaces before paginating through the pods. 
This reduces the startup time on big clusters from 6m+ to ~80s.

```
[root@e44-h32-000-r650 ~]# oc get vm -A | wc -l
10001
[root@e44-h32-000-r650 ~]# oc get pod -n openshift-cnv -w kubemacpool-mac-controller-manager-6bdfb65b45-f4s4r
NAME                                                  READY   STATUS    RESTARTS   AGE
kubemacpool-mac-controller-manager-6bdfb65b45-f4s4r   1/2     Running   0          14s
kubemacpool-mac-controller-manager-6bdfb65b45-f4s4r   2/2     Running   0          81s
```

This PR also increases the readiness timeout to 3m.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
