### PR TITLE
tests: Fix timing race in legacy ConfigMap upgrade test

### DIFF
--- a/tests/tests.go
+++ b/tests/tests.go
@@ -431,8 +431,9 @@ func simulateSoonToBeStaleEntryInConfigMap(macAddress string) error {
 			vmWaitConfigMap.Data = map[string]string{}
 		}
 		// legacy configMap uses time.RFC3339 format timestamps
-		// This entry should go stale after 1 minute
-		vmWaitConfigMap.Data[macAddressDashes] = time.Now().Add(-waitTime + time.Minute).Format(time.RFC3339)
+		// This entry should go stale after 3 minutes
+		const staleAfterDuration = 3 * time.Minute
+		vmWaitConfigMap.Data[macAddressDashes] = time.Now().Add(-waitTime + staleAfterDuration).Format(time.RFC3339)
 		return nil
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is fixing a test flake. The test for legacy ConfigMap migration was failing due to a timing race condition. The MAC entry was becoming stale too quickly (after 1 minute) before the test could verify the "occupied" state.

Changed the stale timeout from 1 minute to 3 minutes in simulateSoonToBeStaleEntryInConfigMap() to give the test sufficient time.
**Special notes for your reviewer**:
Fix https://github.com/k8snetworkplumbingwg/kubemacpool/issues/558

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
