### PR TITLE
makefile, e2e: Increase test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GOLANGICI_LINT ?= GOFLAGS=-mod=mod $(GO) run github.com/golangci/golangci-lint/c
 LINTER_COVERAGE ?= tests/...
 
 E2E_TEST_EXTRA_ARGS ?=
-export E2E_TEST_TIMEOUT ?= 1h
+export E2E_TEST_TIMEOUT ?= 90m
 E2E_TEST_ARGS ?= $(strip -test.v -test.timeout=$(E2E_TEST_TIMEOUT) -ginkgo.timeout=$(E2E_TEST_TIMEOUT) -ginkgo.v $(E2E_TEST_EXTRA_ARGS))
 
 export KUBECTL ?= cluster/kubectl.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Following [0] the e2e takes longer, making it timeout on some CI cases. Increasing the timeout to 90m.

[0] https://github.com/k8snetworkplumbingwg/kubemacpool/pull/559

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
