### PR TITLE
Support day2 range changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GOLANGICI_LINT ?= GOFLAGS=-mod=mod $(GO) run github.com/golangci/golangci-lint/c
 LINTER_COVERAGE ?= tests/...
 
 E2E_TEST_EXTRA_ARGS ?=
-export E2E_TEST_TIMEOUT ?= 90m
+export E2E_TEST_TIMEOUT ?= 100m
 E2E_TEST_ARGS ?= $(strip -test.v -test.timeout=$(E2E_TEST_TIMEOUT) -ginkgo.timeout=$(E2E_TEST_TIMEOUT) -ginkgo.v $(E2E_TEST_EXTRA_ARGS))
 
 export KUBECTL ?= cluster/kubectl.sh

--- a/config/default/rbac/rbac_role.yaml
+++ b/config/default/rbac/rbac_role.yaml
@@ -40,6 +40,7 @@ rules:
   resources:
   - pods
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -80,3 +81,10 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/default/rbac/rbac_role.yaml
+++ b/config/default/rbac/rbac_role.yaml
@@ -66,6 +66,8 @@ rules:
   verbs:
   - get
   - delete
+  - list
+  - watch
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -79,6 +79,8 @@ rules:
   verbs:
   - get
   - delete
+  - list
+  - watch
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -53,6 +53,7 @@ rules:
   resources:
   - pods
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -93,6 +94,13 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -80,6 +80,8 @@ rules:
   verbs:
   - get
   - delete
+  - list
+  - watch
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -54,6 +54,7 @@ rules:
   resources:
   - pods
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -94,6 +95,13 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/controller/add_configmap.go
+++ b/pkg/controller/add_configmap.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/configmap"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, configmap.Add)
+}

--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ConfigMapReconciler reconciles a ConfigMap object for MAC range updates
+type ConfigMapReconciler struct {
+	client.Client
+	Scheme             *runtime.Scheme
+	ConfigMapNamespace string
+}
+
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+
+func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Fetch the ConfigMap (predicate already filtered to our specific ConfigMap)
+	configMap := &corev1.ConfigMap{}
+	err := r.Get(ctx, req.NamespacedName, configMap)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("ConfigMap not found, ignoring since object must be deleted")
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Failed to get ConfigMap")
+		return ctrl.Result{}, err
+	}
+
+	// TODO: In future commits, implement the actual range extraction and update logic
+	logger.Info("ConfigMap reconcile called (stub implementation)",
+		"configMap", configMap.Name,
+		"namespace", configMap.Namespace)
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/controller/configmap/configmap_controller_test.go
+++ b/pkg/controller/configmap/configmap_controller_test.go
@@ -1,0 +1,343 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"context"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
+)
+
+const managerNamespace = "kubemacpool-system"
+
+// MockPoolManager is a test double for PoolManager
+type MockPoolManager struct {
+	currentStart       net.HardwareAddr
+	currentEnd         net.HardwareAddr
+	updateRangesCalled bool
+	updateRangesError  error
+}
+
+func (m *MockPoolManager) GetCurrentRanges() (start, end string) {
+	return m.currentStart.String(), m.currentEnd.String()
+}
+
+func (m *MockPoolManager) UpdateRanges(start, end net.HardwareAddr) error {
+	m.updateRangesCalled = true
+	if m.updateRangesError != nil {
+		return m.updateRangesError
+	}
+	m.currentStart = start
+	m.currentEnd = end
+	return nil
+}
+
+func (m *MockPoolManager) ManagerNamespace() string {
+	return managerNamespace
+}
+
+var _ = Describe("ConfigMap Controller", func() {
+	var reconciler *ConfigMapReconciler
+	var mockPoolManager *MockPoolManager
+
+	BeforeEach(func() {
+		// Setup mock with default ranges
+		startMac, _ := net.ParseMAC("02:00:00:00:00:00")
+		endMac, _ := net.ParseMAC("02:ff:ff:ff:ff:ff")
+
+		mockPoolManager = &MockPoolManager{
+			currentStart:       startMac,
+			currentEnd:         endMac,
+			updateRangesCalled: false,
+		}
+
+		reconciler = &ConfigMapReconciler{
+			PoolManager: mockPoolManager,
+		}
+	})
+
+	Describe("Reconcile", func() {
+		Context("with valid ConfigMap data", func() {
+			It("should return early when ranges are unchanged", func() {
+				// Create ConfigMap with same ranges as mock PoolManager current ranges
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+					Data: map[string]string{
+						"RANGE_START": "02:00:00:00:00:00", // Same as mock current
+						"RANGE_END":   "02:ff:ff:ff:ff:ff", // Same as mock current
+					},
+				}
+
+				// Create fake client with the ConfigMap
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(configMap).
+					Build()
+				reconciler.Client = fakeClient
+
+				// Call Reconcile
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+				}
+				result, err := reconciler.Reconcile(context.TODO(), req)
+
+				// Verify early return
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(mockPoolManager.updateRangesCalled).To(BeFalse(), "UpdateRanges should not be called when ranges are unchanged")
+			})
+
+			It("should update PoolManager when ranges are changed", func() {
+				// Create ConfigMap with different ranges
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+					Data: map[string]string{
+						"RANGE_START": "02:11:11:11:11:11", // Different from mock current
+						"RANGE_END":   "02:22:22:22:22:22", // Different from mock current
+					},
+				}
+
+				// Create fake client with the ConfigMap
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(configMap).
+					Build()
+				reconciler.Client = fakeClient
+
+				// Call Reconcile
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+				}
+				result, err := reconciler.Reconcile(context.TODO(), req)
+
+				// Verify UpdateRanges was called
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(mockPoolManager.updateRangesCalled).To(BeTrue(), "UpdateRanges should be called when ranges changed")
+
+				// Verify the new ranges were set
+				newStart, newEnd := mockPoolManager.GetCurrentRanges()
+				Expect(newStart).To(Equal("02:11:11:11:11:11"))
+				Expect(newEnd).To(Equal("02:22:22:22:22:22"))
+			})
+		})
+
+		Context("with invalid ConfigMap data", func() {
+			It("should return error when RANGE_START is missing", func() {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+					Data: map[string]string{
+						"RANGE_END": "02:ff:ff:ff:ff:ff",
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(configMap).
+					Build()
+				reconciler.Client = fakeClient
+
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+				}
+				result, err := reconciler.Reconcile(context.TODO(), req)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("RANGE_START not found"))
+				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(mockPoolManager.updateRangesCalled).To(BeFalse(), "UpdateRanges should not be called on error")
+			})
+
+			It("should return error when RANGE_END is missing", func() {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+					Data: map[string]string{
+						"RANGE_START": "02:00:00:00:00:00",
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(configMap).
+					Build()
+				reconciler.Client = fakeClient
+
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+				}
+				result, err := reconciler.Reconcile(context.TODO(), req)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("RANGE_END not found"))
+				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(mockPoolManager.updateRangesCalled).To(BeFalse(), "UpdateRanges should not be called on error")
+			})
+
+			It("should return error when RANGE_START is invalid MAC", func() {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+					Data: map[string]string{
+						"RANGE_START": "invalid-mac-address",
+						"RANGE_END":   "02:ff:ff:ff:ff:ff",
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(configMap).
+					Build()
+				reconciler.Client = fakeClient
+
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+				}
+				result, err := reconciler.Reconcile(context.TODO(), req)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid RANGE_START"))
+				Expect(err.Error()).To(ContainSubstring("invalid-mac-address"))
+				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(mockPoolManager.updateRangesCalled).To(BeFalse(), "UpdateRanges should not be called on error")
+			})
+
+			It("should return error when RANGE_END is invalid MAC", func() {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+					Data: map[string]string{
+						"RANGE_START": "02:00:00:00:00:00",
+						"RANGE_END":   "invalid-mac-address",
+					},
+				}
+
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(configMap).
+					Build()
+				reconciler.Client = fakeClient
+
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+				}
+				result, err := reconciler.Reconcile(context.TODO(), req)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid RANGE_END"))
+				Expect(err.Error()).To(ContainSubstring("invalid-mac-address"))
+				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(mockPoolManager.updateRangesCalled).To(BeFalse(), "UpdateRanges should not be called on error")
+			})
+
+			It("should return error when ConfigMap has empty data", func() {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+					Data: map[string]string{},
+				}
+
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					WithObjects(configMap).
+					Build()
+				reconciler.Client = fakeClient
+
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+				}
+				result, err := reconciler.Reconcile(context.TODO(), req)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("RANGE_START not found"))
+				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(mockPoolManager.updateRangesCalled).To(BeFalse(), "UpdateRanges should not be called on error")
+			})
+		})
+
+		Context("when ConfigMap is not found", func() {
+			It("should handle not found gracefully", func() {
+				// Don't create any ConfigMap, so Get will return NotFound
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme.Scheme).
+					Build()
+				reconciler.Client = fakeClient
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      names.MAC_RANGE_CONFIGMAP,
+						Namespace: managerNamespace,
+					},
+				}
+				result, err := reconciler.Reconcile(context.TODO(), req)
+
+				// Should handle gracefully without error
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+				Expect(mockPoolManager.updateRangesCalled).To(BeFalse(), "UpdateRanges should not be called when ConfigMap not found")
+			})
+		})
+	})
+})

--- a/pkg/controller/configmap/configmap_suite_test.go
+++ b/pkg/controller/configmap/configmap_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfigMapController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ConfigMapController Suite")
+}

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -22,6 +22,8 @@ const WAITING_VMS_CONFIGMAP = "kubemacpool-vm-configmap"
 
 const WAIT_TIME_ARG = "wait-time"
 
+const MAC_RANGE_CONFIGMAP = "kubemacpool-mac-range-config"
+
 // Relationship labels
 const COMPONENT_LABEL_KEY = "app.kubernetes.io/component"
 const PART_OF_LABEL_KEY = "app.kubernetes.io/part-of"

--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -39,7 +39,7 @@ func (p *PoolManager) AllocatePodMac(pod *corev1.Pod, isNotDryRun bool) error {
 
 	log.V(1).Info("AllocatePodMac: Data",
 		"macmap", p.macPoolMap,
-		"currentMac", p.currentMac.String())
+		"currentMac", p.getCurrentMAC())
 
 	networkValue, ok := pod.Annotations[networkv1.NetworkAttachmentAnnot]
 	if !ok {

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -440,3 +440,8 @@ func (p *PoolManager) UpdateRanges(newStart, newEnd net.HardwareAddr) error {
 func (p *PoolManager) GetCurrentRanges() (start, end string) {
 	return p.rangeStart.String(), p.rangeEnd.String()
 }
+
+// ManagerNamespace returns the manager namespace
+func (p *PoolManager) ManagerNamespace() string {
+	return p.managerNamespace
+}

--- a/pkg/pool-manager/pool.go
+++ b/pkg/pool-manager/pool.go
@@ -435,3 +435,8 @@ func (p *PoolManager) UpdateRanges(newStart, newEnd net.HardwareAddr) error {
 
 	return nil
 }
+
+// GetCurrentRanges returns the current MAC address ranges
+func (p *PoolManager) GetCurrentRanges() (start, end string) {
+	return p.rangeStart.String(), p.rangeEnd.String()
+}

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Pool", func() {
 				Expect(err).ToNot(HaveOccurred())
 				_, err = NewPoolManager(fakeClient, fakeClient, startPoolRangeEnv, endPoolRangeEnv, testManagerNamespace, false, 10)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("Invalid range. rangeStart: 0a:00:00:00:00:00 rangeEnd: 02:00:00:00:00:00"))
+				Expect(err.Error()).To(Equal("failed to set initial ranges: invalid range. rangeStart: 0a:00:00:00:00:00 rangeEnd: 02:00:00:00:00:00"))
 
 			})
 
@@ -185,7 +185,7 @@ var _ = Describe("Pool", func() {
 				Expect(err).ToNot(HaveOccurred())
 				_, err = NewPoolManager(fakeClient, fakeClient, startPoolRangeEnv, endPoolRangeEnv, testManagerNamespace, false, 10)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("RangeStart is invalid: invalid mac address. Multicast addressing is not supported. Unicast addressing must be used. The first octet is 0X3"))
+				Expect(err.Error()).To(Equal("failed to set initial ranges: invalid range start: invalid mac address. Multicast addressing is not supported. Unicast addressing must be used. The first octet is 0X3"))
 
 			})
 
@@ -197,7 +197,7 @@ var _ = Describe("Pool", func() {
 				Expect(err).ToNot(HaveOccurred())
 				_, err = NewPoolManager(fakeClient, fakeClient, startPoolRangeEnv, endPoolRangeEnv, testManagerNamespace, false, 10)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("RangeEnd is invalid: invalid mac address. Multicast addressing is not supported. Unicast addressing must be used. The first octet is 0X5"))
+				Expect(err.Error()).To(Equal("failed to set initial ranges: invalid range end: invalid mac address. Multicast addressing is not supported. Unicast addressing must be used. The first octet is 0X5"))
 			})
 
 			Context("When poolManager is initialized when there are pods on managed and unmanaged namespaces", func() {

--- a/tests/range_day2_test.go
+++ b/tests/range_day2_test.go
@@ -1,0 +1,358 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
+)
+
+const (
+	updatedRangeStart = "0A:00:00:00:00:00"
+	updatedRangeEnd   = "0A:00:00:00:00:FF"
+
+	// Test timeouts
+	rangeUpdateTimeout  = 30 * time.Second
+	rangeUpdateInterval = 2 * time.Second
+
+	// Test VM names
+	vmBeforeUpdateName = "vm-before-update"
+	vmAfterUpdateName  = "vm-after-update"
+)
+
+var _ = Describe("Day2 MAC Range Changes", Ordered, Label("mac-range-day2-update"), func() {
+	var originalRangeStart, originalRangeEnd string
+
+	BeforeAll(func() {
+		Expect(initKubemacpoolParams()).To(Succeed())
+
+		for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
+			Expect(addLabelsToNamespace(namespace, map[string]string{vmNamespaceOptInLabel: "allocate"})).To(Succeed())
+		}
+		configMap, err := testClient.VirtClient.CoreV1().ConfigMaps(managerNamespace).Get(context.Background(),
+			names.MAC_RANGE_CONFIGMAP, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred(), "ConfigMap should always exist in deployment")
+
+		originalRangeStart = configMap.Data["RANGE_START"]
+		originalRangeEnd = configMap.Data["RANGE_END"]
+	})
+
+	AfterEach(func() {
+		cleanupTestVMs()
+
+		Expect(updateMacRangeConfigMap(originalRangeStart, originalRangeEnd)).To(Succeed())
+
+		for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
+			Expect(cleanNamespaceLabels(namespace)).To(Succeed())
+		}
+	})
+
+	AfterEach(func() {
+		Expect(checkKubemacpoolCrash()).To(Succeed(), "Kubemacpool should not crash during test")
+	})
+	Context("When updating MAC ranges via ConfigMap", func() {
+		It("should update ranges and allocate new MACs from updated range", func() {
+			By("Creating a VM before range update to get MAC from original range")
+			vmBefore, err := createTestVM(vmBeforeUpdateName)
+			Expect(err).ToNot(HaveOccurred())
+			macBefore, err := getMacAddressFromVM(vmBefore)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(macBefore).ToNot(BeEmpty(), "VM should have MAC address allocated")
+			inRange, err := isMacInRange(macBefore, originalRangeStart, originalRangeEnd)
+			Expect(err).ToNot(HaveOccurred(), "MAC range check should not fail")
+			Expect(inRange).To(BeTrue(), "MAC should be from original range")
+
+			By("Updating MAC range ConfigMap")
+			Expect(updateMacRangeConfigMap(updatedRangeStart, updatedRangeEnd)).To(Succeed())
+
+			By("Creating a VM after range update to get MAC from new range")
+			Eventually(func() string {
+				vmAfter, vmErr := createTestVM(vmAfterUpdateName)
+				if vmErr != nil {
+					return ""
+				}
+				defer func() {
+					_ = testClient.VirtClient.VirtualMachine(TestNamespace).Delete(context.Background(),
+						vmAfter.Name, metav1.DeleteOptions{})
+				}()
+				macAfter, macErr := getMacAddressFromVM(vmAfter)
+				if macErr != nil {
+					return ""
+				}
+				return macAfter
+			}, rangeUpdateTimeout, rangeUpdateInterval).Should(SatisfyAll(
+				Not(BeEmpty()),
+				BeInMACRange(updatedRangeStart, updatedRangeEnd),
+			))
+
+			By("Verifying original VM MAC is unchanged")
+			unchangedMac, err := getMacAddressFromVM(vmBefore)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(unchangedMac).To(Equal(macBefore), "existing VM MAC should remain unchanged")
+		})
+
+		It("should reject invalid MAC range updates", func() {
+			By("Attempting to update with invalid MAC range")
+			Expect(updateMacRangeConfigMap("invalid-mac", originalRangeEnd)).To(Succeed())
+
+			By("Verifying range update was rejected (new allocations still use original range)")
+			Eventually(func() string {
+				vm, err := createTestVM("test-invalid-range")
+				if err != nil {
+					return ""
+				}
+				defer func() {
+					_ = testClient.VirtClient.VirtualMachine(TestNamespace).Delete(context.Background(),
+						vm.Name, metav1.DeleteOptions{})
+				}()
+				mac, err := getMacAddressFromVM(vm)
+				if err != nil {
+					return ""
+				}
+				return mac
+			}, rangeUpdateTimeout, rangeUpdateInterval).Should(SatisfyAll(
+				Not(BeEmpty()),
+				BeInMACRange(originalRangeStart, originalRangeEnd),
+			))
+		})
+
+		Context("When ConfigMap is deleted", func() {
+			var deletionTestRangeStart, deletionTestRangeEnd string
+
+			BeforeEach(func() {
+				configMap, err := testClient.VirtClient.CoreV1().ConfigMaps(managerNamespace).Get(context.Background(),
+					names.MAC_RANGE_CONFIGMAP, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				deletionTestRangeStart = configMap.Data["RANGE_START"]
+				deletionTestRangeEnd = configMap.Data["RANGE_END"]
+			})
+
+			AfterEach(func() {
+				Expect(createMacRangeConfigMap(deletionTestRangeStart, deletionTestRangeEnd)).To(Succeed())
+			})
+
+			It("should handle ConfigMap deletion gracefully", func() {
+				By("Creating initial VM to verify current range before deletion")
+				vm, err := createTestVM("test-deletion")
+				Expect(err).ToNot(HaveOccurred())
+				macBefore, err := getMacAddressFromVM(vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(macBefore).ToNot(BeEmpty(), "VM should have MAC address allocated")
+				inRange, err := isMacInRange(macBefore, deletionTestRangeStart, deletionTestRangeEnd)
+				Expect(err).ToNot(HaveOccurred(), "MAC range check should not fail")
+				Expect(inRange).To(BeTrue(), "Initial VM MAC should be from current range")
+
+				By("Deleting the MAC range ConfigMap")
+				err = testClient.VirtClient.CoreV1().ConfigMaps(managerNamespace).Delete(context.Background(),
+					names.MAC_RANGE_CONFIGMAP, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying MAC allocation continues from same range after ConfigMap deletion")
+				Eventually(func() string {
+					newVM, err := createTestVM("test-after-deletion")
+					if err != nil {
+						return ""
+					}
+					defer func() {
+						_ = testClient.VirtClient.VirtualMachine(TestNamespace).Delete(context.Background(),
+							newVM.Name, metav1.DeleteOptions{})
+					}()
+					mac, err := getMacAddressFromVM(newVM)
+					if err != nil {
+						return ""
+					}
+					return mac
+				}, rangeUpdateTimeout, rangeUpdateInterval).Should(SatisfyAll(
+					Not(BeEmpty()),
+					BeInMACRange(deletionTestRangeStart, deletionTestRangeEnd),
+				), "New VM should continue getting MAC from the same range that was active before ConfigMap deletion")
+			})
+		})
+
+		It("should work with multiple range updates", func() {
+			const thirdRangeStart = "0E:00:00:00:00:00"
+			const thirdRangeEnd = "0E:00:00:00:00:FF"
+
+			By("Performing first range update")
+			Expect(updateMacRangeConfigMap(updatedRangeStart, updatedRangeEnd)).To(Succeed())
+
+			By("Verifying first update works")
+			Eventually(func() string {
+				vm, err := createTestVM("test-first-update")
+				if err != nil {
+					return ""
+				}
+				defer func() {
+					_ = testClient.VirtClient.VirtualMachine(TestNamespace).Delete(context.Background(),
+						vm.Name, metav1.DeleteOptions{})
+				}()
+				mac, err := getMacAddressFromVM(vm)
+				if err != nil {
+					return ""
+				}
+				return mac
+			}, rangeUpdateTimeout, rangeUpdateInterval).Should(SatisfyAll(
+				Not(BeEmpty()),
+				BeInMACRange(updatedRangeStart, updatedRangeEnd),
+			))
+
+			By("Performing second range update")
+			Expect(updateMacRangeConfigMap(thirdRangeStart, thirdRangeEnd)).To(Succeed())
+
+			By("Verifying second update works")
+			Eventually(func() string {
+				vm2, err := createTestVM("test-second-update")
+				if err != nil {
+					return ""
+				}
+				defer func() {
+					_ = testClient.VirtClient.VirtualMachine(TestNamespace).Delete(context.Background(),
+						vm2.Name, metav1.DeleteOptions{})
+				}()
+				mac, err := getMacAddressFromVM(vm2)
+				if err != nil {
+					return ""
+				}
+				return mac
+			}, rangeUpdateTimeout, rangeUpdateInterval).Should(SatisfyAll(
+				Not(BeEmpty()),
+				BeInMACRange(thirdRangeStart, thirdRangeEnd),
+			))
+		})
+	})
+})
+
+func updateMacRangeConfigMap(rangeStart, rangeEnd string) error {
+	ctx := context.Background()
+
+	configMap, err := testClient.VirtClient.CoreV1().ConfigMaps(managerNamespace).Get(ctx,
+		names.MAC_RANGE_CONFIGMAP, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	configMap.Data["RANGE_START"] = rangeStart
+	configMap.Data["RANGE_END"] = rangeEnd
+
+	_, err = testClient.VirtClient.CoreV1().ConfigMaps(managerNamespace).Update(ctx,
+		configMap, metav1.UpdateOptions{})
+	return err
+}
+
+func createMacRangeConfigMap(rangeStart, rangeEnd string) error {
+	ctx := context.Background()
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.MAC_RANGE_CONFIGMAP,
+			Namespace: managerNamespace,
+		},
+		Data: map[string]string{
+			"RANGE_START": rangeStart,
+			"RANGE_END":   rangeEnd,
+		},
+	}
+
+	_, err := testClient.VirtClient.CoreV1().ConfigMaps(managerNamespace).Create(ctx,
+		configMap, metav1.CreateOptions{})
+	return err
+}
+
+func createTestVM(name string) (*kubevirtv1.VirtualMachine, error) {
+	vm := CreateVMObject(TestNamespace, []kubevirtv1.Interface{newInterface("default", "")}, []kubevirtv1.Network{newNetwork("default")})
+	vm.Name = name
+
+	return testClient.VirtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+}
+
+func getMacAddressFromVM(vm *kubevirtv1.VirtualMachine) (string, error) {
+	updatedVM, err := testClient.VirtClient.VirtualMachine(vm.Namespace).Get(context.Background(),
+		vm.Name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	if len(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces) > 0 {
+		return updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress, nil
+	}
+	return "", nil
+}
+
+func isMacInRange(macStr, rangeStart, rangeEnd string) (bool, error) {
+	if macStr == "" {
+		return false, fmt.Errorf("MAC address cannot be empty")
+	}
+
+	mac, err := net.ParseMAC(macStr)
+	if err != nil {
+		return false, fmt.Errorf("invalid MAC address %q: %w", macStr, err)
+	}
+
+	start, err := net.ParseMAC(rangeStart)
+	if err != nil {
+		return false, fmt.Errorf("invalid range start MAC %q: %w", rangeStart, err)
+	}
+
+	end, err := net.ParseMAC(rangeEnd)
+	if err != nil {
+		return false, fmt.Errorf("invalid range end MAC %q: %w", rangeEnd, err)
+	}
+
+	inRange := bytes.Compare(mac, start) >= 0 && bytes.Compare(mac, end) <= 0
+	return inRange, nil
+}
+
+// BeInMACRange is a custom Gomega matcher that provides descriptive error messages
+// when MAC address range checking fails
+func BeInMACRange(rangeStart, rangeEnd string) types.GomegaMatcher {
+	return &macRangeMatcher{
+		expectedStart: rangeStart,
+		expectedEnd:   rangeEnd,
+	}
+}
+
+type macRangeMatcher struct {
+	expectedStart string
+	expectedEnd   string
+}
+
+func (m *macRangeMatcher) Match(actual interface{}) (success bool, err error) {
+	mac, ok := actual.(string)
+	if !ok {
+		return false, fmt.Errorf("BeInMACRange matcher expects a string, got %T", actual)
+	}
+	return isMacInRange(mac, m.expectedStart, m.expectedEnd)
+}
+
+func (m *macRangeMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected MAC address %s to be in range %s - %s", actual, m.expectedStart, m.expectedEnd)
+}
+
+func (m *macRangeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected MAC address %s NOT to be in range %s - %s", actual, m.expectedStart, m.expectedEnd)
+}
+
+func cleanupTestVMs() {
+	for _, namespace := range []string{TestNamespace, OtherTestNamespace} {
+		vmList, err := testClient.VirtClient.VirtualMachine(namespace).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			continue
+		}
+
+		for _, vm := range vmList.Items {
+			_ = testClient.VirtClient.VirtualMachine(namespace).Delete(context.Background(),
+				vm.Name, metav1.DeleteOptions{})
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a controller that watches the kubemacpool-mac-range configmap (where the ranges are set, and are extracted as env vars on the kubemacpool manager pod) and safely updates the new ranges.

**Special notes for your reviewer**:
In case of invalid range params inserted on day2, the controller will log the errors and will ignore the new suggested range. 

**Release note**:

```release-note
Support day2 range changes
```
