### PR TITLE
tests/vms: Adding ginkgo labels

### DIFF
--- a/tests/virtual_machines_test.go
+++ b/tests/virtual_machines_test.go
@@ -707,7 +707,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 
-		Context("When all the VMs are not serviced by default (opt-in mode)", func() {
+		Context("When all the VMs are not serviced by default (opt-in mode)", Label("vm-opt-in"), func() {
 			BeforeEach(func() {
 				By("setting vm webhook to not accept all namespaces unless they include opt-in label")
 				err := setWebhookOptMode(vmNamespaceOptInLabel, optInMode)
@@ -806,7 +806,7 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 
-		Context("When all the VMs are serviced by default (opt-out mode)", func() {
+		Context("When all the VMs are serviced by default (opt-out mode)", Label("vm-opt-out"), func() {
 			BeforeEach(func() {
 				By("setting vm webhook to accept all namespaces that don't include opt-out label")
 				err := setWebhookOptMode(vmNamespaceOptInLabel, optOutMode)


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows specifically filtering opt-mode test contexts.
Will remove the need for [programmatic skips](https://github.com/kubevirt/cluster-network-addons-operator/blob/main/automation/check-patch.e2e-kubemacpool-functests.sh#L12-L28) in CNAO

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
