### PR TITLE
tests: Add dry run VMI check after cert recovery

### DIFF
--- a/tests/certificates_test.go
+++ b/tests/certificates_test.go
@@ -7,8 +7,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 )
@@ -34,6 +37,9 @@ var _ = Describe("kube-admission library", func() {
 			deleteServiceSecret()
 
 			checkCertLibraryRecovery(oldCABundle, oldSecret)
+
+			By("checking the webhook is functional after certificate recovery")
+			waitForWebhookWithNewCert()
 		})
 
 		It("should be able to recover from mutatingWebhookConfiguration caBundle deletion", func() {
@@ -42,6 +48,9 @@ var _ = Describe("kube-admission library", func() {
 			deleteServiceCaBundle()
 
 			checkCertLibraryRecovery(oldCABundle, oldSecret)
+
+			By("checking the webhook is functional after certificate recovery")
+			waitForWebhookWithNewCert()
 		})
 	})
 })
@@ -119,4 +128,21 @@ func checkCaBundleRecovery(oldCABundle []byte) {
 		}
 		return caBundles, nil
 	}, timeout, pollingInterval).ShouldNot(ContainElement(oldCABundle), "should successfully renew all webhook's caBundles")
+}
+
+func waitForWebhookWithNewCert() {
+	Eventually(func(g Gomega) {
+		vm := CreateVMObject(TestNamespace,
+			[]kubevirtv1.Interface{newInterface("br", "")},
+			[]kubevirtv1.Network{newNetwork("br")})
+		g.Expect(testClient.CRClient.Create(context.Background(), vm, client.DryRunAll)).To(Succeed(),
+			"webhook should accept requests with the new certificate")
+		g.Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress).ToNot(BeEmpty(),
+			"webhook should have allocated a MAC address")
+
+		err := testClient.CRClient.Get(context.Background(),
+			client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, &kubevirtv1.VirtualMachine{})
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+			"dry-run created VM should not be persisted")
+	}, webhookPropagationTimeout, webhookPropagationInterval).Should(Succeed())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The certificate recovery tests (certificates_test.go) verify that a deleted secret/caBundle gets regenerated, but do not wait for the webhook server to actually reload and serve the new certificate. 

Due to kubelet secret volume propagation delay (~60s), subsequent tests can hit "x509: certificate signed by unknown authority" if they call the webhook before the new cert is in place.

This PR adds a probe in checkCertLibraryRecovery that creates a VM via the webhook and retries until it succeeds, ensuring the new certificate is fully operational before the test completes.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
