### PR TITLE
Swap pod MAC collision webhook block with collision detection

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,8 @@ linters:
             - github.com/pkg/errors
             - github.com/prometheus/client_golang
             - github.com/prometheus/common
+            - github.com/k8snetworkplumbingwg/network-attachment-definition-client
+            - gopkg.in/k8snetworkplumbingwg/multus-cni.v3
           deny:
             - pkg: github.com/sirupsen/logrus
               desc: logging is allowed only by logutils.Log

--- a/pkg/controller/add_maccollision.go
+++ b/pkg/controller/add_maccollision.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/vmicollision"
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/maccollision"
 	pool_manager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
 )
 
@@ -29,7 +29,7 @@ func init() {
 
 func addVMICollisionController(mgr manager.Manager, poolManager *pool_manager.PoolManager) error {
 	if poolManager.IsKubevirtEnabled() {
-		return vmicollision.SetupWithManager(mgr, poolManager)
+		return maccollision.SetupWithManager(mgr, poolManager)
 	}
 
 	return nil

--- a/pkg/controller/add_podcollision.go
+++ b/pkg/controller/add_podcollision.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/maccollision"
+	pool_manager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
+)
+
+func init() {
+	AddToManagerFuncs = append(AddToManagerFuncs, addPodCollisionController)
+}
+
+func addPodCollisionController(mgr manager.Manager, poolManager *pool_manager.PoolManager) error {
+	return maccollision.SetupPodControllerWithManager(mgr, poolManager)
+}

--- a/pkg/controller/maccollision/cache.go
+++ b/pkg/controller/maccollision/cache.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vmicollision
+package maccollision
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +23,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var cacheLog = logf.Log.WithName("VMICollision Cache")
+var cacheLog = logf.Log.WithName("MACCollision Cache")
 
 const (
 	// MacAddressIndexName is the index name for MAC address lookups

--- a/pkg/controller/maccollision/cache.go
+++ b/pkg/controller/maccollision/cache.go
@@ -17,10 +17,15 @@ limitations under the License.
 package maccollision
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	netutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 )
 
 var cacheLog = logf.Log.WithName("MACCollision Cache")
@@ -28,6 +33,9 @@ var cacheLog = logf.Log.WithName("MACCollision Cache")
 const (
 	// MacAddressIndexName is the index name for MAC address lookups
 	MacAddressIndexName = "status.interfaces.mac"
+
+	// PodMacAddressIndexName is the index name for Pod MAC address lookups.
+	PodMacAddressIndexName = "annotations.networks.mac"
 )
 
 // StripVMIForCollisionDetection keeps only:
@@ -80,4 +88,74 @@ func IndexVMIByMAC(obj client.Object) []string {
 	}
 
 	return macs
+}
+
+// StripPodForCollisionDetection keeps only fields needed for collision detection,
+// reducing memory for cached Pod objects.
+func StripPodForCollisionDetection(obj interface{}) (interface{}, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	stripped := &corev1.Pod{
+		TypeMeta: pod.TypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        pod.Name,
+			Namespace:   pod.Namespace,
+			UID:         pod.UID,
+			Labels:      pod.Labels,
+			Annotations: pod.Annotations,
+		},
+		Status: corev1.PodStatus{
+			Phase: pod.Status.Phase,
+		},
+	}
+
+	return stripped, nil
+}
+
+// IndexPodByMAC returns all requested MAC addresses from a Pod's multus
+// network-attachment annotation for indexing.
+// Returns nil if multus has not yet processed the Pod (no network-status annotation).
+func IndexPodByMAC(obj client.Object) []string {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	if _, hasStatus := pod.Annotations[networkv1.NetworkStatusAnnot]; !hasStatus {
+		return nil
+	}
+
+	networks, err := netutils.ParsePodNetworkAnnotation(pod)
+	if err != nil {
+		return nil
+	}
+
+	seen := sets.New[string]()
+	var macs []string
+	for _, net := range networks {
+		if net.MacRequest == "" {
+			continue
+		}
+		normalizedMAC, err := NormalizeMacAddress(net.MacRequest)
+		if err != nil {
+			cacheLog.Error(err, "failed to normalize MAC address", "mac", net.MacRequest, "pod", pod.Name, "namespace", pod.Namespace)
+			continue
+		}
+		if seen.Has(normalizedMAC) {
+			continue
+		}
+		seen.Insert(normalizedMAC)
+		macs = append(macs, normalizedMAC)
+	}
+
+	return macs
+}
+
+// IsKubevirtOwned returns true if the Pod is a virt-launcher Pod.
+// These Pods' MACs are already tracked through the VMI collision controller.
+func IsKubevirtOwned(pod *corev1.Pod) bool {
+	return pod.Labels[kubevirtv1.AppLabel] == "virt-launcher"
 }

--- a/pkg/controller/maccollision/cache_test.go
+++ b/pkg/controller/maccollision/cache_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vmicollision_test
+package maccollision_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
-	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/vmicollision"
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/maccollision"
 )
 
 var _ = Describe("StripVMIForCollisionDetection", func() {
@@ -40,7 +40,7 @@ var _ = Describe("StripVMIForCollisionDetection", func() {
 			},
 		}
 
-		result, err := vmicollision.StripVMIForCollisionDetection(vmi)
+		result, err := maccollision.StripVMIForCollisionDetection(vmi)
 		Expect(err).ToNot(HaveOccurred())
 
 		stripped := result.(*kubevirtv1.VirtualMachineInstance)
@@ -62,7 +62,7 @@ var _ = Describe("StripVMIForCollisionDetection", func() {
 			},
 		}
 
-		result, err := vmicollision.StripVMIForCollisionDetection(vmi)
+		result, err := maccollision.StripVMIForCollisionDetection(vmi)
 		Expect(err).ToNot(HaveOccurred())
 
 		stripped := result.(*kubevirtv1.VirtualMachineInstance)
@@ -93,7 +93,7 @@ var _ = Describe("StripVMIForCollisionDetection", func() {
 			},
 		}
 
-		result, err := vmicollision.StripVMIForCollisionDetection(vmi)
+		result, err := maccollision.StripVMIForCollisionDetection(vmi)
 		Expect(err).ToNot(HaveOccurred())
 
 		stripped := result.(*kubevirtv1.VirtualMachineInstance)
@@ -111,7 +111,7 @@ var _ = Describe("StripVMIForCollisionDetection", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "test"},
 		}
 
-		result, err := vmicollision.StripVMIForCollisionDetection(nonVMI)
+		result, err := maccollision.StripVMIForCollisionDetection(nonVMI)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(Equal(nonVMI), "Should return object unchanged")
 	})
@@ -128,7 +128,7 @@ var _ = Describe("IndexVMIByMAC", func() {
 			},
 		}
 
-		macs := vmicollision.IndexVMIByMAC(vmi)
+		macs := maccollision.IndexVMIByMAC(vmi)
 		Expect(macs).To(HaveLen(2))
 		Expect(macs).To(ContainElement("02:00:00:00:00:01"))
 		Expect(macs).To(ContainElement("02:00:00:00:00:02"))
@@ -144,7 +144,7 @@ var _ = Describe("IndexVMIByMAC", func() {
 			},
 		}
 
-		macs := vmicollision.IndexVMIByMAC(vmi)
+		macs := maccollision.IndexVMIByMAC(vmi)
 		Expect(macs).To(HaveLen(2))
 		Expect(macs).To(ContainElement("02:00:00:00:00:aa"))
 		Expect(macs).To(ContainElement("02:00:00:00:00:bb"))
@@ -160,7 +160,7 @@ var _ = Describe("IndexVMIByMAC", func() {
 			},
 		}
 
-		macs := vmicollision.IndexVMIByMAC(vmi)
+		macs := maccollision.IndexVMIByMAC(vmi)
 		Expect(macs).To(HaveLen(1))
 		Expect(macs).To(ContainElement("02:00:00:00:00:01"))
 	})
@@ -172,7 +172,7 @@ var _ = Describe("IndexVMIByMAC", func() {
 			},
 		}
 
-		macs := vmicollision.IndexVMIByMAC(vmi)
+		macs := maccollision.IndexVMIByMAC(vmi)
 		Expect(macs).To(BeEmpty())
 	})
 
@@ -181,7 +181,7 @@ var _ = Describe("IndexVMIByMAC", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "test"},
 		}
 
-		macs := vmicollision.IndexVMIByMAC(nonVMI)
+		macs := maccollision.IndexVMIByMAC(nonVMI)
 		Expect(macs).To(BeNil())
 	})
 })

--- a/pkg/controller/maccollision/cache_test.go
+++ b/pkg/controller/maccollision/cache_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package maccollision_test
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/maccollision"
 )
@@ -185,3 +190,164 @@ var _ = Describe("IndexVMIByMAC", func() {
 		Expect(macs).To(BeNil())
 	})
 })
+
+func podWithProcessedNetworks(name, namespace string, networks []*networkv1.NetworkSelectionElement) *corev1.Pod {
+	pod := podWithPendingNetworks(name, namespace, networks)
+	pod.Annotations[networkv1.NetworkStatusAnnot] = "[]"
+	return pod
+}
+
+func podWithPendingNetworks(name, namespace string, networks []*networkv1.NetworkSelectionElement) *corev1.Pod {
+	annotations := map[string]string{}
+	if networks != nil {
+		netJSON, _ := json.Marshal(networks)
+		annotations[networkv1.NetworkAttachmentAnnot] = string(netJSON)
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+	}
+}
+
+var _ = Describe("StripPodForCollisionDetection", func() {
+	It("should keep essential metadata and phase", func() {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "test-ns",
+				UID:       types.UID("pod-uid-123"),
+				Labels:    map[string]string{"app": "test"},
+				Annotations: map[string]string{
+					networkv1.NetworkAttachmentAnnot: `[{"name":"net1","mac":"02:00:00:00:00:01"}]`,
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "worker-1",
+			},
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodRunning,
+				PodIP:  "10.0.0.1",
+				HostIP: "192.168.1.1",
+			},
+		}
+
+		result, err := maccollision.StripPodForCollisionDetection(pod)
+		Expect(err).ToNot(HaveOccurred())
+
+		stripped := result.(*corev1.Pod)
+		Expect(stripped.Name).To(Equal("test-pod"))
+		Expect(stripped.Namespace).To(Equal("test-ns"))
+		Expect(stripped.UID).To(Equal(types.UID("pod-uid-123")))
+		Expect(stripped.Annotations).To(HaveKey(networkv1.NetworkAttachmentAnnot))
+		Expect(stripped.Labels).To(HaveKeyWithValue("app", "test"))
+		Expect(stripped.Status.Phase).To(Equal(corev1.PodRunning))
+		Expect(stripped.OwnerReferences).To(BeEmpty(), "OwnerReferences should be stripped")
+		Expect(stripped.Spec.NodeName).To(BeEmpty(), "Spec should be stripped")
+		Expect(stripped.Status.PodIP).To(BeEmpty(), "PodIP should be stripped")
+	})
+
+	It("should handle non-Pod objects gracefully", func() {
+		vmi := &kubevirtv1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		}
+
+		result, err := maccollision.StripPodForCollisionDetection(vmi)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(vmi), "Should return object unchanged")
+	})
+})
+
+var _ = Describe("IndexPodByMAC", func() {
+	It("should return MAC addresses from network-attachment annotation", func() {
+		pod := podWithProcessedNetworks("pod1", "ns1", []*networkv1.NetworkSelectionElement{
+			{Name: "net1", MacRequest: "02:00:00:00:00:01"},
+			{Name: "net2", MacRequest: "02:00:00:00:00:02"},
+		})
+
+		macs := maccollision.IndexPodByMAC(pod)
+		Expect(macs).To(HaveLen(2))
+		Expect(macs).To(ContainElement("02:00:00:00:00:01"))
+		Expect(macs).To(ContainElement("02:00:00:00:00:02"))
+	})
+
+	It("should normalize MAC addresses to lowercase", func() {
+		pod := podWithProcessedNetworks("pod1", "ns1", []*networkv1.NetworkSelectionElement{
+			{Name: "net1", MacRequest: "02:00:00:00:00:AA"},
+		})
+
+		macs := maccollision.IndexPodByMAC(pod)
+		Expect(macs).To(HaveLen(1))
+		Expect(macs).To(ContainElement("02:00:00:00:00:aa"))
+	})
+
+	It("should skip networks without MacRequest", func() {
+		pod := podWithProcessedNetworks("pod1", "ns1", []*networkv1.NetworkSelectionElement{
+			{Name: "net1", MacRequest: "02:00:00:00:00:01"},
+			{Name: "net2"},
+		})
+
+		macs := maccollision.IndexPodByMAC(pod)
+		Expect(macs).To(HaveLen(1))
+		Expect(macs).To(ContainElement("02:00:00:00:00:01"))
+	})
+
+	It("should deduplicate MACs within the same pod", func() {
+		pod := podWithProcessedNetworks("pod1", "ns1", []*networkv1.NetworkSelectionElement{
+			{Name: "net1", MacRequest: "02:00:00:00:00:01"},
+			{Name: "net2", MacRequest: "02:00:00:00:00:01"},
+		})
+
+		macs := maccollision.IndexPodByMAC(pod)
+		Expect(macs).To(HaveLen(1))
+		Expect(macs).To(ContainElement("02:00:00:00:00:01"))
+	})
+
+	It("should return nil when network-status annotation is absent", func() {
+		pod := podWithPendingNetworks("pod1", "ns1", []*networkv1.NetworkSelectionElement{
+			{Name: "net1", MacRequest: "02:00:00:00:00:01"},
+		})
+
+		macs := maccollision.IndexPodByMAC(pod)
+		Expect(macs).To(BeNil())
+	})
+
+	It("should return nil for non-Pod objects", func() {
+		vmi := &kubevirtv1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		}
+
+		macs := maccollision.IndexPodByMAC(vmi)
+		Expect(macs).To(BeNil())
+	})
+
+	It("should return nil when no network-attachment annotation exists", func() {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod1",
+				Namespace: "ns1",
+				Annotations: map[string]string{
+					networkv1.NetworkStatusAnnot: "[]",
+				},
+			},
+		}
+
+		macs := maccollision.IndexPodByMAC(pod)
+		Expect(macs).To(BeNil())
+	})
+})
+
+var _ = DescribeTable("IsKubevirtOwned",
+	func(labels map[string]string, expected bool) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels},
+		}
+		Expect(maccollision.IsKubevirtOwned(pod)).To(Equal(expected))
+	},
+	Entry("virt-launcher pod", map[string]string{kubevirtv1.AppLabel: "virt-launcher"}, true),
+	Entry("different kubevirt.io label value", map[string]string{kubevirtv1.AppLabel: "hotplug-disk"}, false),
+	Entry("no kubevirt labels", map[string]string{"app": "my-app"}, false),
+	Entry("no labels at all", nil, false),
+)

--- a/pkg/controller/maccollision/mac.go
+++ b/pkg/controller/maccollision/mac.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vmicollision
+package maccollision
 
 import "net"
 

--- a/pkg/controller/maccollision/migration.go
+++ b/pkg/controller/maccollision/migration.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vmicollision
+package maccollision
 
 import (
 	"fmt"
@@ -24,7 +24,7 @@ import (
 )
 
 // filterOutDecentralizedMigrations filters out VMIs that share MACs due to decentralized migration, returning only real collisions
-func (r *VMICollisionReconciler) filterOutDecentralizedMigrations(reconciledVMI *kubevirtv1.VirtualMachineInstance, duplicates []*kubevirtv1.VirtualMachineInstance, logger logr.Logger) []*kubevirtv1.VirtualMachineInstance {
+func (r *VMIReconciler) filterOutDecentralizedMigrations(reconciledVMI *kubevirtv1.VirtualMachineInstance, duplicates []*kubevirtv1.VirtualMachineInstance, logger logr.Logger) []*kubevirtv1.VirtualMachineInstance {
 	reconciledSourceUID, reconciledTargetUID := extractMigrationUIDs(reconciledVMI)
 	if reconciledSourceUID == "" && reconciledTargetUID == "" {
 		// No active migration on reconciled VMI, all duplicates are real collisions

--- a/pkg/controller/maccollision/pod_candidates.go
+++ b/pkg/controller/maccollision/pod_candidates.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maccollision
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func listRunningPodsWithMAC(ctx context.Context, k8sClient client.Client, normalizedMAC string) ([]*corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(ctx, podList, client.MatchingFields{PodMacAddressIndexName: normalizedMAC}); err != nil {
+		return nil, errors.Wrap(err, "failed to list Pods by MAC")
+	}
+
+	var runningPods []*corev1.Pod
+	for i := range podList.Items {
+		p := &podList.Items[i]
+		if p.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		runningPods = append(runningPods, p)
+	}
+
+	return runningPods, nil
+}
+
+func excludePodUID(pods []*corev1.Pod, excludeUID types.UID) []*corev1.Pod {
+	var filtered []*corev1.Pod
+	for _, p := range pods {
+		if p.UID == excludeUID {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
+}
+
+func filterCollisionCandidatePods(pods []*corev1.Pod, reconciledNamespace string, poolManager PoolManagerInterface, logger logr.Logger) []*corev1.Pod {
+	managedNamespaces := sets.New[string](reconciledNamespace)
+
+	var filtered []*corev1.Pod
+	for _, p := range pods {
+		if IsKubevirtOwned(p) {
+			logger.V(1).Info("Filtering out kubevirt-owned pod", "pod", p.Name, "namespace", p.Namespace)
+			continue
+		}
+
+		if managedNamespaces.Has(p.Namespace) {
+			filtered = append(filtered, p)
+			continue
+		}
+
+		managed, err := poolManager.IsPodManaged(p.Namespace)
+		if err != nil {
+			logger.Error(err, "Failed to check if pod namespace is managed, including in collisions",
+				"namespace", p.Namespace, "pod", p.Name)
+			filtered = append(filtered, p)
+			managedNamespaces.Insert(p.Namespace)
+			continue
+		}
+
+		if !managed {
+			logger.V(1).Info("Filtering out pod from unmanaged namespace",
+				"namespace", p.Namespace, "pod", p.Name)
+			continue
+		}
+
+		managedNamespaces.Insert(p.Namespace)
+		filtered = append(filtered, p)
+	}
+
+	return filtered
+}

--- a/pkg/controller/maccollision/pod_controller.go
+++ b/pkg/controller/maccollision/pod_controller.go
@@ -88,8 +88,45 @@ func SetupPodControllerWithManager(mgr manager.Manager, poolManager *pool_manage
 		return fmt.Errorf("failed to watch Pods: %w", err)
 	}
 
+	if r.poolManager.IsKubevirtEnabled() {
+		err = c.Watch(
+			source.Kind(
+				mgr.GetCache(),
+				&kubevirtv1.VirtualMachineInstance{},
+				handler.TypedEnqueueRequestsFromMapFunc(r.mapVMIToPods),
+				collisionRelevantChanges(),
+			),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to watch VMIs for Pod cross-type collisions: %w", err)
+		}
+	}
+
 	podLog.Info("Successfully registered MAC collision Pod controller")
 	return nil
+}
+
+func (r *PodReconciler) mapVMIToPods(ctx context.Context, vmi *kubevirtv1.VirtualMachineInstance) []reconcile.Request {
+	macs := IndexVMIByMAC(vmi)
+
+	var requests []reconcile.Request
+	seen := map[types.NamespacedName]struct{}{}
+	for _, mac := range macs {
+		var podList corev1.PodList
+		if err := r.List(ctx, &podList, client.MatchingFields{PodMacAddressIndexName: mac}); err != nil {
+			podLog.Error(err, "failed to list Pods by MAC for cross-type enqueue", "mac", mac)
+			continue
+		}
+		for i := range podList.Items {
+			key := types.NamespacedName{Namespace: podList.Items[i].Namespace, Name: podList.Items[i].Name}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			requests = append(requests, reconcile.Request{NamespacedName: key})
+		}
+	}
+	return requests
 }
 
 // Reconcile handles Pod reconciliation for collision detection.

--- a/pkg/controller/maccollision/pod_controller.go
+++ b/pkg/controller/maccollision/pod_controller.go
@@ -18,12 +18,17 @@ package maccollision
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
+	"sort"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -38,6 +43,7 @@ var podLog = logf.Log.WithName("MACCollision Pod Controller")
 type PodReconciler struct {
 	client.Client
 	poolManager PoolManagerInterface
+	recorder    record.EventRecorder
 }
 
 // SetupPodControllerWithManager sets up the Pod collision controller with the Manager.
@@ -45,6 +51,7 @@ func SetupPodControllerWithManager(mgr manager.Manager, poolManager *pool_manage
 	r := &PodReconciler{
 		Client:      mgr.GetClient(),
 		poolManager: poolManager,
+		recorder:    mgr.GetEventRecorderFor("kubemacpool"),
 	}
 
 	if err := mgr.GetFieldIndexer().IndexField(
@@ -75,8 +82,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	err := r.Get(ctx, req.NamespacedName, pod)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.V(1).Info("Pod not found, assuming deleted")
-			// TODO: Handle Pod deletion (remove from collision tracking)
+			logger.V(1).Info("Pod not found, assuming deleted, removing from collision tracking")
+			r.removePodFromAllCollisions(req.Namespace, req.Name)
 			return reconcile.Result{}, nil
 		}
 		logger.Error(err, "Failed to get Pod")
@@ -98,19 +105,147 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return reconcile.Result{}, nil
 	}
 
-	// TODO: Implement collision detection logic
-	// This will be implemented in subsequent commits:
-	// - Check if Pod is Running
-	// - Find other Pods with same MAC addresses
-	// - Update collision tracking in PoolManager
-	// - Emit collision events
-
-	r.checkMACCollisions(ctx, pod, logger)
+	if err = r.checkMACCollisions(ctx, pod, logger); err != nil {
+		logger.Error(err, "Failed to check MAC collisions")
+		return reconcile.Result{}, errors.Wrap(err, "failed to check MAC collisions")
+	}
 
 	return reconcile.Result{}, nil
 }
 
-func (r *PodReconciler) checkMACCollisions(ctx context.Context, pod *corev1.Pod, logger logr.Logger) {
-	// TODO: Implement collision detection logic
-	logger.V(1).Info("Collision detection not yet implemented")
+func (r *PodReconciler) checkMACCollisions(ctx context.Context, pod *corev1.Pod, logger logr.Logger) error {
+	if pod.Status.Phase != corev1.PodRunning {
+		logger.V(1).Info("Pod not running, removing from collision tracking", "phase", pod.Status.Phase)
+		r.removePodFromAllCollisions(pod.Namespace, pod.Name)
+		return nil
+	}
+
+	macs := r.extractMACsFromPod(pod)
+	if len(macs) == 0 {
+		logger.V(1).Info("Pod has no MAC addresses, skipping collision check")
+		return nil
+	}
+
+	allCollisionsButOwn := make(map[string][]pool_manager.ObjectReference)
+	for mac := range macs {
+		collidingPods, err := r.findRunningPodsWithMAC(ctx, mac, pod.UID, logger)
+		if err != nil {
+			return errors.Wrapf(err, "failed to find Pods with MAC %s", mac)
+		}
+
+		collidingPods = r.filterPodsForCollision(collidingPods, pod.Namespace, logger)
+
+		if len(collidingPods) > 0 {
+			var refs []pool_manager.ObjectReference
+			for _, p := range collidingPods {
+				refs = append(refs, podObjectRef(p.Namespace, p.Name))
+			}
+
+			logger.Info("Found MAC collision", "mac", mac, "collisionCount", len(refs))
+			allCollisionsButOwn[mac] = refs
+			r.emitCollisionEvents(pod, mac, collidingPods)
+		}
+	}
+
+	r.poolManager.UpdateCollisionsMap(podObjectRef(pod.Namespace, pod.Name), allCollisionsButOwn)
+	return nil
+}
+
+func (r *PodReconciler) extractMACsFromPod(pod *corev1.Pod) map[string]struct{} {
+	indexMACs := IndexPodByMAC(pod)
+	macs := make(map[string]struct{}, len(indexMACs))
+	for _, mac := range indexMACs {
+		macs[mac] = struct{}{}
+	}
+	return macs
+}
+
+func (r *PodReconciler) findRunningPodsWithMAC(ctx context.Context, normalizedMAC string, excludeUID types.UID, logger logr.Logger) ([]*corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList, client.MatchingFields{PodMacAddressIndexName: normalizedMAC}); err != nil {
+		return nil, errors.Wrap(err, "failed to list Pods by MAC")
+	}
+
+	var runningPods []*corev1.Pod
+	for i := range podList.Items {
+		p := &podList.Items[i]
+		if p.UID == excludeUID {
+			continue
+		}
+		if p.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		runningPods = append(runningPods, p)
+	}
+
+	return runningPods, nil
+}
+
+func (r *PodReconciler) filterPodsForCollision(pods []*corev1.Pod, reconciledNamespace string, logger logr.Logger) []*corev1.Pod {
+	managedNamespaces := map[string]struct{}{
+		reconciledNamespace: {},
+	}
+
+	var filtered []*corev1.Pod
+	for _, p := range pods {
+		if IsKubevirtOwned(p) {
+			logger.V(1).Info("Filtering out kubevirt-owned pod", "pod", p.Name, "namespace", p.Namespace)
+			continue
+		}
+
+		if _, alreadyChecked := managedNamespaces[p.Namespace]; alreadyChecked {
+			filtered = append(filtered, p)
+			continue
+		}
+
+		isManaged, err := r.poolManager.IsPodManaged(p.Namespace)
+		if err != nil {
+			logger.Error(err, "Failed to check if pod namespace is managed, including in collisions",
+				"namespace", p.Namespace, "pod", p.Name)
+			filtered = append(filtered, p)
+			managedNamespaces[p.Namespace] = struct{}{}
+			continue
+		}
+
+		if !isManaged {
+			logger.V(1).Info("Filtering out pod from unmanaged namespace",
+				"namespace", p.Namespace, "pod", p.Name)
+			continue
+		}
+
+		managedNamespaces[p.Namespace] = struct{}{}
+		filtered = append(filtered, p)
+	}
+
+	return filtered
+}
+
+func (r *PodReconciler) emitCollisionEvents(pod *corev1.Pod, mac string, collidingPods []*corev1.Pod) {
+	selfRef := podObjectRef(pod.Namespace, pod.Name)
+	all := []string{selfRef.Key()}
+	for _, p := range collidingPods {
+		all = append(all, podObjectRef(p.Namespace, p.Name).Key())
+	}
+
+	sort.Strings(all)
+
+	message := fmt.Sprintf("MAC %s: Collision between %s", mac, strings.Join(all, ", "))
+
+	r.recorder.Event(pod, corev1.EventTypeWarning, "MACCollision", message)
+
+	for _, p := range collidingPods {
+		r.recorder.Event(p, corev1.EventTypeWarning, "MACCollision", message)
+	}
+}
+
+func (r *PodReconciler) removePodFromAllCollisions(namespace, name string) {
+	r.poolManager.UpdateCollisionsMap(podObjectRef(namespace, name), nil)
+}
+
+func podObjectRef(namespace, name string) pool_manager.ObjectReference {
+	return pool_manager.ObjectReference{
+		Type:      pool_manager.ObjectTypePod,
+		Namespace: namespace,
+		Name:      name,
+	}
 }

--- a/pkg/controller/maccollision/pod_controller.go
+++ b/pkg/controller/maccollision/pod_controller.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -147,22 +148,31 @@ func (r *PodReconciler) checkMACCollisions(ctx context.Context, pod *corev1.Pod,
 
 	allCollisionsButOwn := make(map[string][]pool_manager.ObjectReference)
 	for mac := range macs {
+		var refs []pool_manager.ObjectReference
+
 		collidingPods, err := r.findRunningPodsWithMAC(ctx, mac, pod.UID, logger)
 		if err != nil {
 			return errors.Wrapf(err, "failed to find Pods with MAC %s", mac)
 		}
-
 		collidingPods = r.filterPodsForCollision(collidingPods, pod.Namespace, logger)
+		for _, p := range collidingPods {
+			refs = append(refs, podObjectRef(p.Namespace, p.Name))
+		}
 
-		if len(collidingPods) > 0 {
-			var refs []pool_manager.ObjectReference
-			for _, p := range collidingPods {
-				refs = append(refs, podObjectRef(p.Namespace, p.Name))
+		if r.poolManager.IsKubevirtEnabled() {
+			collidingVMIs, err := r.filterVMIsWithMAC(ctx, mac, logger)
+			if err != nil {
+				return errors.Wrapf(err, "failed to find VMIs with MAC %s", mac)
 			}
+			for _, v := range collidingVMIs {
+				refs = append(refs, vmiObjectRef(v.Namespace, v.Name))
+			}
+		}
 
+		if len(refs) > 0 {
 			logger.Info("Found MAC collision", "mac", mac, "collisionCount", len(refs))
 			allCollisionsButOwn[mac] = refs
-			r.emitCollisionEvents(pod, mac, collidingPods)
+			r.emitCollisionEvents(pod, mac, collidingPods, refs)
 		}
 	}
 
@@ -239,13 +249,20 @@ func (r *PodReconciler) filterPodsForCollision(pods []*corev1.Pod, reconciledNam
 	return filtered
 }
 
-func (r *PodReconciler) emitCollisionEvents(pod *corev1.Pod, mac string, collidingPods []*corev1.Pod) {
+func (r *PodReconciler) filterVMIsWithMAC(ctx context.Context, normalizedMAC string, logger logr.Logger) ([]*kubevirtv1.VirtualMachineInstance, error) {
+	runningVMIs, err := listRunningVMIsByMAC(ctx, r.Client, normalizedMAC)
+	if err != nil {
+		return nil, err
+	}
+	return filterManagedVMIs(runningVMIs, nil, r.poolManager, logger), nil
+}
+
+func (r *PodReconciler) emitCollisionEvents(pod *corev1.Pod, mac string, collidingPods []*corev1.Pod, colliderRefs []pool_manager.ObjectReference) {
 	selfRef := podObjectRef(pod.Namespace, pod.Name)
 	all := []string{selfRef.Key()}
-	for _, p := range collidingPods {
-		all = append(all, podObjectRef(p.Namespace, p.Name).Key())
+	for _, ref := range colliderRefs {
+		all = append(all, ref.Key())
 	}
-
 	sort.Strings(all)
 
 	message := fmt.Sprintf("MAC %s: Collision between %s", mac, strings.Join(all, ", "))

--- a/pkg/controller/maccollision/pod_controller.go
+++ b/pkg/controller/maccollision/pod_controller.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maccollision
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	pool_manager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
+)
+
+var podLog = logf.Log.WithName("MACCollision Pod Controller")
+
+// PodReconciler watches Pod objects and detects MAC address collisions.
+type PodReconciler struct {
+	client.Client
+	poolManager PoolManagerInterface
+}
+
+// SetupPodControllerWithManager sets up the Pod collision controller with the Manager.
+func SetupPodControllerWithManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) error {
+	r := &PodReconciler{
+		Client:      mgr.GetClient(),
+		poolManager: poolManager,
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&corev1.Pod{},
+		PodMacAddressIndexName,
+		IndexPodByMAC,
+	); err != nil {
+		return errors.Wrap(err, "failed to setup Pod MAC address indexer")
+	}
+
+	podLog.Info("Successfully registered MAC address indexer for Pod collision detection")
+
+	// TODO: Build controller with watches and event handlers
+	// This will be implemented in subsequent commits
+
+	_ = r
+	return nil
+}
+
+// Reconcile handles Pod reconciliation for collision detection.
+func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	reconcileRequestId := rand.Intn(100000)
+	logger := podLog.WithName("Reconcile").WithValues("RequestId", reconcileRequestId, "pod-collision-detect", req.NamespacedName)
+	logger.V(1).Info("Reconciling Pod for collision detection")
+
+	pod := &corev1.Pod{}
+	err := r.Get(ctx, req.NamespacedName, pod)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(1).Info("Pod not found, assuming deleted")
+			// TODO: Handle Pod deletion (remove from collision tracking)
+			return reconcile.Result{}, nil
+		}
+		logger.Error(err, "Failed to get Pod")
+		return reconcile.Result{}, errors.Wrapf(err, "failed to get Pod %s", req.NamespacedName)
+	}
+
+	if IsKubevirtOwned(pod) {
+		logger.V(1).Info("Pod is virt-launcher, skipping (tracked via VMI controller)")
+		return reconcile.Result{}, nil
+	}
+
+	isManaged, err := r.poolManager.IsPodManaged(pod.Namespace)
+	if err != nil {
+		logger.Error(err, "Failed to check if namespace is managed")
+		return reconcile.Result{}, errors.Wrapf(err, "failed to check if namespace %s is managed", pod.Namespace)
+	}
+	if !isManaged {
+		logger.V(1).Info("Pod namespace not managed by kubemacpool, skipping")
+		return reconcile.Result{}, nil
+	}
+
+	// TODO: Implement collision detection logic
+	// This will be implemented in subsequent commits:
+	// - Check if Pod is Running
+	// - Find other Pods with same MAC addresses
+	// - Update collision tracking in PoolManager
+	// - Emit collision events
+
+	r.checkMACCollisions(ctx, pod, logger)
+
+	return reconcile.Result{}, nil
+}
+
+func (r *PodReconciler) checkMACCollisions(ctx context.Context, pod *corev1.Pod, logger logr.Logger) {
+	// TODO: Implement collision detection logic
+	logger.V(1).Info("Collision detection not yet implemented")
+}

--- a/pkg/controller/maccollision/pod_controller.go
+++ b/pkg/controller/maccollision/pod_controller.go
@@ -30,9 +30,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	pool_manager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
 )
@@ -65,10 +68,26 @@ func SetupPodControllerWithManager(mgr manager.Manager, poolManager *pool_manage
 
 	podLog.Info("Successfully registered MAC address indexer for Pod collision detection")
 
-	// TODO: Build controller with watches and event handlers
-	// This will be implemented in subsequent commits
+	c, err := controller.New("maccollision-pod-controller", mgr, controller.Options{
+		Reconciler: r,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create MAC collision Pod controller: %w", err)
+	}
 
-	_ = r
+	err = c.Watch(
+		source.Kind(
+			mgr.GetCache(),
+			&corev1.Pod{},
+			&handler.TypedEnqueueRequestForObject[*corev1.Pod]{},
+			podCollisionRelevantChanges(),
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to watch Pods: %w", err)
+	}
+
+	podLog.Info("Successfully registered MAC collision Pod controller")
 	return nil
 }
 

--- a/pkg/controller/maccollision/pod_controller.go
+++ b/pkg/controller/maccollision/pod_controller.go
@@ -190,63 +190,15 @@ func (r *PodReconciler) extractMACsFromPod(pod *corev1.Pod) map[string]struct{} 
 }
 
 func (r *PodReconciler) findRunningPodsWithMAC(ctx context.Context, normalizedMAC string, excludeUID types.UID, logger logr.Logger) ([]*corev1.Pod, error) {
-	podList := &corev1.PodList{}
-	if err := r.List(ctx, podList, client.MatchingFields{PodMacAddressIndexName: normalizedMAC}); err != nil {
-		return nil, errors.Wrap(err, "failed to list Pods by MAC")
+	runningPods, err := listRunningPodsWithMAC(ctx, r.Client, normalizedMAC)
+	if err != nil {
+		return nil, err
 	}
-
-	var runningPods []*corev1.Pod
-	for i := range podList.Items {
-		p := &podList.Items[i]
-		if p.UID == excludeUID {
-			continue
-		}
-		if p.Status.Phase != corev1.PodRunning {
-			continue
-		}
-		runningPods = append(runningPods, p)
-	}
-
-	return runningPods, nil
+	return excludePodUID(runningPods, excludeUID), nil
 }
 
 func (r *PodReconciler) filterPodsForCollision(pods []*corev1.Pod, reconciledNamespace string, logger logr.Logger) []*corev1.Pod {
-	managedNamespaces := map[string]struct{}{
-		reconciledNamespace: {},
-	}
-
-	var filtered []*corev1.Pod
-	for _, p := range pods {
-		if IsKubevirtOwned(p) {
-			logger.V(1).Info("Filtering out kubevirt-owned pod", "pod", p.Name, "namespace", p.Namespace)
-			continue
-		}
-
-		if _, alreadyChecked := managedNamespaces[p.Namespace]; alreadyChecked {
-			filtered = append(filtered, p)
-			continue
-		}
-
-		isManaged, err := r.poolManager.IsPodManaged(p.Namespace)
-		if err != nil {
-			logger.Error(err, "Failed to check if pod namespace is managed, including in collisions",
-				"namespace", p.Namespace, "pod", p.Name)
-			filtered = append(filtered, p)
-			managedNamespaces[p.Namespace] = struct{}{}
-			continue
-		}
-
-		if !isManaged {
-			logger.V(1).Info("Filtering out pod from unmanaged namespace",
-				"namespace", p.Namespace, "pod", p.Name)
-			continue
-		}
-
-		managedNamespaces[p.Namespace] = struct{}{}
-		filtered = append(filtered, p)
-	}
-
-	return filtered
+	return filterCollisionCandidatePods(pods, reconciledNamespace, r.poolManager, logger)
 }
 
 func (r *PodReconciler) filterVMIsWithMAC(ctx context.Context, normalizedMAC string, logger logr.Logger) ([]*kubevirtv1.VirtualMachineInstance, error) {

--- a/pkg/controller/maccollision/pod_controller_test.go
+++ b/pkg/controller/maccollision/pod_controller_test.go
@@ -114,17 +114,21 @@ func newTestPod(namespace, name string, opts ...podOption) *corev1.Pod {
 func setupPodReconciler(mockPoolManager *MockPoolManager, objects ...client.Object) (*PodReconciler, *PodMockEventRecorder) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
+	_ = kubevirtv1.AddToScheme(scheme)
 
-	fakeClient := fake.NewClientBuilder().
+	builder := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objects...).
-		WithIndex(&corev1.Pod{}, PodMacAddressIndexName, IndexPodByMAC).
-		Build()
+		WithIndex(&corev1.Pod{}, PodMacAddressIndexName, IndexPodByMAC)
+
+	if mockPoolManager.kubevirtEnabled {
+		builder = builder.WithIndex(&kubevirtv1.VirtualMachineInstance{}, MacAddressIndexName, IndexVMIByMAC)
+	}
 
 	mockRecorder := &PodMockEventRecorder{Events: []MockEvent{}}
 
 	reconciler := &PodReconciler{
-		Client:      fakeClient,
+		Client:      builder.Build(),
 		poolManager: mockPoolManager,
 		recorder:    mockRecorder,
 	}
@@ -151,6 +155,7 @@ var _ = Describe("Pod Collision Controller", func() {
 		mockPoolManager = &MockPoolManager{
 			isPodManagedCalls: []string{},
 			managedNamespaces: nil,
+			kubevirtEnabled:   false,
 		}
 		ctx = context.Background()
 	})
@@ -381,6 +386,135 @@ var _ = Describe("Pod Collision Controller", func() {
 					Reason:          "MACCollision",
 					Message:         expectedMessage,
 				}))
+			})
+		})
+
+		Context("cross-type Pod-VMI collision detection", func() {
+			BeforeEach(func() {
+				mockPoolManager.kubevirtEnabled = true
+			})
+
+			It("should detect collision between Pod and running VMI", func() {
+				pod := newTestPod(testNamespace, testPodName,
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				vmi := newVMI(testNamespace, "colliding-vmi",
+					withPhase(kubevirtv1.Running),
+					withMACs(testMAC1))
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod, vmi)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testPodName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(mockRecorder.Events).To(HaveLen(1))
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between pod/%s/%s, vmi/%s/colliding-vmi",
+					testMAC1, testNamespace, testPodName, testNamespace)
+				Expect(mockRecorder.Events[0]).To(Equal(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      testPodName,
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+			})
+
+			It("should not detect collision with non-running VMI", func() {
+				pod := newTestPod(testNamespace, testPodName,
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				vmi := newVMI(testNamespace, "pending-vmi",
+					withPhase(kubevirtv1.Pending),
+					withMACs(testMAC1))
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod, vmi)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testPodName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+
+			It("should detect collision with both Pods and VMIs for the same MAC", func() {
+				pod1 := newTestPod(testNamespace, "pod1",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				pod2 := newTestPod(testNamespace, "pod2",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				vmi := newVMI(testNamespace, "vmi1",
+					withPhase(kubevirtv1.Running),
+					withMACs(testMAC1))
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod1, pod2, vmi)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(mockRecorder.Events).To(HaveLen(2))
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between pod/%s/pod1, pod/%s/pod2, vmi/%s/vmi1",
+					testMAC1, testNamespace, testNamespace, testNamespace)
+
+				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      "pod1",
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      "pod2",
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+			})
+
+			It("should filter out VMI from unmanaged namespace", func() {
+				pod := newTestPod("managed-ns", testPodName,
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				vmi := newVMI("unmanaged-ns", "vmi1",
+					withPhase(kubevirtv1.Running),
+					withMACs(testMAC1))
+				mockPoolManager.managedNamespaces = map[string]bool{
+					"managed-ns":   true,
+					"unmanaged-ns": false,
+				}
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod, vmi)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "managed-ns", Name: testPodName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+
+			It("should not query VMI index when kubevirt is disabled", func() {
+				mockPoolManager.kubevirtEnabled = false
+				pod := newTestPod(testNamespace, testPodName,
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testPodName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
 			})
 		})
 	})

--- a/pkg/controller/maccollision/pod_controller_test.go
+++ b/pkg/controller/maccollision/pod_controller_test.go
@@ -1,0 +1,387 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maccollision
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+)
+
+type PodMockEventRecorder struct {
+	Events []MockEvent
+}
+
+func (m *PodMockEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	pod, ok := object.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	m.Events = append(m.Events, MockEvent{
+		ObjectNamespace: pod.Namespace,
+		ObjectName:      pod.Name,
+		Type:            eventtype,
+		Reason:          reason,
+		Message:         message,
+	})
+}
+
+func (m *PodMockEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	m.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (m *PodMockEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	m.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+type podOption func(*corev1.Pod)
+
+func withPodPhase(phase corev1.PodPhase) podOption {
+	return func(pod *corev1.Pod) {
+		pod.Status.Phase = phase
+	}
+}
+
+func withPodMACs(macs ...string) podOption {
+	return func(pod *corev1.Pod) {
+		var networks []*networkv1.NetworkSelectionElement
+		for i, mac := range macs {
+			networks = append(networks, &networkv1.NetworkSelectionElement{
+				Name:       fmt.Sprintf("net%d", i),
+				MacRequest: mac,
+			})
+		}
+		netJSON, _ := json.Marshal(networks)
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		pod.Annotations[networkv1.NetworkAttachmentAnnot] = string(netJSON)
+		pod.Annotations[networkv1.NetworkStatusAnnot] = "[]"
+	}
+}
+
+func withVirtLauncherLabel() podOption {
+	return func(pod *corev1.Pod) {
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
+		}
+		pod.Labels[kubevirtv1.AppLabel] = "virt-launcher"
+	}
+}
+
+func newTestPod(namespace, name string, opts ...podOption) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(namespace + "-" + name + "-uid"),
+		},
+	}
+	for _, opt := range opts {
+		opt(pod)
+	}
+	return pod
+}
+
+func setupPodReconciler(mockPoolManager *MockPoolManager, objects ...client.Object) (*PodReconciler, *PodMockEventRecorder) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithIndex(&corev1.Pod{}, PodMacAddressIndexName, IndexPodByMAC).
+		Build()
+
+	mockRecorder := &PodMockEventRecorder{Events: []MockEvent{}}
+
+	reconciler := &PodReconciler{
+		Client:      fakeClient,
+		poolManager: mockPoolManager,
+		recorder:    mockRecorder,
+	}
+
+	return reconciler, mockRecorder
+}
+
+var _ = Describe("Pod Collision Controller", func() {
+	const (
+		testNamespace = "test-ns"
+		testPodName   = "test-pod"
+		testMAC1      = "aa:bb:cc:dd:ee:01"
+		testMAC2      = "aa:bb:cc:dd:ee:02"
+	)
+
+	var (
+		mockPoolManager *MockPoolManager
+		mockRecorder    *PodMockEventRecorder
+		reconciler      *PodReconciler
+		ctx             context.Context
+	)
+
+	BeforeEach(func() {
+		mockPoolManager = &MockPoolManager{
+			isPodManagedCalls: []string{},
+			managedNamespaces: nil,
+		}
+		ctx = context.Background()
+	})
+
+	Describe("Reconcile", func() {
+		Context("when Pod is not found", func() {
+			It("should clean up collision tracking", func() {
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: "non-existent"},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+		})
+
+		Context("when Pod is a virt-launcher", func() {
+			It("should skip without checking namespace", func() {
+				pod := newTestPod(testNamespace, testPodName,
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1),
+					withVirtLauncherLabel())
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testPodName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockPoolManager.isPodManagedCalls).To(BeEmpty())
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+		})
+
+		Context("when Pod is in non-managed namespace", func() {
+			It("should skip collision detection", func() {
+				pod := newTestPod(testNamespace, testPodName,
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				mockPoolManager.managedNamespaces = map[string]bool{testNamespace: false}
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testPodName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+		})
+
+		Context("when Pod is not running", func() {
+			It("should clean up collision tracking", func() {
+				pod := newTestPod(testNamespace, testPodName,
+					withPodPhase(corev1.PodPending),
+					withPodMACs(testMAC1))
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testPodName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+		})
+
+		Context("when Pod is running with no collisions", func() {
+			It("should report no collisions", func() {
+				pod := newTestPod(testNamespace, testPodName,
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testPodName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+		})
+
+		Context("when Pod has MAC collision with another running Pod", func() {
+			It("should emit events on all colliding Pods", func() {
+				pod1 := newTestPod(testNamespace, "pod1",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				pod2 := newTestPod(testNamespace, "pod2",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod1, pod2)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(mockRecorder.Events).To(HaveLen(2))
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between pod/%s/pod1, pod/%s/pod2",
+					testMAC1, testNamespace, testNamespace)
+
+				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      "pod1",
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      "pod2",
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+
+				Expect(mockRecorder.Events[0].Message).To(Equal(mockRecorder.Events[1].Message))
+			})
+		})
+
+		Context("when colliding Pod is not running", func() {
+			It("should not report collision", func() {
+				pod1 := newTestPod(testNamespace, "pod1",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				pod2 := newTestPod(testNamespace, "pod2",
+					withPodPhase(corev1.PodPending),
+					withPodMACs(testMAC1))
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod1, pod2)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+		})
+
+		Context("when colliding Pod is a virt-launcher", func() {
+			It("should filter it out", func() {
+				pod1 := newTestPod(testNamespace, "pod1",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				pod2 := newTestPod(testNamespace, "pod2",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1),
+					withVirtLauncherLabel())
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod1, pod2)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+		})
+
+		Context("when colliding Pod is in unmanaged namespace", func() {
+			It("should filter it out", func() {
+				pod1 := newTestPod("managed-ns", "pod1",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				pod2 := newTestPod("unmanaged-ns", "pod2",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				mockPoolManager.managedNamespaces = map[string]bool{
+					"managed-ns":   true,
+					"unmanaged-ns": false,
+				}
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod1, pod2)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "managed-ns", Name: "pod1"},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+		})
+
+		Context("when Pod has multiple MACs with different collision states", func() {
+			It("should report collision only for the colliding MAC", func() {
+				pod1 := newTestPod(testNamespace, "pod1",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1, testMAC2))
+				pod2 := newTestPod(testNamespace, "pod2",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				reconciler, mockRecorder = setupPodReconciler(mockPoolManager, pod1, pod2)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: "pod1"},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(mockRecorder.Events).To(HaveLen(2))
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between pod/%s/pod1, pod/%s/pod2",
+					testMAC1, testNamespace, testNamespace)
+
+				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      "pod1",
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      "pod2",
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+			})
+		})
+	})
+})

--- a/pkg/controller/maccollision/predicates.go
+++ b/pkg/controller/maccollision/predicates.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vmicollision
+package maccollision
 
 import (
 	"maps"
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-var predicateLog = logf.Log.WithName("VMICollision Predicate")
+var predicateLog = logf.Log.WithName("MACCollision Predicate")
 
 func collisionRelevantChanges() predicate.TypedPredicate[*kubevirtv1.VirtualMachineInstance] {
 	return predicate.TypedFuncs[*kubevirtv1.VirtualMachineInstance]{

--- a/pkg/controller/maccollision/predicates.go
+++ b/pkg/controller/maccollision/predicates.go
@@ -19,10 +19,13 @@ package maccollision
 import (
 	"maps"
 
+	corev1 "k8s.io/api/core/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 )
 
 var predicateLog = logf.Log.WithName("MACCollision Predicate")
@@ -100,4 +103,34 @@ func getTargetMigrationUID(vmi *kubevirtv1.VirtualMachineInstance) string {
 		return string(vmi.Status.MigrationState.TargetState.MigrationUID)
 	}
 	return ""
+}
+
+func podCollisionRelevantChanges() predicate.TypedPredicate[*corev1.Pod] {
+	return predicate.TypedFuncs[*corev1.Pod]{
+		CreateFunc: func(e event.TypedCreateEvent[*corev1.Pod]) bool {
+			_, hasNetworks := e.Object.GetAnnotations()[networkv1.NetworkAttachmentAnnot]
+			return hasNetworks
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*corev1.Pod]) bool {
+			oldPod := e.ObjectOld
+			newPod := e.ObjectNew
+
+			if oldPod.Status.Phase != newPod.Status.Phase {
+				return true
+			}
+
+			if oldPod.Annotations[networkv1.NetworkAttachmentAnnot] != newPod.Annotations[networkv1.NetworkAttachmentAnnot] {
+				return true
+			}
+
+			if oldPod.Annotations[networkv1.NetworkStatusAnnot] != newPod.Annotations[networkv1.NetworkStatusAnnot] {
+				return true
+			}
+
+			return false
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*corev1.Pod]) bool {
+			return true
+		},
+	}
 }

--- a/pkg/controller/maccollision/predicates_test.go
+++ b/pkg/controller/maccollision/predicates_test.go
@@ -4,10 +4,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 )
 
 var _ = Describe("Predicates", func() {
@@ -386,4 +389,68 @@ var _ = Describe("Predicates", func() {
 			Expect(predicate.Generic(e)).To(BeTrue())
 		})
 	})
+})
+
+var _ = Describe("Pod Predicates", func() {
+	var podPredicate = podCollisionRelevantChanges()
+
+	basePod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					networkv1.NetworkAttachmentAnnot: `[{"name":"net1","mac":"02:00:00:00:00:01"}]`,
+					networkv1.NetworkStatusAnnot:     "[]",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
+		}
+	}
+
+	It("should allow create events for pods with network attachment annotation", func() {
+		e := event.TypedCreateEvent[*corev1.Pod]{Object: basePod()}
+		Expect(podPredicate.Create(e)).To(BeTrue())
+	})
+
+	It("should filter create events for pods without network attachment annotation", func() {
+		pod := basePod()
+		delete(pod.Annotations, networkv1.NetworkAttachmentAnnot)
+
+		e := event.TypedCreateEvent[*corev1.Pod]{Object: pod}
+		Expect(podPredicate.Create(e)).To(BeFalse())
+	})
+
+	It("should allow delete events", func() {
+		e := event.TypedDeleteEvent[*corev1.Pod]{Object: basePod()}
+		Expect(podPredicate.Delete(e)).To(BeTrue())
+	})
+
+	DescribeTable("Update",
+		func(mutate func(old, new *corev1.Pod), expected bool) {
+			oldPod := basePod()
+			newPod := oldPod.DeepCopy()
+			mutate(oldPod, newPod)
+
+			e := event.TypedUpdateEvent[*corev1.Pod]{
+				ObjectOld: oldPod,
+				ObjectNew: newPod,
+			}
+			Expect(podPredicate.Update(e)).To(Equal(expected))
+		},
+		Entry("phase changes", func(_, newPod *corev1.Pod) {
+			newPod.Status.Phase = corev1.PodSucceeded
+		}, true),
+		Entry("network-attachment annotation changes", func(_, newPod *corev1.Pod) {
+			newPod.Annotations[networkv1.NetworkAttachmentAnnot] = `[{"name":"net2","mac":"02:00:00:00:00:02"}]`
+		}, true),
+		Entry("network-status annotation appears", func(oldPod, _ *corev1.Pod) {
+			delete(oldPod.Annotations, networkv1.NetworkStatusAnnot)
+		}, true),
+		Entry("no relevant changes", func(_, newPod *corev1.Pod) {
+			newPod.Labels = map[string]string{"new-label": "value"}
+		}, false),
+	)
 })

--- a/pkg/controller/maccollision/predicates_test.go
+++ b/pkg/controller/maccollision/predicates_test.go
@@ -1,4 +1,4 @@
-package vmicollision
+package maccollision
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/pkg/controller/maccollision/suite_test.go
+++ b/pkg/controller/maccollision/suite_test.go
@@ -1,4 +1,4 @@
-package vmicollision
+package maccollision
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestVMICollision(t *testing.T) {
+func TestMACCollision(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "VMI Collision Controller Suite")
+	RunSpecs(t, "MAC Collision Controller Suite")
 }

--- a/pkg/controller/maccollision/vmi_candidates.go
+++ b/pkg/controller/maccollision/vmi_candidates.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2025 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maccollision
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func listVMIsByMAC(ctx context.Context, k8sClient client.Client, normalizedMAC string) (*kubevirtv1.VirtualMachineInstanceList, error) {
+	vmiList := &kubevirtv1.VirtualMachineInstanceList{}
+	if err := k8sClient.List(ctx, vmiList, client.MatchingFields{MacAddressIndexName: normalizedMAC}); err != nil {
+		return nil, errors.Wrap(err, "failed to list VMIs by MAC")
+	}
+	return vmiList, nil
+}
+
+func listRunningVMIsByMAC(ctx context.Context, k8sClient client.Client, normalizedMAC string) ([]*kubevirtv1.VirtualMachineInstance, error) {
+	vmiList, err := listVMIsByMAC(ctx, k8sClient, normalizedMAC)
+	if err != nil {
+		return nil, err
+	}
+
+	var runningVMIs []*kubevirtv1.VirtualMachineInstance
+	for i := range vmiList.Items {
+		vmi := &vmiList.Items[i]
+		if vmi.Status.Phase != kubevirtv1.Running {
+			continue
+		}
+		runningVMIs = append(runningVMIs, vmi)
+	}
+
+	return runningVMIs, nil
+}
+
+func listRunningVMIsByMACWithExcludeUID(ctx context.Context, k8sClient client.Client, normalizedMAC string, excludeUID types.UID) ([]*kubevirtv1.VirtualMachineInstance, error) {
+	vmiList, err := listVMIsByMAC(ctx, k8sClient, normalizedMAC)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []*kubevirtv1.VirtualMachineInstance
+	for i := range vmiList.Items {
+		vmi := &vmiList.Items[i]
+		if vmi.Status.Phase != kubevirtv1.Running {
+			continue
+		}
+		if vmi.UID == excludeUID {
+			continue
+		}
+		filtered = append(filtered, vmi)
+	}
+
+	return filtered, nil
+}
+
+func filterManagedVMIs(candidates []*kubevirtv1.VirtualMachineInstance, knownManagedNamespaces map[string]struct{}, poolManager PoolManagerInterface, logger logr.Logger) []*kubevirtv1.VirtualMachineInstance {
+	if knownManagedNamespaces == nil {
+		knownManagedNamespaces = map[string]struct{}{}
+	}
+
+	var filtered []*kubevirtv1.VirtualMachineInstance
+	for _, candidate := range candidates {
+		if _, ok := knownManagedNamespaces[candidate.Namespace]; ok {
+			filtered = append(filtered, candidate)
+			continue
+		}
+
+		isManaged, err := poolManager.IsVirtualMachineManaged(candidate.Namespace)
+		if err != nil {
+			logger.Error(err, "Failed to check if VMI namespace is managed, including in collisions",
+				"namespace", candidate.Namespace, "vmi", candidate.Name)
+			filtered = append(filtered, candidate)
+			knownManagedNamespaces[candidate.Namespace] = struct{}{}
+			continue
+		}
+
+		if !isManaged {
+			logger.V(1).Info("Filtering out VMI from unmanaged namespace",
+				"namespace", candidate.Namespace, "vmi", candidate.Name)
+			continue
+		}
+
+		knownManagedNamespaces[candidate.Namespace] = struct{}{}
+		filtered = append(filtered, candidate)
+	}
+
+	return filtered
+}

--- a/pkg/controller/maccollision/vmi_controller.go
+++ b/pkg/controller/maccollision/vmi_controller.go
@@ -154,48 +154,54 @@ func (r *VMIReconciler) checkMACCollisions(ctx context.Context, vmi *kubevirtv1.
 		return nil
 	}
 
-	otherVMIsCollidingPerMAC := make(map[string][]*kubevirtv1.VirtualMachineInstance)
+	allCollisionsButOwn := make(map[string][]pool_manager.ObjectReference)
 	for mac := range macs {
-		collisionCandidates, err := r.filterVMIsWithMAC(ctx, mac, vmi.UID, logger)
+		var refs []pool_manager.ObjectReference
+
+		collidingVMIs, err := r.filterVMIsWithMAC(ctx, mac, vmi.UID, logger)
 		if err != nil {
 			return errors.Wrapf(err, "failed to find VMIs with MAC %s", mac)
 		}
+		collidingVMIs = r.filterOutDecentralizedMigrations(vmi, collidingVMIs, logger)
+		collidingVMIs = r.filterOutUnmanagedNamespaces(collidingVMIs, vmi.Namespace, logger)
+		for _, v := range collidingVMIs {
+			refs = append(refs, vmiObjectRef(v.Namespace, v.Name))
+		}
 
-		collisionCandidates = r.filterOutDecentralizedMigrations(vmi, collisionCandidates, logger)
-		collisionCandidates = r.filterOutUnmanagedNamespaces(collisionCandidates, vmi.Namespace, logger)
+		collidingPods, err := r.findRunningPodsWithMAC(ctx, mac, logger)
+		if err != nil {
+			return errors.Wrapf(err, "failed to find Pods with MAC %s", mac)
+		}
+		for _, p := range collidingPods {
+			refs = append(refs, podObjectRef(p.Namespace, p.Name))
+		}
 
-		actualCollisions := collisionCandidates
-
-		if len(actualCollisions) > 0 {
-			logger.Info("Found MAC collision", "mac", mac, "collisionCount", len(actualCollisions))
-			otherVMIsCollidingPerMAC[mac] = actualCollisions
-
-			r.emitCollisionEvents(vmi, mac, actualCollisions)
+		if len(refs) > 0 {
+			logger.Info("Found MAC collision", "mac", mac, "collisionCount", len(refs))
+			allCollisionsButOwn[mac] = refs
+			r.emitCollisionEvents(vmi, mac, collidingVMIs, refs)
 		}
 	}
 
-	collisions := convertToObjectReferenceMap(otherVMIsCollidingPerMAC)
-	r.poolManager.UpdateCollisionsMap(vmiObjectRef(vmi.Namespace, vmi.Name), collisions)
+	r.poolManager.UpdateCollisionsMap(vmiObjectRef(vmi.Namespace, vmi.Name), allCollisionsButOwn)
 
 	return nil
 }
 
-// emitCollisionEvents emits Kubernetes events on all VMIs involved in a MAC collision
-func (r *VMIReconciler) emitCollisionEvents(vmi *kubevirtv1.VirtualMachineInstance, mac string, collisions []*kubevirtv1.VirtualMachineInstance) {
-	allVMIs := []string{fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name)}
-	for _, duplicate := range collisions {
-		allVMIs = append(allVMIs, fmt.Sprintf("%s/%s", duplicate.Namespace, duplicate.Name))
+func (r *VMIReconciler) emitCollisionEvents(vmi *kubevirtv1.VirtualMachineInstance, mac string, collidingVMIs []*kubevirtv1.VirtualMachineInstance, colliderRefs []pool_manager.ObjectReference) {
+	selfRef := vmiObjectRef(vmi.Namespace, vmi.Name)
+	all := []string{selfRef.Key()}
+	for _, ref := range colliderRefs {
+		all = append(all, ref.Key())
 	}
+	sort.Strings(all)
 
-	sort.Strings(allVMIs)
-
-	// Universal message - same for all VMIs and better deduplication
-	message := fmt.Sprintf("MAC %s: Collision between %s", mac, strings.Join(allVMIs, ", "))
+	message := fmt.Sprintf("MAC %s: Collision between %s", mac, strings.Join(all, ", "))
 
 	r.recorder.Event(vmi, corev1.EventTypeWarning, "MACCollision", message)
 
-	for _, duplicate := range collisions {
-		r.recorder.Event(duplicate, corev1.EventTypeWarning, "MACCollision", message)
+	for _, v := range collidingVMIs {
+		r.recorder.Event(v, corev1.EventTypeWarning, "MACCollision", message)
 	}
 }
 
@@ -241,17 +247,12 @@ func (r *VMIReconciler) filterOutUnmanagedNamespaces(collisionCandidates []*kube
 	return managedCollisions
 }
 
-// convertToObjectReferenceMap converts a map of VMIs to a map of ObjectReferences
-func convertToObjectReferenceMap(duplicates map[string][]*kubevirtv1.VirtualMachineInstance) map[string][]pool_manager.ObjectReference {
-	collisions := make(map[string][]pool_manager.ObjectReference)
-	for mac, vmis := range duplicates {
-		refs := make([]pool_manager.ObjectReference, len(vmis))
-		for i, v := range vmis {
-			refs[i] = vmiObjectRef(v.Namespace, v.Name)
-		}
-		collisions[mac] = refs
+func (r *VMIReconciler) findRunningPodsWithMAC(ctx context.Context, normalizedMAC string, logger logr.Logger) ([]*corev1.Pod, error) {
+	runningPods, err := listRunningPodsWithMAC(ctx, r.Client, normalizedMAC)
+	if err != nil {
+		return nil, err
 	}
-	return collisions
+	return filterCollisionCandidatePods(runningPods, "", r.poolManager, logger), nil
 }
 
 // removeVMIFromAllCollisions removes a VMI from all collision tracking

--- a/pkg/controller/maccollision/vmi_controller.go
+++ b/pkg/controller/maccollision/vmi_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vmicollision
+package maccollision
 
 import (
 	"context"
@@ -41,16 +41,16 @@ import (
 	pool_manager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
 )
 
-var log = logf.Log.WithName("VMICollision Controller")
+var log = logf.Log.WithName("MACCollision Controller")
 
-// PoolManagerInterface defines the methods required by VMICollisionReconciler
+// PoolManagerInterface defines the methods required by VMIReconciler
 type PoolManagerInterface interface {
 	IsVirtualMachineManaged(namespace string) (bool, error)
 	UpdateCollisionsMap(objectRef pool_manager.ObjectReference, collisions map[string][]pool_manager.ObjectReference)
 }
 
-// VMICollisionReconciler watches VirtualMachineInstance objects and detects MAC address collisions
-type VMICollisionReconciler struct {
+// VMIReconciler watches VirtualMachineInstance objects and detects MAC address collisions
+type VMIReconciler struct {
 	client.Client
 	poolManager PoolManagerInterface
 	recorder    record.EventRecorder
@@ -59,7 +59,7 @@ type VMICollisionReconciler struct {
 // SetupWithManager sets up the controller with the Manager.
 func SetupWithManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) error {
 	// Create the reconciler
-	r := &VMICollisionReconciler{
+	r := &VMIReconciler{
 		Client:      mgr.GetClient(),
 		poolManager: poolManager,
 		recorder:    mgr.GetEventRecorderFor("kubemacpool"),
@@ -77,11 +77,11 @@ func SetupWithManager(mgr manager.Manager, poolManager *pool_manager.PoolManager
 
 	log.Info("Successfully registered MAC address indexer for VMI collision detection")
 
-	c, err := controller.New("vmicollision-controller", mgr, controller.Options{
+	c, err := controller.New("maccollision-vmi-controller", mgr, controller.Options{
 		Reconciler: r,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create VMI collision controller: %w", err)
+		return fmt.Errorf("failed to create MAC collision VMI controller: %w", err)
 	}
 
 	err = c.Watch(
@@ -96,12 +96,12 @@ func SetupWithManager(mgr manager.Manager, poolManager *pool_manager.PoolManager
 		return fmt.Errorf("failed to watch VMIs: %w", err)
 	}
 
-	log.Info("Successfully registered VMI collision controller")
+	log.Info("Successfully registered MAC collision VMI controller")
 	return nil
 }
 
 // Reconcile handles VMI reconciliation for collision detection
-func (r *VMICollisionReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+func (r *VMIReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	reconcileRequestId := rand.Intn(100000)
 	logger := log.WithName("Reconcile").WithValues("RequestId", reconcileRequestId, "vmi-collision-detect", req.NamespacedName)
 	logger.V(1).Info("Reconciling VMI for collision detection")
@@ -139,7 +139,7 @@ func (r *VMICollisionReconciler) Reconcile(ctx context.Context, req reconcile.Re
 }
 
 // checkMACCollisions detects MAC collisions for the given VMI
-func (r *VMICollisionReconciler) checkMACCollisions(ctx context.Context, vmi *kubevirtv1.VirtualMachineInstance, logger logr.Logger) error {
+func (r *VMIReconciler) checkMACCollisions(ctx context.Context, vmi *kubevirtv1.VirtualMachineInstance, logger logr.Logger) error {
 	if vmi.Status.Phase != kubevirtv1.Running {
 		logger.V(1).Info("VMI not running, removing from collision tracking", "phase", vmi.Status.Phase)
 		r.removeVMIFromAllCollisions(vmi.Namespace, vmi.Name)
@@ -179,7 +179,7 @@ func (r *VMICollisionReconciler) checkMACCollisions(ctx context.Context, vmi *ku
 }
 
 // emitCollisionEvents emits Kubernetes events on all VMIs involved in a MAC collision
-func (r *VMICollisionReconciler) emitCollisionEvents(vmi *kubevirtv1.VirtualMachineInstance, mac string, collisions []*kubevirtv1.VirtualMachineInstance) {
+func (r *VMIReconciler) emitCollisionEvents(vmi *kubevirtv1.VirtualMachineInstance, mac string, collisions []*kubevirtv1.VirtualMachineInstance) {
 	allVMIs := []string{fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name)}
 	for _, duplicate := range collisions {
 		allVMIs = append(allVMIs, fmt.Sprintf("%s/%s", duplicate.Namespace, duplicate.Name))
@@ -200,7 +200,7 @@ func (r *VMICollisionReconciler) emitCollisionEvents(vmi *kubevirtv1.VirtualMach
 // findRunningVMIsWithMAC queries the indexer to find all Running VMIs with the given MAC address
 // Excludes the VMI with the given UID (to avoid finding itself)
 // Assumes MAC is already normalized
-func (r *VMICollisionReconciler) findRunningVMIsWithMAC(ctx context.Context, NormalizedMAC string, excludeUID types.UID, logger logr.Logger) ([]*kubevirtv1.VirtualMachineInstance, error) {
+func (r *VMIReconciler) findRunningVMIsWithMAC(ctx context.Context, NormalizedMAC string, excludeUID types.UID, logger logr.Logger) ([]*kubevirtv1.VirtualMachineInstance, error) {
 	// Query the indexer
 	vmiList := &kubevirtv1.VirtualMachineInstanceList{}
 	if err := r.List(ctx, vmiList, client.MatchingFields{MacAddressIndexName: NormalizedMAC}); err != nil {
@@ -229,7 +229,7 @@ func (r *VMICollisionReconciler) findRunningVMIsWithMAC(ctx context.Context, Nor
 }
 
 // extractMACsFromVMI returns a set of normalized MAC addresses from a VMI's status interfaces
-func (r *VMICollisionReconciler) extractMACsFromVMI(vmi *kubevirtv1.VirtualMachineInstance, logger logr.Logger) map[string]struct{} {
+func (r *VMIReconciler) extractMACsFromVMI(vmi *kubevirtv1.VirtualMachineInstance, logger logr.Logger) map[string]struct{} {
 	macs := make(map[string]struct{})
 	for _, iface := range vmi.Status.Interfaces {
 		if iface.MAC != "" {
@@ -246,7 +246,7 @@ func (r *VMICollisionReconciler) extractMACsFromVMI(vmi *kubevirtv1.VirtualMachi
 
 // filterOutUnmanagedNamespaces filters out VMIs from unmanaged namespaces, returning only collisions in managed namespaces
 // reconciledNamespace is the namespace of the VMI being reconciled, which is known to be managed
-func (r *VMICollisionReconciler) filterOutUnmanagedNamespaces(collisionCandidates []*kubevirtv1.VirtualMachineInstance, reconciledNamespace string, logger logr.Logger) []*kubevirtv1.VirtualMachineInstance {
+func (r *VMIReconciler) filterOutUnmanagedNamespaces(collisionCandidates []*kubevirtv1.VirtualMachineInstance, reconciledNamespace string, logger logr.Logger) []*kubevirtv1.VirtualMachineInstance {
 	managedNamespaces := map[string]struct{}{
 		reconciledNamespace: {},
 	}
@@ -308,7 +308,7 @@ func convertToObjectReferenceMap(duplicates map[string][]*kubevirtv1.VirtualMach
 }
 
 // removeVMIFromAllCollisions removes a VMI from all collision tracking
-func (r *VMICollisionReconciler) removeVMIFromAllCollisions(namespace, name string) {
+func (r *VMIReconciler) removeVMIFromAllCollisions(namespace, name string) {
 	r.poolManager.UpdateCollisionsMap(vmiObjectRef(namespace, name), nil)
 }
 

--- a/pkg/controller/maccollision/vmi_controller.go
+++ b/pkg/controller/maccollision/vmi_controller.go
@@ -43,9 +43,10 @@ import (
 
 var log = logf.Log.WithName("MACCollision Controller")
 
-// PoolManagerInterface defines the methods required by VMIReconciler
+// PoolManagerInterface defines the methods required by collision reconcilers.
 type PoolManagerInterface interface {
 	IsVirtualMachineManaged(namespace string) (bool, error)
+	IsPodManaged(namespace string) (bool, error)
 	UpdateCollisionsMap(objectRef pool_manager.ObjectReference, collisions map[string][]pool_manager.ObjectReference)
 }
 

--- a/pkg/controller/maccollision/vmi_controller.go
+++ b/pkg/controller/maccollision/vmi_controller.go
@@ -45,6 +45,7 @@ var log = logf.Log.WithName("MACCollision Controller")
 
 // PoolManagerInterface defines the methods required by collision reconcilers.
 type PoolManagerInterface interface {
+	IsKubevirtEnabled() bool
 	IsVirtualMachineManaged(namespace string) (bool, error)
 	IsPodManaged(namespace string) (bool, error)
 	UpdateCollisionsMap(objectRef pool_manager.ObjectReference, collisions map[string][]pool_manager.ObjectReference)
@@ -155,7 +156,7 @@ func (r *VMIReconciler) checkMACCollisions(ctx context.Context, vmi *kubevirtv1.
 
 	otherVMIsCollidingPerMAC := make(map[string][]*kubevirtv1.VirtualMachineInstance)
 	for mac := range macs {
-		collisionCandidates, err := r.findRunningVMIsWithMAC(ctx, mac, vmi.UID, logger)
+		collisionCandidates, err := r.filterVMIsWithMAC(ctx, mac, vmi.UID, logger)
 		if err != nil {
 			return errors.Wrapf(err, "failed to find VMIs with MAC %s", mac)
 		}
@@ -201,32 +202,8 @@ func (r *VMIReconciler) emitCollisionEvents(vmi *kubevirtv1.VirtualMachineInstan
 // findRunningVMIsWithMAC queries the indexer to find all Running VMIs with the given MAC address
 // Excludes the VMI with the given UID (to avoid finding itself)
 // Assumes MAC is already normalized
-func (r *VMIReconciler) findRunningVMIsWithMAC(ctx context.Context, NormalizedMAC string, excludeUID types.UID, logger logr.Logger) ([]*kubevirtv1.VirtualMachineInstance, error) {
-	// Query the indexer
-	vmiList := &kubevirtv1.VirtualMachineInstanceList{}
-	if err := r.List(ctx, vmiList, client.MatchingFields{MacAddressIndexName: NormalizedMAC}); err != nil {
-		return nil, errors.Wrap(err, "failed to list VMIs by MAC")
-	}
-
-	// Filter to only Running VMIs (excluding the given UID)
-	var runningVMIs []*kubevirtv1.VirtualMachineInstance
-	for i := range vmiList.Items {
-		vmi := &vmiList.Items[i]
-
-		// Skip the VMI itself
-		if vmi.UID == excludeUID {
-			continue
-		}
-
-		// Only consider Running VMIs
-		if vmi.Status.Phase != kubevirtv1.Running {
-			continue
-		}
-
-		runningVMIs = append(runningVMIs, vmi)
-	}
-
-	return runningVMIs, nil
+func (r *VMIReconciler) filterVMIsWithMAC(ctx context.Context, normalizedMAC string, excludeUID types.UID, _ logr.Logger) ([]*kubevirtv1.VirtualMachineInstance, error) {
+	return listRunningVMIsByMACWithExcludeUID(ctx, r.Client, normalizedMAC, excludeUID)
 }
 
 // extractMACsFromVMI returns a set of normalized MAC addresses from a VMI's status interfaces
@@ -252,38 +229,7 @@ func (r *VMIReconciler) filterOutUnmanagedNamespaces(collisionCandidates []*kube
 		reconciledNamespace: {},
 	}
 
-	var managedCollisions []*kubevirtv1.VirtualMachineInstance
-
-	for _, candidate := range collisionCandidates {
-		// Check if we've already verified this namespace
-		if _, alreadyChecked := managedNamespaces[candidate.Namespace]; alreadyChecked {
-			managedCollisions = append(managedCollisions, candidate)
-			continue
-		}
-
-		// Check if namespace is managed
-		isManaged, err := r.poolManager.IsVirtualMachineManaged(candidate.Namespace)
-		if err != nil {
-			logger.Error(err, "Failed to check if namespace is managed, including VMI in collisions",
-				"namespace", candidate.Namespace,
-				"vmi", candidate.Name)
-			// Include the VMI in collisions on error (fail-safe)
-			managedCollisions = append(managedCollisions, candidate)
-			managedNamespaces[candidate.Namespace] = struct{}{}
-			continue
-		}
-
-		if !isManaged {
-			logger.V(1).Info("Filtering out VMI from unmanaged namespace",
-				"namespace", candidate.Namespace,
-				"vmi", candidate.Name)
-			continue
-		}
-
-		// Cache this namespace as managed
-		managedNamespaces[candidate.Namespace] = struct{}{}
-		managedCollisions = append(managedCollisions, candidate)
-	}
+	managedCollisions := filterManagedVMIs(collisionCandidates, managedNamespaces, r.poolManager, logger)
 
 	if len(managedCollisions) < len(collisionCandidates) {
 		logger.Info("Filtered out VMIs from unmanaged namespaces",

--- a/pkg/controller/maccollision/vmi_controller.go
+++ b/pkg/controller/maccollision/vmi_controller.go
@@ -98,8 +98,43 @@ func SetupWithManager(mgr manager.Manager, poolManager *pool_manager.PoolManager
 		return fmt.Errorf("failed to watch VMIs: %w", err)
 	}
 
+	err = c.Watch(
+		source.Kind(
+			mgr.GetCache(),
+			&corev1.Pod{},
+			handler.TypedEnqueueRequestsFromMapFunc(r.mapPodToVMIs),
+			podCollisionRelevantChanges(),
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to watch Pods for VMI cross-type collisions: %w", err)
+	}
+
 	log.Info("Successfully registered MAC collision VMI controller")
 	return nil
+}
+
+func (r *VMIReconciler) mapPodToVMIs(ctx context.Context, pod *corev1.Pod) []reconcile.Request {
+	macs := IndexPodByMAC(pod)
+
+	var requests []reconcile.Request
+	seen := map[types.NamespacedName]struct{}{}
+	for _, mac := range macs {
+		var vmiList kubevirtv1.VirtualMachineInstanceList
+		if err := r.List(ctx, &vmiList, client.MatchingFields{MacAddressIndexName: mac}); err != nil {
+			log.Error(err, "failed to list VMIs by MAC for cross-type enqueue", "mac", mac)
+			continue
+		}
+		for i := range vmiList.Items {
+			key := types.NamespacedName{Namespace: vmiList.Items[i].Namespace, Name: vmiList.Items[i].Name}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			requests = append(requests, reconcile.Request{NamespacedName: key})
+		}
+	}
+	return requests
 }
 
 // Reconcile handles VMI reconciliation for collision detection

--- a/pkg/controller/maccollision/vmi_controller_test.go
+++ b/pkg/controller/maccollision/vmi_controller_test.go
@@ -1,4 +1,4 @@
-package vmicollision
+package maccollision
 
 import (
 	"context"
@@ -125,7 +125,7 @@ func newVMI(namespace, name string, opts ...vmiOption) *kubevirtv1.VirtualMachin
 	return vmi
 }
 
-func setupReconciler(mockPoolManager *MockPoolManager, objects ...client.Object) (*VMICollisionReconciler, *MockEventRecorder, client.Client) {
+func setupReconciler(mockPoolManager *MockPoolManager, objects ...client.Object) (*VMIReconciler, *MockEventRecorder, client.Client) {
 	scheme := runtime.NewScheme()
 	_ = kubevirtv1.AddToScheme(scheme)
 
@@ -137,7 +137,7 @@ func setupReconciler(mockPoolManager *MockPoolManager, objects ...client.Object)
 
 	mockRecorder := &MockEventRecorder{Events: []MockEvent{}}
 
-	reconciler := &VMICollisionReconciler{
+	reconciler := &VMIReconciler{
 		Client:      fakeClient,
 		poolManager: mockPoolManager,
 		recorder:    mockRecorder,
@@ -157,7 +157,7 @@ var _ = Describe("VMI Collision Controller", func() {
 	var (
 		mockPoolManager *MockPoolManager
 		mockRecorder    *MockEventRecorder
-		reconciler      *VMICollisionReconciler
+		reconciler      *VMIReconciler
 		ctx             context.Context
 	)
 

--- a/pkg/controller/maccollision/vmi_controller_test.go
+++ b/pkg/controller/maccollision/vmi_controller_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -142,11 +143,13 @@ func newVMI(namespace, name string, opts ...vmiOption) *kubevirtv1.VirtualMachin
 func setupReconciler(mockPoolManager *MockPoolManager, objects ...client.Object) (*VMIReconciler, *MockEventRecorder, client.Client) {
 	scheme := runtime.NewScheme()
 	_ = kubevirtv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objects...).
 		WithIndex(&kubevirtv1.VirtualMachineInstance{}, MacAddressIndexName, IndexVMIByMAC).
+		WithIndex(&corev1.Pod{}, PodMacAddressIndexName, IndexPodByMAC).
 		Build()
 
 	mockRecorder := &MockEventRecorder{Events: []MockEvent{}}
@@ -339,10 +342,9 @@ var _ = Describe("VMI Collision Controller", func() {
 				Expect(mockRecorder.Events).To(HaveLen(2))
 
 				// Expected message (sorted VMI list for deduplication)
-				expectedMessage := fmt.Sprintf("MAC %s: Collision between %s/%s, %s/%s",
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between vmi/%s/%s, vmi/%s/%s",
 					testMAC1, testNamespace, "vmi1", testNamespace, "vmi2")
 
-				// Check event on vmi1
 				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
 					ObjectNamespace: testNamespace,
 					ObjectName:      "vmi1",
@@ -351,7 +353,6 @@ var _ = Describe("VMI Collision Controller", func() {
 					Message:         expectedMessage,
 				}))
 
-				// Check event on vmi2
 				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
 					ObjectNamespace: testNamespace,
 					ObjectName:      "vmi2",
@@ -360,7 +361,6 @@ var _ = Describe("VMI Collision Controller", func() {
 					Message:         expectedMessage,
 				}))
 
-				// Verify messages are identical (for Kubernetes deduplication)
 				Expect(mockRecorder.Events[0].Message).To(Equal(mockRecorder.Events[1].Message))
 			})
 
@@ -389,7 +389,7 @@ var _ = Describe("VMI Collision Controller", func() {
 				Expect(mockRecorder.Events).To(HaveLen(2))
 
 				// Expected message (sorted by namespace/name)
-				expectedMessage := fmt.Sprintf("MAC %s: Collision between %s/%s, %s/%s",
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between vmi/%s/%s, vmi/%s/%s",
 					testMAC1, "ns1", "vmi1", "ns2", "vmi2")
 
 				// Check event on vmi1
@@ -436,7 +436,7 @@ var _ = Describe("VMI Collision Controller", func() {
 				Expect(result).To(Equal(reconcile.Result{}))
 
 				Expect(mockRecorder.Events).To(HaveLen(3))
-				expectedMessage := fmt.Sprintf("MAC %s: Collision between %s/%s, %s/%s, %s/%s",
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between vmi/%s/%s, vmi/%s/%s, vmi/%s/%s",
 					testMAC1, testNamespace, "vmi1", testNamespace, "vmi2", testNamespace, "vmi3")
 
 				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
@@ -484,7 +484,7 @@ var _ = Describe("VMI Collision Controller", func() {
 				Expect(result).To(Equal(reconcile.Result{}))
 
 				Expect(mockRecorder.Events).To(HaveLen(2))
-				expectedMessage := fmt.Sprintf("MAC %s: Collision between %s/%s, %s/%s",
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between vmi/%s/%s, vmi/%s/%s",
 					testMAC1, testNamespace, "vmi1", testNamespace, "vmi2")
 
 				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
@@ -579,7 +579,7 @@ var _ = Describe("VMI Collision Controller", func() {
 				Expect(result).To(Equal(reconcile.Result{}))
 
 				Expect(mockRecorder.Events).To(HaveLen(2))
-				expectedMessage := fmt.Sprintf("MAC %s: Collision between %s/%s, %s/%s",
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between vmi/%s/%s, vmi/%s/%s",
 					testMAC1, testNamespace, "vmi1", testNamespace, "vmi2")
 
 				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
@@ -674,7 +674,7 @@ var _ = Describe("VMI Collision Controller", func() {
 				Expect(result).To(Equal(reconcile.Result{}))
 
 				Expect(mockRecorder.Events).To(HaveLen(2))
-				expectedMessage := fmt.Sprintf("MAC %s: Collision between %s/%s, %s/%s",
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between vmi/%s/%s, vmi/%s/%s",
 					testMAC1, testNamespace, "vmi1", testNamespace, "vmi2")
 
 				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
@@ -717,7 +717,7 @@ var _ = Describe("VMI Collision Controller", func() {
 				Expect(result).To(Equal(reconcile.Result{}))
 
 				Expect(mockRecorder.Events).To(HaveLen(2))
-				expectedMessage := fmt.Sprintf("MAC %s: Collision between %s/%s, %s/%s",
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between vmi/%s/%s, vmi/%s/%s",
 					testMAC1, testNamespace, "vmi1", testNamespace, "vmi2")
 
 				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
@@ -810,7 +810,7 @@ var _ = Describe("VMI Collision Controller", func() {
 				Expect(result).To(Equal(reconcile.Result{}))
 
 				Expect(mockRecorder.Events).To(HaveLen(2))
-				expectedMessage := fmt.Sprintf("MAC %s: Collision between %s/%s, %s/%s",
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between vmi/%s/%s, vmi/%s/%s",
 					testMAC1, managedNS, "vmi-managed-1", managedNS, "vmi-managed-2")
 
 				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
@@ -827,6 +827,134 @@ var _ = Describe("VMI Collision Controller", func() {
 					Reason:          "MACCollision",
 					Message:         expectedMessage,
 				}))
+			})
+		})
+
+		Context("cross-type VMI-Pod collision detection", func() {
+			It("should detect collision between VMI and running Pod", func() {
+				vmi := newVMI(testNamespace, testVMIName,
+					withPhase(kubevirtv1.Running),
+					withMACs(testMAC1))
+				pod := newTestPod(testNamespace, "colliding-pod",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				reconciler, mockRecorder, _ = setupReconciler(mockPoolManager, vmi, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testVMIName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(mockRecorder.Events).To(HaveLen(1))
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between pod/%s/colliding-pod, vmi/%s/%s",
+					testMAC1, testNamespace, testNamespace, testVMIName)
+				Expect(mockRecorder.Events[0]).To(Equal(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      testVMIName,
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+			})
+
+			It("should not detect collision with non-running Pod", func() {
+				vmi := newVMI(testNamespace, testVMIName,
+					withPhase(kubevirtv1.Running),
+					withMACs(testMAC1))
+				pod := newTestPod(testNamespace, "pending-pod",
+					withPodPhase(corev1.PodPending),
+					withPodMACs(testMAC1))
+				reconciler, mockRecorder, _ = setupReconciler(mockPoolManager, vmi, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testVMIName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+
+			It("should filter out virt-launcher Pod", func() {
+				vmi := newVMI(testNamespace, testVMIName,
+					withPhase(kubevirtv1.Running),
+					withMACs(testMAC1))
+				pod := newTestPod(testNamespace, "virt-launcher-pod",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1),
+					withVirtLauncherLabel())
+				reconciler, mockRecorder, _ = setupReconciler(mockPoolManager, vmi, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testVMIName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
+			})
+
+			It("should detect collision with both VMIs and Pods for the same MAC", func() {
+				vmi1 := newVMI(testNamespace, "vmi1",
+					withPhase(kubevirtv1.Running),
+					withMACs(testMAC1))
+				vmi2 := newVMI(testNamespace, "vmi2",
+					withPhase(kubevirtv1.Running),
+					withMACs(testMAC1))
+				pod := newTestPod(testNamespace, "pod1",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				reconciler, mockRecorder, _ = setupReconciler(mockPoolManager, vmi1, vmi2, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: "vmi1"},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(mockRecorder.Events).To(HaveLen(2))
+				expectedMessage := fmt.Sprintf("MAC %s: Collision between pod/%s/pod1, vmi/%s/vmi1, vmi/%s/vmi2",
+					testMAC1, testNamespace, testNamespace, testNamespace)
+
+				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      "vmi1",
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+				Expect(mockRecorder.Events).To(ContainElement(MockEvent{
+					ObjectNamespace: testNamespace,
+					ObjectName:      "vmi2",
+					Type:            "Warning",
+					Reason:          "MACCollision",
+					Message:         expectedMessage,
+				}))
+			})
+
+			It("should filter out Pod from unmanaged namespace", func() {
+				vmi := newVMI("managed-ns", testVMIName,
+					withPhase(kubevirtv1.Running),
+					withMACs(testMAC1))
+				pod := newTestPod("unmanaged-ns", "pod1",
+					withPodPhase(corev1.PodRunning),
+					withPodMACs(testMAC1))
+				mockPoolManager.managedNamespaces = map[string]bool{
+					"managed-ns":   true,
+					"unmanaged-ns": false,
+				}
+				reconciler, mockRecorder, _ = setupReconciler(mockPoolManager, vmi, pod)
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "managed-ns", Name: testVMIName},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(mockRecorder.Events).To(BeEmpty())
 			})
 		})
 	})

--- a/pkg/controller/maccollision/vmi_controller_test.go
+++ b/pkg/controller/maccollision/vmi_controller_test.go
@@ -22,6 +22,7 @@ type MockPoolManager struct {
 	isVirtualMachineManagedCalls []string
 	isPodManagedCalls            []string
 	managedNamespaces            map[string]bool
+	kubevirtEnabled              bool
 }
 
 func (m *MockPoolManager) IsVirtualMachineManaged(namespace string) (bool, error) {
@@ -38,6 +39,10 @@ func (m *MockPoolManager) IsPodManaged(namespace string) (bool, error) {
 		return true, nil
 	}
 	return m.managedNamespaces[namespace], nil
+}
+
+func (m *MockPoolManager) IsKubevirtEnabled() bool {
+	return m.kubevirtEnabled
 }
 
 func (m *MockPoolManager) UpdateCollisionsMap(pool_manager.ObjectReference, map[string][]pool_manager.ObjectReference) {

--- a/pkg/controller/maccollision/vmi_controller_test.go
+++ b/pkg/controller/maccollision/vmi_controller_test.go
@@ -20,11 +20,20 @@ import (
 
 type MockPoolManager struct {
 	isVirtualMachineManagedCalls []string
+	isPodManagedCalls            []string
 	managedNamespaces            map[string]bool
 }
 
 func (m *MockPoolManager) IsVirtualMachineManaged(namespace string) (bool, error) {
 	m.isVirtualMachineManagedCalls = append(m.isVirtualMachineManagedCalls, namespace)
+	if m.managedNamespaces == nil {
+		return true, nil
+	}
+	return m.managedNamespaces[namespace], nil
+}
+
+func (m *MockPoolManager) IsPodManaged(namespace string) (bool, error) {
+	m.isPodManagedCalls = append(m.isPodManagedCalls, namespace)
 	if m.managedNamespaces == nil {
 		return true, nil
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -211,6 +211,9 @@ func (k *KubeMacPoolManager) initRuntimeManager(isKubevirtInstalled bool) error 
 				},
 				Field: configMapNameFieldSelector,
 			},
+			&corev1.Pod{}: {
+				Transform: maccollision.StripPodForCollisionDetection,
+			},
 		},
 	}
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -44,7 +44,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller"
-	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/vmicollision"
+	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/controller/maccollision"
 	monitoringmetrics "github.com/k8snetworkplumbingwg/kubemacpool/pkg/monitoring/metrics"
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
 	poolmanager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
@@ -219,7 +219,7 @@ func (k *KubeMacPoolManager) initRuntimeManager(isKubevirtInstalled bool) error 
 	// When kubevirt is installed then the Manager will restart.
 	if isKubevirtInstalled {
 		cacheOptions.ByObject[&kubevirt_api.VirtualMachineInstance{}] = cache.ByObject{
-			Transform: vmicollision.StripVMIForCollisionDetection,
+			Transform: maccollision.StripVMIForCollisionDetection,
 		}
 	}
 

--- a/pkg/pool-manager/pod_pool.go
+++ b/pkg/pool-manager/pod_pool.go
@@ -148,21 +148,6 @@ func (p *PoolManager) allocatePodRequestedMac(network *multus.NetworkSelectionEl
 		}
 		return nil
 	}
-	if entries, exist := p.macPoolMap[NewMacKey(requestedMac)]; exist {
-		if !macAlreadyBelongsToPodAndNetwork(podFullName, network.Name, entries) {
-			err := fmt.Errorf("failed to allocate requested mac address")
-			conflictInfo := ""
-			for _, entry := range entries {
-				if conflictInfo != "" {
-					conflictInfo += ", "
-				}
-				conflictInfo += fmt.Sprintf("%s:%s", entry.instanceName, entry.macInstanceKey)
-			}
-			log.Error(err, fmt.Sprintf("mac address already allocated to [%s]", conflictInfo))
-
-			return err
-		}
-	}
 
 	if isNotDryRun {
 		p.macPoolMap.createOrUpdateEntry(requestedMac, podFullName, network.Name)
@@ -311,19 +296,6 @@ func (p *PoolManager) initPodMap() error {
 	}
 
 	return nil
-}
-
-func macAlreadyBelongsToPodAndNetwork(podFullName, networkName string, entries []macEntry) bool {
-	for _, entry := range entries {
-		if entry.instanceName == tempPodName {
-			// do not block macs with not yet updated pod names.
-			return false
-		}
-		if entry.instanceName == podFullName && entry.macInstanceKey == networkName {
-			return true
-		}
-	}
-	return false
 }
 
 // Revert allocation if one of the requested mac addresses fails to be allocated

--- a/pkg/pool-manager/pool_test.go
+++ b/pkg/pool-manager/pool_test.go
@@ -878,6 +878,26 @@ var _ = Describe("Pool", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newPod.Annotations[networkv1.NetworkAttachmentAnnot]).To(Equal(afterAllocationAnnotation(managedNamespaceName, managedNamespaceMAC)[networkv1.NetworkAttachmentAnnot]))
 		})
+		It("should allow a pod requesting a MAC already allocated to another pod", func() {
+			poolManager := createPoolManager(minRangeMACPool, maxRangeMACPool, OptOutMode, &managedPodWithMacAllocated)
+
+			duplicatePod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "duplicate-pod",
+					Namespace:   managedNamespaceName,
+					Annotations: afterAllocationAnnotation(managedNamespaceName, managedNamespaceMAC),
+				},
+			}
+
+			err := poolManager.AllocatePodMac(&duplicatePod, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			entries, exist := poolManager.macPoolMap[NewMacKey(managedNamespaceMAC)]
+			Expect(exist).To(BeTrue())
+			Expect(entries).To(HaveLen(2))
+			Expect(entries[0].instanceName).To(Equal(podNamespaced(&managedPodWithMacAllocated)))
+			Expect(entries[1].instanceName).To(Equal(podNamespaced(&duplicatePod)))
+		})
 	})
 
 	Describe("Multus Network Annotations API Tests", func() {

--- a/pkg/pool-manager/vmi_collision.go
+++ b/pkg/pool-manager/vmi_collision.go
@@ -20,6 +20,7 @@ type ObjectType string
 
 const (
 	ObjectTypeVMI ObjectType = "vmi"
+	ObjectTypePod ObjectType = "pod"
 )
 
 type ObjectReference struct {

--- a/tests/cross_type_collision_test.go
+++ b/tests/cross_type_collision_test.go
@@ -1,0 +1,185 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Cross-Type MAC Collision Detection",
+	Label(PodMACCollisionDetectionLabel), Label(MACCollisionDetectionLabel), Ordered, func() {
+		testNamespaces := []string{TestNamespace, OtherTestNamespace}
+
+		BeforeEach(func() {
+			By("Verify that there are no test Pods left from previous tests")
+			for _, ns := range testNamespaces {
+				podList, err := testClient.K8sClient.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Should successfully list Pods")
+				Expect(len(podList.Items)).To(BeZero(), "There should be no Pods in namespace %s before a test", ns)
+
+				err = cleanNamespaceLabels(ns)
+				Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
+			}
+		})
+
+		BeforeEach(func() {
+			optInNamespaceForPods(TestNamespace)
+		})
+
+		AfterEach(func() {
+			cleanupTestPodsInNamespaces(testNamespaces)
+
+			vmiList := &kubevirtv1.VirtualMachineInstanceList{}
+			Expect(testClient.CRClient.List(context.TODO(), vmiList)).To(Succeed())
+			for i := range vmiList.Items {
+				err := testClient.CRClient.Delete(context.TODO(), &vmiList.Items[i])
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+			Eventually(func() []kubevirtv1.VirtualMachineInstance {
+				list := &kubevirtv1.VirtualMachineInstanceList{}
+				Expect(testClient.CRClient.List(context.TODO(), list)).To(Succeed())
+				return list.Items
+			}).WithTimeout(timeout).WithPolling(pollingInterval).Should(HaveLen(0), "failed to remove all VMI objects")
+		})
+
+		Context("and a Pod and VMI share the same MAC address", func() {
+			var nadName string
+
+			BeforeEach(func() {
+				nadName = randName("br")
+				By(fmt.Sprintf("Creating network attachment definition: %s", nadName))
+				Expect(createNetworkAttachmentDefinition(TestNamespace, nadName)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				Expect(deleteNetworkAttachmentDefinition(TestNamespace, nadName)).To(Succeed())
+			})
+
+			It("should detect collision between Pod and VMI with same MAC", Label(MetricsLabel), func() {
+				const sharedMAC = "02:00:00:00:cc:01"
+
+				pod1 := NewCollisionPod(TestNamespace, "test-cross-pod",
+					WithMultusNetwork(nadName, sharedMAC))
+				_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Pod should be created successfully")
+
+				vmi1 := NewVMI(TestNamespace, "test-cross-vmi",
+					WithInterface(newInterface(nadName, sharedMAC)),
+					WithNetwork(newNetwork(nadName)))
+				Expect(testClient.CRClient.Create(context.TODO(), vmi1)).To(Succeed(), "VMI should be created successfully")
+
+				normalizedMAC, err := net.ParseMAC(sharedMAC)
+				Expect(err).ToNot(HaveOccurred())
+
+				pods := []podReference{{pod1.Namespace, pod1.Name}}
+				vmis := []vmiReference{{vmi1.Namespace, vmi1.Name}}
+				allRefs := []collisionRef{
+					podRef(pod1.Namespace, pod1.Name),
+					vmiRef(vmi1.Namespace, vmi1.Name),
+				}
+
+				waitForPodsRunning(pods)
+				waitForVMIsRunning(vmis)
+
+				By("Verifying collision events on Pod")
+				expectPodMACCollisionEvents(normalizedMAC.String(), allRefs)
+
+				By("Verifying collision events on VMI")
+				expectedVMIMessage := buildCollisionMessage(normalizedMAC.String(), allRefs)
+				Eventually(func(g Gomega) []corev1.Event {
+					events, evErr := getVMIEvents(vmi1.Namespace, vmi1.Name)
+					g.Expect(evErr).NotTo(HaveOccurred())
+					return events.Items
+				}).WithTimeout(timeout).WithPolling(pollingInterval).Should(ContainElement(And(
+					HaveField("Reason", "MACCollision"),
+					HaveField("Message", expectedVMIMessage),
+				)))
+
+				expectMACCollisionGauge(normalizedMAC.String(), len(allRefs))
+			})
+
+			It("should clear Pod collision when colliding VMI is deleted", Label(MetricsLabel), func() {
+				const sharedMAC = "02:00:00:00:cc:10"
+
+				pod1 := NewCollisionPod(TestNamespace, "test-clear-pod",
+					WithMultusNetwork(nadName, sharedMAC))
+				_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi1 := NewVMI(TestNamespace, "test-clear-vmi",
+					WithInterface(newInterface(nadName, sharedMAC)),
+					WithNetwork(newNetwork(nadName)))
+				Expect(testClient.CRClient.Create(context.TODO(), vmi1)).To(Succeed())
+
+				normalizedMAC, err := net.ParseMAC(sharedMAC)
+				Expect(err).ToNot(HaveOccurred())
+
+				waitForPodsRunning([]podReference{{pod1.Namespace, pod1.Name}})
+				waitForVMIsRunning([]vmiReference{{vmi1.Namespace, vmi1.Name}})
+
+				By("Verifying collision is detected")
+				expectMACCollisionGauge(normalizedMAC.String(), 2)
+
+				By("Deleting the colliding VMI")
+				Expect(testClient.CRClient.Delete(context.TODO(), vmi1)).To(Succeed())
+
+				By("Waiting for VMI to be deleted")
+				Eventually(func() bool {
+					return apierrors.IsNotFound(testClient.CRClient.Get(context.TODO(), client.ObjectKey{
+						Namespace: vmi1.Namespace,
+						Name:      vmi1.Name,
+					}, &kubevirtv1.VirtualMachineInstance{}))
+				}).WithTimeout(timeout).WithPolling(pollingInterval).Should(BeTrue())
+
+				By("Verifying collision is cleared")
+				expectMACCollisionGauge(normalizedMAC.String(), 0)
+			})
+
+			It("should clear VMI collision when colliding Pod is deleted", Label(MetricsLabel), func() {
+				const sharedMAC = "02:00:00:00:cc:20"
+
+				pod1 := NewCollisionPod(TestNamespace, "test-clear-pod",
+					WithMultusNetwork(nadName, sharedMAC))
+				_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi1 := NewVMI(TestNamespace, "test-clear-vmi",
+					WithInterface(newInterface(nadName, sharedMAC)),
+					WithNetwork(newNetwork(nadName)))
+				Expect(testClient.CRClient.Create(context.TODO(), vmi1)).To(Succeed())
+
+				normalizedMAC, err := net.ParseMAC(sharedMAC)
+				Expect(err).ToNot(HaveOccurred())
+
+				waitForPodsRunning([]podReference{{pod1.Namespace, pod1.Name}})
+				waitForVMIsRunning([]vmiReference{{vmi1.Namespace, vmi1.Name}})
+
+				By("Verifying collision is detected")
+				expectMACCollisionGauge(normalizedMAC.String(), 2)
+
+				By("Deleting the colliding Pod")
+				err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Delete(context.TODO(), pod1.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for Pod to be deleted")
+				Eventually(func() bool {
+					_, getErr := testClient.K8sClient.CoreV1().Pods(pod1.Namespace).Get(context.TODO(), pod1.Name, metav1.GetOptions{})
+					return apierrors.IsNotFound(getErr)
+				}).WithTimeout(timeout).WithPolling(pollingInterval).Should(BeTrue())
+
+				By("Verifying collision is cleared")
+				expectMACCollisionGauge(normalizedMAC.String(), 0)
+			})
+		})
+	})

--- a/tests/pod.go
+++ b/tests/pod.go
@@ -1,0 +1,90 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	multus "gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/types"
+)
+
+const (
+	podCollisionCleanupTimeout  = 2 * time.Minute
+	podCollisionCleanupInterval = 5 * time.Second
+)
+
+type PodOption func(*corev1.Pod)
+
+func WithMultusNetwork(nadName, mac string) PodOption {
+	return func(pod *corev1.Pod) {
+		var networks []*multus.NetworkSelectionElement
+		if existing, ok := pod.Annotations[networkv1.NetworkAttachmentAnnot]; ok {
+			_ = json.Unmarshal([]byte(existing), &networks)
+		}
+		networks = append(networks, &multus.NetworkSelectionElement{
+			Name:       nadName,
+			Namespace:  pod.Namespace,
+			MacRequest: mac,
+		})
+		data, _ := json.Marshal(networks)
+		pod.Annotations[networkv1.NetworkAttachmentAnnot] = string(data)
+	}
+}
+
+func NewCollisionPod(namespace, name string, opts ...PodOption) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        randName(name),
+			Namespace:   namespace,
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.PodSpec{
+			TerminationGracePeriodSeconds: &gracePeriodSeconds,
+			Containers: []corev1.Container{
+				{
+					Name:    "test",
+					Image:   "quay.io/centos/centos:stream9",
+					Command: []string{"/bin/bash", "-c", "sleep INF"},
+				},
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(pod)
+	}
+	return pod
+}
+
+func getPodEvents(namespace, podName string) (*corev1.EventList, error) {
+	return testClient.K8sClient.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod", podName),
+	})
+}
+
+func cleanupTestPodsInNamespaces(namespaces []string) {
+	for _, namespace := range namespaces {
+		podList, err := testClient.K8sClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		for i := range podList.Items {
+			err = testClient.K8sClient.CoreV1().Pods(namespace).Delete(context.TODO(), podList.Items[i].Name, metav1.DeleteOptions{})
+			if err != nil {
+				continue
+			}
+		}
+
+		Eventually(func() int {
+			list, listErr := testClient.K8sClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(listErr).ToNot(HaveOccurred())
+			return len(list.Items)
+		}).WithTimeout(podCollisionCleanupTimeout).WithPolling(podCollisionCleanupInterval).Should(Equal(0),
+			"All test pods in namespace %s should be deleted", namespace)
+	}
+}

--- a/tests/pod_collision_test.go
+++ b/tests/pod_collision_test.go
@@ -1,0 +1,555 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const PodMACCollisionDetectionLabel = "pod-mac-collision-detection"
+
+var _ = Describe("Pod MAC Collision Detection",
+	Label(PodMACCollisionDetectionLabel), Ordered, func() {
+		testNamespaces := []string{TestNamespace, OtherTestNamespace}
+
+		BeforeEach(func() {
+			By("Verify that there are no test Pods left from previous tests")
+			for _, ns := range testNamespaces {
+				podList, err := testClient.K8sClient.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Should successfully list Pods")
+				Expect(len(podList.Items)).To(BeZero(), "There should be no Pods in namespace %s before a test", ns)
+
+				err = cleanNamespaceLabels(ns)
+				Expect(err).ToNot(HaveOccurred(), "should be able to remove the namespace labels")
+			}
+		})
+
+		Context("Pod-Pod Collision Detection", func() {
+			BeforeEach(func() {
+				optInNamespaceForPods(TestNamespace)
+			})
+
+			AfterEach(func() {
+				cleanupTestPodsInNamespaces(testNamespaces)
+			})
+
+			Context("and the client tries to assign the same MAC address for two different Pods", func() {
+				var nadName1, nadName2 string
+
+				BeforeEach(func() {
+					nadName1 = randName("br")
+					nadName2 = randName("br-overlap")
+					By(fmt.Sprintf("Creating network attachment definitions: %s, %s", nadName1, nadName2))
+					Expect(createNetworkAttachmentDefinition(TestNamespace, nadName1)).To(Succeed())
+					Expect(createNetworkAttachmentDefinition(TestNamespace, nadName2)).To(Succeed())
+				})
+
+				AfterEach(func() {
+					By("Deleting network attachment definitions")
+					Expect(deleteNetworkAttachmentDefinition(TestNamespace, nadName1)).To(Succeed())
+					Expect(deleteNetworkAttachmentDefinition(TestNamespace, nadName2)).To(Succeed())
+				})
+
+				Context("When the MAC address is within range", func() {
+					DescribeTable("should detect inter-Pod MAC collisions", Label(MetricsLabel), func(separator string) {
+						const sharedMAC = "02:00:00:00:bb:01"
+						macWithSeparator := strings.Replace(sharedMAC, ":", separator, 5)
+
+						pod1 := NewCollisionPod(TestNamespace, "test-pod-1",
+							WithMultusNetwork(nadName1, sharedMAC))
+						_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+						Expect(err).ToNot(HaveOccurred(), "First Pod should be created successfully")
+
+						pod2 := NewCollisionPod(TestNamespace, "test-pod-2",
+							WithMultusNetwork(nadName2, macWithSeparator))
+						_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Second Pod with duplicate MAC should be created successfully")
+
+						normalizedMAC, err := net.ParseMAC(sharedMAC)
+						Expect(err).ToNot(HaveOccurred(), "Should parse shared MAC")
+
+						pods := []podReference{
+							{pod1.Namespace, pod1.Name},
+							{pod2.Namespace, pod2.Name},
+						}
+						refs := []collisionRef{
+							podRef(pod1.Namespace, pod1.Name),
+							podRef(pod2.Namespace, pod2.Name),
+						}
+
+						waitForPodsRunning(pods)
+						expectPodMACCollisionEvents(normalizedMAC.String(), refs)
+						expectMACCollisionGauge(normalizedMAC.String(), len(refs))
+					},
+						Entry("with the same mac format", ":"),
+						Entry("with different mac format", "-"),
+					)
+				})
+
+				Context("and the MAC address is out of range", func() {
+					It("should detect inter-Pod MAC collisions for out-of-range MAC", Label(MetricsLabel), func() {
+						outOfRangeMAC := "06:00:00:00:bb:00"
+
+						pod1 := NewCollisionPod(TestNamespace, "test-pod-out-range-1",
+							WithMultusNetwork(nadName1, outOfRangeMAC))
+						_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+						Expect(err).ToNot(HaveOccurred(), "First Pod should be created successfully")
+
+						pod2 := NewCollisionPod(TestNamespace, "test-pod-out-range-2",
+							WithMultusNetwork(nadName2, outOfRangeMAC))
+						_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Second Pod with duplicate MAC should be created successfully")
+
+						normalizedMAC, err := net.ParseMAC(outOfRangeMAC)
+						Expect(err).ToNot(HaveOccurred(), "Should parse out-of-range MAC")
+
+						pods := []podReference{
+							{pod1.Namespace, pod1.Name},
+							{pod2.Namespace, pod2.Name},
+						}
+						refs := []collisionRef{
+							podRef(pod1.Namespace, pod1.Name),
+							podRef(pod2.Namespace, pod2.Name),
+						}
+
+						waitForPodsRunning(pods)
+						expectPodMACCollisionEvents(normalizedMAC.String(), refs)
+						expectMACCollisionGauge(normalizedMAC.String(), len(refs))
+					})
+
+					It("should detect collision for 3+ Pods with same MAC", Label(MetricsLabel), func() {
+						const sharedMAC = "02:00:00:00:bb:10"
+
+						pod1 := NewCollisionPod(TestNamespace, "test-pod-multi-1",
+							WithMultusNetwork(nadName1, sharedMAC))
+						_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+						Expect(err).ToNot(HaveOccurred(), "First Pod should be created successfully")
+
+						pod2 := NewCollisionPod(TestNamespace, "test-pod-multi-2",
+							WithMultusNetwork(nadName2, sharedMAC))
+						_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Second Pod should be created successfully")
+
+						pod3 := NewCollisionPod(TestNamespace, "test-pod-multi-3",
+							WithMultusNetwork(nadName1, sharedMAC))
+						_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod3, metav1.CreateOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Third Pod should be created successfully")
+
+						normalizedMAC, err := net.ParseMAC(sharedMAC)
+						Expect(err).ToNot(HaveOccurred(), "Should parse shared MAC")
+
+						pods := []podReference{
+							{pod1.Namespace, pod1.Name},
+							{pod2.Namespace, pod2.Name},
+							{pod3.Namespace, pod3.Name},
+						}
+						refs := []collisionRef{
+							podRef(pod1.Namespace, pod1.Name),
+							podRef(pod2.Namespace, pod2.Name),
+							podRef(pod3.Namespace, pod3.Name),
+						}
+
+						waitForPodsRunning(pods)
+						expectPodMACCollisionEvents(normalizedMAC.String(), refs)
+						expectMACCollisionGauge(normalizedMAC.String(), len(refs))
+					})
+				})
+			})
+
+			Context("and Pods have multiple interfaces with partial MAC collisions", func() {
+				var net1Name, net2Name, net3Name string
+
+				BeforeEach(func() {
+					net1Name = randName("net1")
+					net2Name = randName("net2")
+					net3Name = randName("net3")
+					By(fmt.Sprintf("Creating network attachment definitions: %s, %s, %s", net1Name, net2Name, net3Name))
+					Expect(createNetworkAttachmentDefinition(TestNamespace, net1Name)).To(Succeed())
+					Expect(createNetworkAttachmentDefinition(TestNamespace, net2Name)).To(Succeed())
+					Expect(createNetworkAttachmentDefinition(TestNamespace, net3Name)).To(Succeed())
+				})
+
+				AfterEach(func() {
+					By("Deleting network attachment definitions")
+					Expect(deleteNetworkAttachmentDefinition(TestNamespace, net1Name)).To(Succeed())
+					Expect(deleteNetworkAttachmentDefinition(TestNamespace, net2Name)).To(Succeed())
+					Expect(deleteNetworkAttachmentDefinition(TestNamespace, net3Name)).To(Succeed())
+				})
+
+				It("should detect collision only for the colliding MAC when Pod has multiple interfaces", Label(MetricsLabel), func() {
+					const (
+						collidingMAC = "02:00:00:00:bb:20"
+						uniqueMAC1   = "02:00:00:00:bb:21"
+						uniqueMAC2   = "02:00:00:00:bb:22"
+					)
+
+					pod1 := NewCollisionPod(TestNamespace, "test-pod-partial-1",
+						WithMultusNetwork(net1Name, collidingMAC),
+						WithMultusNetwork(net2Name, uniqueMAC1))
+					_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					pod2 := NewCollisionPod(TestNamespace, "test-pod-partial-2",
+						WithMultusNetwork(net1Name, collidingMAC),
+						WithMultusNetwork(net3Name, uniqueMAC2))
+					_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					pods := []podReference{
+						{pod1.Namespace, pod1.Name},
+						{pod2.Namespace, pod2.Name},
+					}
+					refs := []collisionRef{
+						podRef(pod1.Namespace, pod1.Name),
+						podRef(pod2.Namespace, pod2.Name),
+					}
+
+					waitForPodsRunning(pods)
+
+					By("Verifying collision event only for the colliding MAC")
+					normalizedCollidingMAC, err := net.ParseMAC(collidingMAC)
+					Expect(err).ToNot(HaveOccurred())
+					normalizedUniqueMAC2, err := net.ParseMAC(uniqueMAC2)
+					Expect(err).ToNot(HaveOccurred())
+
+					expectPodMACCollisionEvents(normalizedCollidingMAC.String(), refs)
+					expectMACCollisionGauge(normalizedCollidingMAC.String(), len(refs))
+					expectNoMACCollisionGaugeConsistently(normalizedUniqueMAC2.String())
+				})
+
+				It("should detect multiple collisions on same Pod when it has multiple colliding MACs", Label(MetricsLabel), func() {
+					const (
+						macA = "02:00:00:00:bb:30"
+						macB = "02:00:00:00:bb:31"
+					)
+
+					pod1 := NewCollisionPod(TestNamespace, "test-pod-double-1",
+						WithMultusNetwork(net1Name, macA),
+						WithMultusNetwork(net2Name, macB))
+					_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					pod2 := NewCollisionPod(TestNamespace, "test-pod-double-2",
+						WithMultusNetwork(net1Name, macA))
+					_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					pod3 := NewCollisionPod(TestNamespace, "test-pod-double-3",
+						WithMultusNetwork(net2Name, macB))
+					_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod3, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					waitForPodsRunning([]podReference{
+						{pod1.Namespace, pod1.Name},
+						{pod2.Namespace, pod2.Name},
+						{pod3.Namespace, pod3.Name},
+					})
+
+					By("Verifying collision events for macA")
+					normalizedMacA, err := net.ParseMAC(macA)
+					Expect(err).ToNot(HaveOccurred())
+					expectPodMACCollisionEvents(normalizedMacA.String(),
+						[]collisionRef{
+							podRef(pod1.Namespace, pod1.Name),
+							podRef(pod2.Namespace, pod2.Name),
+						})
+					expectMACCollisionGauge(normalizedMacA.String(), 2)
+
+					By("Verifying collision events for macB")
+					normalizedMacB, err := net.ParseMAC(macB)
+					Expect(err).ToNot(HaveOccurred())
+					expectPodMACCollisionEvents(normalizedMacB.String(),
+						[]collisionRef{
+							podRef(pod1.Namespace, pod1.Name),
+							podRef(pod3.Namespace, pod3.Name),
+						})
+					expectMACCollisionGauge(normalizedMacB.String(), 2)
+				})
+
+				It("should clear collision when colliding Pod is deleted", Label(MetricsLabel), func() {
+					const sharedMAC = "02:00:00:00:bb:40"
+
+					pod1 := NewCollisionPod(TestNamespace, "test-pod-delete-1",
+						WithMultusNetwork(net1Name, sharedMAC))
+					_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					pod2 := NewCollisionPod(TestNamespace, "test-pod-delete-2",
+						WithMultusNetwork(net2Name, sharedMAC))
+					_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					normalizedMAC, err := net.ParseMAC(sharedMAC)
+					Expect(err).ToNot(HaveOccurred())
+
+					waitForPodsRunning([]podReference{
+						{pod1.Namespace, pod1.Name},
+						{pod2.Namespace, pod2.Name},
+					})
+
+					By("Verifying collision is detected")
+					expectMACCollisionGauge(normalizedMAC.String(), 2)
+
+					By("Deleting one of the colliding Pods")
+					err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Delete(context.TODO(), pod1.Name, metav1.DeleteOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Waiting for Pod to be deleted")
+					Eventually(func() bool {
+						_, getErr := testClient.K8sClient.CoreV1().Pods(pod1.Namespace).Get(context.TODO(), pod1.Name, metav1.GetOptions{})
+						return apierrors.IsNotFound(getErr)
+					}).WithTimeout(timeout).WithPolling(pollingInterval).Should(BeTrue())
+
+					By("Verifying collision is cleared")
+					expectMACCollisionGauge(normalizedMAC.String(), 0)
+				})
+
+				It("should clear only specific collision when one of multiple colliding Pods is deleted", Label(MetricsLabel), func() {
+					const (
+						macA = "02:00:00:00:bb:50"
+						macB = "02:00:00:00:bb:51"
+					)
+
+					pod1 := NewCollisionPod(TestNamespace, "test-pod-multi-collision-1",
+						WithMultusNetwork(net1Name, macA),
+						WithMultusNetwork(net2Name, macB))
+					_, err := testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					pod2 := NewCollisionPod(TestNamespace, "test-pod-multi-collision-2",
+						WithMultusNetwork(net1Name, macA))
+					_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					pod3 := NewCollisionPod(TestNamespace, "test-pod-multi-collision-3",
+						WithMultusNetwork(net2Name, macB))
+					_, err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Create(context.TODO(), pod3, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					normalizedMacA, err := net.ParseMAC(macA)
+					Expect(err).ToNot(HaveOccurred())
+					normalizedMacB, err := net.ParseMAC(macB)
+					Expect(err).ToNot(HaveOccurred())
+
+					waitForPodsRunning([]podReference{
+						{pod1.Namespace, pod1.Name},
+						{pod2.Namespace, pod2.Name},
+						{pod3.Namespace, pod3.Name},
+					})
+
+					By("Verifying both collisions are detected")
+					expectMACCollisionGauge(normalizedMacA.String(), 2)
+					expectMACCollisionGauge(normalizedMacB.String(), 2)
+
+					By("Deleting pod2 (involved only in macA collision)")
+					err = testClient.K8sClient.CoreV1().Pods(TestNamespace).Delete(context.TODO(), pod2.Name, metav1.DeleteOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Waiting for pod2 to be deleted")
+					Eventually(func() bool {
+						_, getErr := testClient.K8sClient.CoreV1().Pods(pod2.Namespace).Get(context.TODO(), pod2.Name, metav1.GetOptions{})
+						return apierrors.IsNotFound(getErr)
+					}).WithTimeout(timeout).WithPolling(pollingInterval).Should(BeTrue())
+
+					By("Verifying macA collision is cleared but macB collision remains")
+					expectMACCollisionGauge(normalizedMacA.String(), 0)
+					expectMACCollisionGauge(normalizedMacB.String(), 2)
+				})
+			})
+		})
+
+		Context("Pod collision detection and namespace management", Label("pod-opt-in"), func() {
+			managedNamespace := OtherTestNamespace
+			notManagedNamespace := TestNamespace
+
+			BeforeEach(func() {
+				By("Setting pod webhook to opt-in mode")
+				Expect(setPodWebhookOptMode(optInMode)).To(Succeed(),
+					"should set pod opt-mode to opt-in in mutatingwebhookconfiguration")
+			})
+
+			AfterEach(func() {
+				cleanupTestPodsInNamespaces(testNamespaces)
+
+				By("Restoring pod webhook to opt-out mode")
+				Expect(setPodWebhookOptMode(optOutMode)).To(Succeed(),
+					"should restore pod opt-mode to opt-out in mutatingwebhookconfiguration")
+			})
+
+			Context("and both Pods are created in an opted-in namespace", func() {
+				var nadName string
+
+				BeforeEach(func() {
+					optInNamespaceForPods(managedNamespace)
+
+					nadName = randName("br")
+					Expect(createNetworkAttachmentDefinition(managedNamespace, nadName)).To(Succeed())
+				})
+				AfterEach(func() {
+					Expect(deleteNetworkAttachmentDefinition(managedNamespace, nadName)).To(Succeed())
+				})
+
+				It("should detect collision for Pods in opted-in namespace with duplicate MAC", Label(MetricsLabel), func() {
+					const sharedMAC = "02:00:00:00:bb:60"
+
+					pod1 := NewCollisionPod(managedNamespace, "test-pod-optin-1",
+						WithMultusNetwork(nadName, sharedMAC))
+					_, err := testClient.K8sClient.CoreV1().Pods(managedNamespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					pod2 := NewCollisionPod(managedNamespace, "test-pod-optin-2",
+						WithMultusNetwork(nadName, sharedMAC))
+					_, err = testClient.K8sClient.CoreV1().Pods(managedNamespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					normalizedMAC, err := net.ParseMAC(sharedMAC)
+					Expect(err).ToNot(HaveOccurred())
+
+					pods := []podReference{
+						{pod1.Namespace, pod1.Name},
+						{pod2.Namespace, pod2.Name},
+					}
+					refs := []collisionRef{
+						podRef(pod1.Namespace, pod1.Name),
+						podRef(pod2.Namespace, pod2.Name),
+					}
+
+					waitForPodsRunning(pods)
+					expectPodMACCollisionEvents(normalizedMAC.String(), refs)
+					expectMACCollisionGauge(normalizedMAC.String(), len(refs))
+				})
+			})
+
+			Context("and one Pod is in an opted-in namespace and the other in a non-opted-in namespace", func() {
+				var nadName string
+
+				BeforeEach(func() {
+					optInNamespaceForPods(managedNamespace)
+
+					nadName = randName("br")
+					Expect(createNetworkAttachmentDefinition(notManagedNamespace, nadName)).To(Succeed())
+					Expect(createNetworkAttachmentDefinition(managedNamespace, nadName)).To(Succeed())
+				})
+				AfterEach(func() {
+					Expect(deleteNetworkAttachmentDefinition(notManagedNamespace, nadName)).To(Succeed())
+					Expect(deleteNetworkAttachmentDefinition(managedNamespace, nadName)).To(Succeed())
+				})
+
+				It("should not report collision for Pod in managed vs unmanaged namespace with same MAC", Label(MetricsLabel), func() {
+					const sharedMAC = "02:00:00:00:bb:70"
+
+					By("Creating Pod in unmanaged (non-opted-in) namespace")
+					podUnmanaged := NewCollisionPod(notManagedNamespace, "test-pod-unmanaged",
+						WithMultusNetwork(nadName, sharedMAC))
+					_, err := testClient.K8sClient.CoreV1().Pods(notManagedNamespace).Create(context.TODO(), podUnmanaged, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Creating Pod in managed (opted-in) namespace with same MAC")
+					podManaged := NewCollisionPod(managedNamespace, "test-pod-managed",
+						WithMultusNetwork(nadName, sharedMAC))
+					_, err = testClient.K8sClient.CoreV1().Pods(managedNamespace).Create(context.TODO(), podManaged, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					allPods := []podReference{
+						{podManaged.Namespace, podManaged.Name},
+						{podUnmanaged.Namespace, podUnmanaged.Name},
+					}
+
+					waitForPodsRunning(allPods)
+					expectNoPodMACCollisionEvents(allPods, "unmanaged namespace is ignored")
+					expectNoMACCollisionGaugeConsistently(sharedMAC)
+				})
+			})
+		})
+
+	})
+
+type podReference struct {
+	namespace string
+	name      string
+}
+
+type collisionRef struct {
+	objectType string
+	namespace  string
+	name       string
+}
+
+func podRef(namespace, name string) collisionRef {
+	return collisionRef{objectType: "pod", namespace: namespace, name: name}
+}
+
+func vmiRef(namespace, name string) collisionRef {
+	return collisionRef{objectType: "vmi", namespace: namespace, name: name}
+}
+
+func buildCollisionMessage(mac string, refs []collisionRef) string {
+	keys := make([]string, len(refs))
+	for i, ref := range refs {
+		keys[i] = fmt.Sprintf("%s/%s/%s", ref.objectType, ref.namespace, ref.name)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("MAC %s: Collision between %s", mac, strings.Join(keys, ", "))
+}
+
+func waitForPodsRunning(pods []podReference) {
+	By("Waiting for Pods to reach Running phase")
+	for _, pod := range pods {
+		Eventually(func() corev1.PodPhase {
+			p, err := testClient.K8sClient.CoreV1().Pods(pod.namespace).Get(context.TODO(), pod.name, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return p.Status.Phase
+		}).WithTimeout(timeout).WithPolling(pollingInterval).Should(Equal(corev1.PodRunning),
+			"Pod %s/%s should reach Running phase", pod.namespace, pod.name)
+	}
+}
+
+// expectPodMACCollisionEvents checks collision events on all Pod refs in allRefs.
+// Non-Pod refs are only used to construct the expected collision message.
+func expectPodMACCollisionEvents(mac string, allRefs []collisionRef) {
+	By("checking for collision event on Pods")
+	expectedMessage := buildCollisionMessage(mac, allRefs)
+
+	for _, ref := range allRefs {
+		if ref.objectType != "pod" {
+			continue
+		}
+
+		By(fmt.Sprintf("Checking for MACCollision event on Pod %s/%s", ref.namespace, ref.name))
+		Eventually(func(g Gomega) []corev1.Event {
+			events, err := getPodEvents(ref.namespace, ref.name)
+			g.Expect(err).NotTo(HaveOccurred())
+			return events.Items
+		}).WithTimeout(timeout).WithPolling(pollingInterval).Should(ContainElement(And(
+			HaveField("Reason", "MACCollision"),
+			HaveField("Message", expectedMessage),
+		)), fmt.Sprintf("Pod %s/%s should have MACCollision event", ref.namespace, ref.name))
+	}
+}
+
+func expectNoPodMACCollisionEvents(pods []podReference, reason string) {
+	By(fmt.Sprintf("checking that Pods do NOT have collision events: %s", reason))
+	const consistentlyTimeout = 5 * time.Second
+	for _, pod := range pods {
+		By(fmt.Sprintf("Checking that Pod %s/%s does NOT have MACCollision event", pod.namespace, pod.name))
+		Consistently(func(g Gomega) []corev1.Event {
+			events, err := getPodEvents(pod.namespace, pod.name)
+			g.Expect(err).NotTo(HaveOccurred())
+			return events.Items
+		}).WithTimeout(consistentlyTimeout).WithPolling(pollingInterval).ShouldNot(ContainElement(
+			HaveField("Reason", "MACCollision"),
+		), fmt.Sprintf("Pod %s/%s should NOT have MACCollision event: %s", pod.namespace, pod.name, reason))
+	}
+}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -521,8 +521,7 @@ func getOptMode(webhookName string) (string, error) {
 	return "", fmt.Errorf("webhook %s not found in mutatingWebhookConfiguration", webhookName)
 }
 
-func setVMWebhookOptMode(optMode string) error {
-	const webhookName = vmNamespaceOptInLabel
+func setWebhookOptMode(webhookName, optMode string) error {
 	By(fmt.Sprintf("Setting webhook %s to %s in MutatingWebhookConfigurations instance", webhookName, optMode))
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		mutatingWebhook, err := testClient.K8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(),
@@ -564,6 +563,43 @@ func setVMWebhookOptMode(optMode string) error {
 		return errors.Wrap(err, "failed to perform Retry on Conflict to set opt mode")
 	}
 	return nil
+}
+
+func setVMWebhookOptMode(optMode string) error {
+	return setWebhookOptMode(vmNamespaceOptInLabel, optMode)
+}
+
+func setPodWebhookOptMode(optMode string) error {
+	return setWebhookOptMode(podNamespaceOptInLabel, optMode)
+}
+
+func optInNamespaceForPods(namespace string) {
+	By(fmt.Sprintf("opting in namespace %s for pod MAC allocation", namespace))
+	Expect(addLabelsToNamespace(namespace, map[string]string{podNamespaceOptInLabel: "allocate"})).To(Succeed(),
+		"should be able to add opt-in label to namespace")
+
+	probeNadName := randName("probe-nad")
+	Expect(createNetworkAttachmentDefinition(namespace, probeNadName)).To(Succeed(),
+		"should create probe NAD for opt-in verification")
+	defer func() {
+		Expect(deleteNetworkAttachmentDefinition(namespace, probeNadName)).To(Succeed(),
+			"should delete probe NAD after opt-in verification")
+	}()
+
+	By("waiting for webhook to recognize namespace as opted-in for pods")
+	Eventually(func(g Gomega) {
+		pod := NewCollisionPod(namespace, "webhook-probe",
+			WithMultusNetwork(probeNadName, ""))
+		created, createErr := testClient.K8sClient.CoreV1().Pods(namespace).Create(
+			context.TODO(),
+			pod,
+			metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+		)
+		g.Expect(createErr).To(Succeed())
+		macAnnotation := created.Annotations["k8s.v1.cni.cncf.io/networks"]
+		g.Expect(macAnnotation).To(ContainSubstring("mac"),
+			"Pod should have MAC allocated by webhook in opted-in namespace")
+	}, webhookPropagationTimeout, webhookPropagationInterval).Should(Succeed())
 }
 
 func addFinalizer(virtualMachine *kubevirtv1.VirtualMachine, finalizerName string) error {

--- a/tests/vmi_migration_test.go
+++ b/tests/vmi_migration_test.go
@@ -77,6 +77,16 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				waitForVMsDeleted(testNamespaces)
 				waitForVMIsDeleted(testNamespaces)
 
+				By("Waiting for virt-launcher pods to terminate in test namespaces")
+				for _, ns := range testNamespaces {
+					Eventually(func() int {
+						podList, err := testClient.K8sClient.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return len(podList.Items)
+					}).WithTimeout(timeout).WithPolling(pollingInterval).Should(BeZero(),
+						"All pods in namespace %s should terminate after VMI cleanup", ns)
+				}
+
 				By("Deleting network attachment definitions")
 				Expect(deleteNetworkAttachmentDefinition(TestNamespace, nadName)).To(Succeed())
 				Expect(deleteNetworkAttachmentDefinition(OtherTestNamespace, nadName)).To(Succeed())

--- a/tests/vmi_test.go
+++ b/tests/vmi_test.go
@@ -604,7 +604,7 @@ type vmiReference struct {
 func buildExpectedCollisionMessage(mac string, vmis []vmiReference) string {
 	vmiRefs := make([]string, len(vmis))
 	for i, vmi := range vmis {
-		vmiRefs[i] = fmt.Sprintf("%s/%s", vmi.namespace, vmi.name)
+		vmiRefs[i] = fmt.Sprintf("vmi/%s/%s", vmi.namespace, vmi.name)
 	}
 	sort.Strings(vmiRefs)
 	return fmt.Sprintf("MAC %s: Collision between %s", mac, strings.Join(vmiRefs, ", "))

--- a/tests/vmi_test.go
+++ b/tests/vmi_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "k8s.io/api/core/v1"
@@ -55,6 +56,16 @@ var _ = Describe("[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(testClient.CRClient.List(context.TODO(), vmiList)).To(Succeed())
 					return vmiList.Items
 				}).WithTimeout(timeout).WithPolling(pollingInterval).Should(HaveLen(0), "failed to remove all vmi objects")
+
+				By("Waiting for virt-launcher pods to terminate in test namespaces")
+				for _, ns := range []string{TestNamespace, OtherTestNamespace} {
+					Eventually(func() int {
+						podList, err := testClient.K8sClient.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return len(podList.Items)
+					}).WithTimeout(timeout).WithPolling(pollingInterval).Should(BeZero(),
+						"All pods in namespace %s should terminate after VMI cleanup", ns)
+				}
 			})
 
 			Context("and the client tries to assign the same MAC address for two different VMI. Within Range and out of range", func() {


### PR DESCRIPTION
This PR introduces a pod MAC collision detection controller, that will replace the current pod  MAC collision rejection webhook behavior.
It introduces a controller for pod collisions, and also handles cross-pod-vmi coliision cases.
In order to keep consistency between the cross-collision objects, a secondary watch is added, along with e2e that cover all above scenarios.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
```release-note
Remove pod create/update rejection behavior when colliding MAC
Add pod MAC collision detection controller
```
