### PR TITLE
Proposal: Change some env vars to flags

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"net"
 	"os"
 	"time"
@@ -36,22 +35,8 @@ import (
 
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/manager"
 	"github.com/k8snetworkplumbingwg/kubemacpool/pkg/names"
-	poolmanager "github.com/k8snetworkplumbingwg/kubemacpool/pkg/pool-manager"
 	kmptls "github.com/k8snetworkplumbingwg/kubemacpool/pkg/tls"
 )
-
-func loadMacAddressFromEnvVar(envName string) (net.HardwareAddr, error) {
-	if value, ok := os.LookupEnv(envName); ok {
-		poolRange, err := net.ParseMAC(value)
-		if err != nil {
-			return nil, err
-		}
-
-		return poolRange, nil
-	}
-
-	return nil, fmt.Errorf("Environment variable %s don't exist", envName)
-}
 
 func main() {
 	_, ok := os.LookupEnv("RUN_CERT_MANAGER")
@@ -154,6 +139,7 @@ func runKubemacpoolManager() {
 	var logType, metricsAddr string
 	var waitingTime int
 	var tlsMinVersion, tlsCiphers string
+	var macRangeStart, macRangeEnd string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&logType, "v", "production", "Log type (debug/production).")
@@ -165,6 +151,8 @@ func runKubemacpoolManager() {
 		"Supported values are tls package constants names (e.g. TLS_AES_128_GCM_SHA256), please see "+
 		"https://pkg.go.dev/crypto/tls#pkg-constants. "+
 		"When 'tls-min-version' is 'VersionTLS13', cipher suites are selected by the runtime.")
+	flag.StringVar(&macRangeStart, "mac-pool-range-start", "", "MAC address pool range start (e.g. 02:00:00:00:00:00)")
+	flag.StringVar(&macRangeEnd, "mac-pool-range-end", "", "MAC address pool range end (e.g. 02:FF:FF:FF:FF:FF)")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(logType != "production")))
@@ -183,15 +171,15 @@ func runKubemacpoolManager() {
 		os.Exit(1)
 	}
 
-	rangeStart, err := loadMacAddressFromEnvVar(poolmanager.RangeStartEnv)
+	rangeStart, err := net.ParseMAC(macRangeStart)
 	if err != nil {
-		log.Error(err, "Failed to load mac address from environment variable")
+		log.Error(err, "Failed to parse mac-pool-range-start flag")
 		os.Exit(1)
 	}
 
-	rangeEnd, err := loadMacAddressFromEnvVar(poolmanager.RangeEndEnv)
+	rangeEnd, err := net.ParseMAC(macRangeEnd)
 	if err != nil {
-		log.Error(err, "Failed to load mac address from environment variable")
+		log.Error(err, "Failed to parse mac-pool-range-end flag")
 		os.Exit(1)
 	}
 

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -85,6 +85,8 @@ spec:
         args:
           - "--v=production"
           - "--wait-time=300"
+          - "--mac-pool-range-start=02:00:00:00:00:00"
+          - "--mac-pool-range-end=02:FF:FF:FF:FF:FF"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -102,16 +104,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: RANGE_START
-            valueFrom:
-              configMapKeyRef:
-                name: mac-range-config
-                key: RANGE_START
-          - name: RANGE_END
-            valueFrom:
-              configMapKeyRef:
-                name: mac-range-config
-                key: RANGE_END
           - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
             value: "v1"
         resources:

--- a/config/release/kubemacpool.yaml
+++ b/config/release/kubemacpool.yaml
@@ -275,6 +275,8 @@ spec:
       - args:
         - --v=production
         - --wait-time=300
+        - --mac-pool-range-start=02:00:00:00:00:00
+        - --mac-pool-range-end=02:FF:FF:FF:FF:FF
         command:
         - /manager
         env:
@@ -286,16 +288,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: RANGE_START
-          valueFrom:
-            configMapKeyRef:
-              key: RANGE_START
-              name: kubemacpool-mac-range-config
-        - name: RANGE_END
-          valueFrom:
-            configMapKeyRef:
-              key: RANGE_END
-              name: kubemacpool-mac-range-config
         - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
           value: v1
         image: quay.io/kubevirt/kubemacpool:latest

--- a/config/test/kubemacpool.yaml
+++ b/config/test/kubemacpool.yaml
@@ -276,6 +276,8 @@ spec:
       - args:
         - --v=debug
         - --wait-time=300
+        - --mac-pool-range-start=02:00:00:00:00:00
+        - --mac-pool-range-end=02:FF:FF:FF:FF:FF
         command:
         - /manager
         env:
@@ -287,16 +289,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: RANGE_START
-          valueFrom:
-            configMapKeyRef:
-              key: RANGE_START
-              name: kubemacpool-mac-range-config
-        - name: RANGE_END
-          valueFrom:
-            configMapKeyRef:
-              key: RANGE_END
-              name: kubemacpool-mac-range-config
         - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
           value: v1
         image: registry:5000/kubevirt/kubemacpool:latest


### PR DESCRIPTION
Fixes #606

**What this PR does / why we need it**:

This PR replaces the `RANGE_START` and `RANGE_END` environment variables with command-line flags `--mac-pool-range-start` and `--mac-pool-range-end`.

Flags are easier to work with, provide better validation, and offer predictable default values with built-in descriptions. This change follows the same pattern as the recent TLS flags conversion in #608.

Changes:
- Added `--mac-pool-range-start` and `--mac-pool-range-end` flags to the manager
- Removed environment variable loading for `RANGE_START` and `RANGE_END`
- Updated deployment manifests (default, release, and test) to pass MAC range values as command-line arguments instead of environment variables
- Removed unused `loadMacAddressFromEnvVar` helper function

The ConfigMap-based dynamic range updates (Day 2 operations) are still supported through the ConfigMap controller.

**Special notes for your reviewer**:

- Unit tests pass successfully
- The ConfigMap controller continues to work for runtime updates to the MAC pool range
- This change only affects the initial configuration at startup
- The `RANGE_START` and `RANGE_END` constants in `pkg/pool-manager/pool.go` are kept for now (similar to how the TLS constants were kept in PR #608)

**Release note**:

```release-note
Replace RANGE_START and RANGE_END environment variables with --mac-pool-range-start and --mac-pool-range-end command-line flags. Users must update their deployment manifests to pass these values as flags instead of environment variables.
```

<!-- oompa-bot v:90d370e -->