### PR TITLE
docs: add contributing guide for commit signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thank you for contributing to Kubemacpool.
+
+## Commit requirements
+
+All commits must meet both requirements below:
+
+- Include a `Signed-off-by` trailer (DCO sign-off).
+- Be created with a verified cryptographic signature (`GPG` or `SSH`).


### PR DESCRIPTION
**What this PR does / why we need it**:
Document contribution requirements for DCO signoff and verified cryptographic commit signatures.

**Special notes for your reviewer**:
Required signature was enabled, lets have it documented.

**Release note**:

```release-note
NONE
```
