### PR TITLE
Proposal: Change some env vars to flags

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -40,17 +40,27 @@ import (
 	kmptls "github.com/k8snetworkplumbingwg/kubemacpool/pkg/tls"
 )
 
-func loadMacAddressFromEnvVar(envName string) (net.HardwareAddr, error) {
-	if value, ok := os.LookupEnv(envName); ok {
-		poolRange, err := net.ParseMAC(value)
+// loadMacAddress loads MAC address from flag value or falls back to environment variable for backward compatibility
+func loadMacAddress(flagValue, envName string) (net.HardwareAddr, error) {
+	// Prefer flag value if provided
+	if flagValue != "" {
+		poolRange, err := net.ParseMAC(flagValue)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse MAC address from flag: %w", err)
 		}
-
 		return poolRange, nil
 	}
 
-	return nil, fmt.Errorf("Environment variable %s don't exist", envName)
+	// Fall back to environment variable for backward compatibility
+	if value, ok := os.LookupEnv(envName); ok {
+		poolRange, err := net.ParseMAC(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse MAC address from environment variable %s: %w", envName, err)
+		}
+		return poolRange, nil
+	}
+
+	return nil, fmt.Errorf("MAC address not provided via flag or environment variable %s", envName)
 }
 
 func main() {
@@ -154,6 +164,7 @@ func runKubemacpoolManager() {
 	var logType, metricsAddr string
 	var waitingTime int
 	var tlsMinVersion, tlsCiphers string
+	var macPoolRangeStart, macPoolRangeEnd string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&logType, "v", "production", "Log type (debug/production).")
@@ -165,6 +176,8 @@ func runKubemacpoolManager() {
 		"Supported values are tls package constants names (e.g. TLS_AES_128_GCM_SHA256), please see "+
 		"https://pkg.go.dev/crypto/tls#pkg-constants. "+
 		"When 'tls-min-version' is 'VersionTLS13', cipher suites are selected by the runtime.")
+	flag.StringVar(&macPoolRangeStart, "mac-pool-range-start", "", "MAC address pool range start (e.g. 02:00:00:00:00:00).")
+	flag.StringVar(&macPoolRangeEnd, "mac-pool-range-end", "", "MAC address pool range end (e.g. 02:FF:FF:FF:FF:FF).")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(logType != "production")))
@@ -183,15 +196,15 @@ func runKubemacpoolManager() {
 		os.Exit(1)
 	}
 
-	rangeStart, err := loadMacAddressFromEnvVar(poolmanager.RangeStartEnv)
+	rangeStart, err := loadMacAddress(macPoolRangeStart, poolmanager.RangeStartEnv)
 	if err != nil {
-		log.Error(err, "Failed to load mac address from environment variable")
+		log.Error(err, "Failed to load MAC pool range start")
 		os.Exit(1)
 	}
 
-	rangeEnd, err := loadMacAddressFromEnvVar(poolmanager.RangeEndEnv)
+	rangeEnd, err := loadMacAddress(macPoolRangeEnd, poolmanager.RangeEndEnv)
 	if err != nil {
-		log.Error(err, "Failed to load mac address from environment variable")
+		log.Error(err, "Failed to load MAC pool range end")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Fixes #606

**What this PR does / why we need it**:

This PR converts the MAC pool range environment variables (`RANGE_START` and `RANGE_END`) to command-line flags (`--mac-pool-range-start` and `--mac-pool-range-end`) as proposed in issue #606.

The change provides:
- More idiomatic configuration via flags with built-in help documentation
- Predictable defaults and clearer error messages
- Backward compatibility by falling back to environment variables when flags are not provided

Note: The TLS-related environment variables (`TLS_MIN_VERSION` and `TLS_CIPHERS`) mentioned in the issue were already converted to flags (`--tls-min-version` and `--tls-cipher-suites`) in a previous change.

**Special notes for your reviewer**:

- The implementation maintains full backward compatibility - existing deployments using environment variables will continue to work
- Flags take precedence over environment variables when both are provided
- The constants `RangeStartEnv` and `RangeEndEnv` in `pkg/pool-manager/pool.go` are kept for backward compatibility
- No changes to deployment manifests are required, though users are encouraged to migrate to flags for better clarity

**Release note**:

```release-note
Add command-line flags --mac-pool-range-start and --mac-pool-range-end for configuring MAC pool ranges. Environment variables RANGE_START and RANGE_END are still supported for backward compatibility.
```

<!-- oompa-bot v:121748b -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now configure MAC pool range via command-line flags, with environment variable fallback for enhanced configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->