### PR TITLE
CI: Docker daemon startup failure and e2e timeouts on release-0.39 Prow jobs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["release-0.45", "release-0.44", "release-0.43", "release-0.42", "release-0.41", "release-0.39" ,"main"],
+  "baseBranches": ["release-0.45", "release-0.44", "release-0.43", "release-0.42", "release-0.41", "main"],
   "prConcurrentLimit": 3,
   "lockFileMaintenance": {
     "enabled": false


### PR DESCRIPTION
Fixes #645

**What this PR does / why we need it**:

This PR removes release-0.39 from Renovate's `baseBranches` configuration to stop automatic dependency update PRs that consistently fail CI checks.

The release-0.39 branch Prow CI jobs are failing due to infrastructure incompatibility:
- Unit-test jobs: Docker/Podman daemon fails to start within the container environment
- E2e jobs: Either the same daemon failure or 3-hour timeout during kubevirtci cluster image download

The release-0.39 branch uses very old versions (k8s-1.23, kubevirtci tag from 2022) that are incompatible with the current Prow infrastructure.

**Special notes for your reviewer**:

This change prevents Renovate from automatically creating PRs for the release-0.39 branch. If critical security updates are needed for this old release, they can be manually backported. The other active release branches (0.41-0.45) remain in Renovate's configuration and will continue to receive automatic updates.

**Release note**:

```release-note
NONE
```

<!-- oompa-bot v:0936faa -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation configuration to remove deprecated branch references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->