### PR TITLE
Add govulncheck Makefile target and per-CVE check script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,23 @@ lint-fix: $(GOLANGCI_LINT_BIN)
 lint-metrics: $(GO)
 	OCI_BIN=$(OCI_BIN) ./hack/prom_metric_linter.sh --operator-name="kmp" --sub-operator-name="kmp"
 
+GOVULNCHECK_BIN := $(BIN_DIR)/govulncheck
+
+$(GOVULNCHECK_BIN): $(GO)
+	GOFLAGS= GOBIN=$(BIN_DIR) $(GO) install golang.org/x/vuln/cmd/govulncheck@latest
+
+govulncheck: $(GOVULNCHECK_BIN)
+	@$(GOVULNCHECK_BIN) -format json ./...
+
+GOVULNCHECK_PARSER_BIN := $(BIN_DIR)/govulncheck-parser
+
+GOVULNCHECK_PARSER_SRC := $(wildcard tools/govulncheck-parser/*.go)
+
+$(GOVULNCHECK_PARSER_BIN): $(GO) $(GOVULNCHECK_PARSER_SRC)
+	$(GO) build -o $(GOVULNCHECK_PARSER_BIN) ./tools/govulncheck-parser
+
+govulncheck-parser: $(GOVULNCHECK_PARSER_BIN)
+
 install-deep-copy: $(GO)
 	$(DEEPCOPY_GEN)
 
@@ -231,4 +248,6 @@ vendor: $(GO)
 	lint \
 	lint-fix \
 	lint-metrics \
+	govulncheck \
+	govulncheck-parser \
 	prom-rules-verify

--- a/hack/check-cve.sh
+++ b/hack/check-cve.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+
+CVE_ID="${1}"
+if [[ -z "${CVE_ID}" ]]; then
+    echo "Usage: $0 <CVE-ID>"
+    echo "Example: $0 CVE-2025-22868"
+    exit 1
+fi
+
+if [[ ! "${CVE_ID}" =~ ^CVE-[0-9]{4}-[0-9]+$ ]]; then
+    echo "Error: '${CVE_ID}' is not a valid CVE ID (expected format: CVE-YYYY-NNNNN)"
+    exit 1
+fi
+
+PROJECT_ROOT="$(readlink -e "$(dirname "${BASH_SOURCE[0]}")/../")"
+PARSER="${PROJECT_ROOT}/build/_output/bin/govulncheck-parser"
+
+if [[ ! -x "${PARSER}" ]]; then
+    echo "Building govulncheck-parser..."
+    make -C "${PROJECT_ROOT}" govulncheck-parser >/dev/null 2>&1
+fi
+
+echo "Scanning for ${CVE_ID}..."
+if ! OUTPUT=$(make -C "${PROJECT_ROOT}" govulncheck 2>&1); then
+    echo "Error: govulncheck scan failed:"
+    echo "${OUTPUT}" | tail -10
+    exit 2
+fi
+
+RESULT=$(echo "${OUTPUT}" | "${PARSER}" "${CVE_ID}") \
+    || { echo "Error: failed to parse govulncheck output"; exit 2; }
+
+case "${RESULT}" in
+    AFFECTED)
+        echo "AFFECTED: ${CVE_ID} — vulnerable code is reachable"
+        exit 1
+        ;;
+    NOT_REACHABLE)
+        echo "NOT AFFECTED: ${CVE_ID} — false positive (module is a dependency but vulnerable code is not reachable)"
+        exit 0
+        ;;
+    NOT_FOUND)
+        echo "NOT FOUND: ${CVE_ID} — no matching entry in govulncheck results (verify the CVE ID is correct)"
+        exit 0
+        ;;
+    *)
+        echo "Error: unexpected result from govulncheck parsing"
+        exit 2
+        ;;
+esac

--- a/tools/govulncheck-parser/main.go
+++ b/tools/govulncheck-parser/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	ResultAffected     = "AFFECTED"
+	ResultNotReachable = "NOT_REACHABLE"
+	ResultNotFound     = "NOT_FOUND"
+)
+
+type osvEntry struct {
+	ID      string   `json:"id"`
+	Aliases []string `json:"aliases"`
+}
+
+type findingEntry struct {
+	OSV string `json:"osv"`
+}
+
+type record struct {
+	OSV     *osvEntry     `json:"osv,omitempty"`
+	Finding *findingEntry `json:"finding,omitempty"`
+}
+
+func stripNonJSON(data []byte) []byte {
+	var buf bytes.Buffer
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 || trimmed[0] == '{' || trimmed[0] == '}' ||
+			trimmed[0] == '"' || trimmed[0] == '[' || trimmed[0] == ']' ||
+			trimmed[0] == ',' || (trimmed[0] >= '0' && trimmed[0] <= '9') ||
+			bytes.Equal(trimmed, []byte("true")) || bytes.Equal(trimmed, []byte("false")) ||
+			bytes.Equal(trimmed, []byte("null")) {
+			buf.Write(line)
+			buf.WriteByte('\n')
+		}
+	}
+	return buf.Bytes()
+}
+
+func CheckCVE(input io.Reader, cveID string) (string, error) {
+	raw, err := io.ReadAll(input)
+	if err != nil {
+		return "", fmt.Errorf("reading input: %w", err)
+	}
+
+	data := stripNonJSON(raw)
+	osvIDsForCVE := map[string]bool{}
+	findingOSVIDs := map[string]bool{}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	for {
+		var rec record
+		if err := decoder.Decode(&rec); err == io.EOF {
+			break
+		} else if err != nil {
+			break
+		}
+
+		if rec.OSV != nil {
+			for _, alias := range rec.OSV.Aliases {
+				if alias == cveID {
+					osvIDsForCVE[rec.OSV.ID] = true
+				}
+			}
+		}
+
+		if rec.Finding != nil && rec.Finding.OSV != "" {
+			findingOSVIDs[rec.Finding.OSV] = true
+		}
+	}
+
+	for id := range osvIDsForCVE {
+		if findingOSVIDs[id] {
+			return ResultAffected, nil
+		}
+	}
+
+	if len(osvIDsForCVE) > 0 {
+		return ResultNotReachable, nil
+	}
+
+	return ResultNotFound, nil
+}
+
+const (
+	expectedArgs   = 2
+	exitUsageError = 2
+)
+
+func main() {
+	if len(os.Args) != expectedArgs {
+		fmt.Fprintf(os.Stderr, "Usage: %s <CVE-ID>\n", os.Args[0])
+		os.Exit(exitUsageError)
+	}
+
+	result, err := CheckCVE(os.Stdin, os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(result)
+}

--- a/tools/govulncheck-parser/main_test.go
+++ b/tools/govulncheck-parser/main_test.go
@@ -1,0 +1,107 @@
+package main_test
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	parser "github.com/k8snetworkplumbingwg/kubemacpool/tools/govulncheck-parser"
+)
+
+func TestGovulncheckParser(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Govulncheck Parser Suite")
+}
+
+var _ = Describe("CheckCVE", func() {
+	type testCase struct {
+		input    string
+		cveID    string
+		expected string
+	}
+
+	DescribeTable("should correctly classify CVEs",
+		func(tc testCase) {
+			result, err := parser.CheckCVE(strings.NewReader(tc.input), tc.cveID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(tc.expected))
+		},
+		Entry("affected - CVE has matching OSV and finding", testCase{
+			cveID:    "CVE-2025-22868",
+			expected: parser.ResultAffected,
+			input: `{"config": {"scanner_name": "govulncheck"}}
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868"]}}
+{"finding": {"osv": "GO-2025-3488"}}`,
+		}),
+		Entry("not reachable - CVE has OSV but no finding", testCase{
+			cveID:    "CVE-2025-22868",
+			expected: parser.ResultNotReachable,
+			input: `{"config": {"scanner_name": "govulncheck"}}
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868"]}}`,
+		}),
+		Entry("not found - CVE not in any OSV entry", testCase{
+			cveID:    "CVE-9999-99999",
+			expected: parser.ResultNotFound,
+			input: `{"config": {"scanner_name": "govulncheck"}}
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868"]}}`,
+		}),
+		Entry("not found - empty output", testCase{
+			cveID:    "CVE-2025-22868",
+			expected: parser.ResultNotFound,
+			input:    `{"config": {"scanner_name": "govulncheck"}}`,
+		}),
+		Entry("affected - multiple OSV entries, one matches", testCase{
+			cveID:    "CVE-2025-22870",
+			expected: parser.ResultAffected,
+			input: `{"config": {"scanner_name": "govulncheck"}}
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868"]}}
+{"osv": {"id": "GO-2025-3503", "aliases": ["CVE-2025-22870"]}}
+{"finding": {"osv": "GO-2025-3503"}}`,
+		}),
+		Entry("not reachable - finding exists for different OSV", testCase{
+			cveID:    "CVE-2025-22868",
+			expected: parser.ResultNotReachable,
+			input: `{"config": {"scanner_name": "govulncheck"}}
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868"]}}
+{"osv": {"id": "GO-2025-3503", "aliases": ["CVE-2025-22870"]}}
+{"finding": {"osv": "GO-2025-3503"}}`,
+		}),
+		Entry("non-JSON lines before JSON are skipped", testCase{
+			cveID:    "CVE-2025-22868",
+			expected: parser.ResultNotReachable,
+			input: `/path/to/govulncheck -format json ./...
+{"config": {"scanner_name": "govulncheck"}}
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868"]}}`,
+		}),
+		Entry("non-JSON lines between JSON records are skipped", testCase{
+			cveID:    "CVE-2025-22868",
+			expected: parser.ResultAffected,
+			input: `some log line
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868"]}}
+another log line
+{"finding": {"osv": "GO-2025-3488"}}`,
+		}),
+		Entry("affected - CVE is one of multiple aliases", testCase{
+			cveID:    "CVE-2025-22868",
+			expected: parser.ResultAffected,
+			input: `{"config": {"scanner_name": "govulncheck"}}
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868", "GHSA-6v2p-p543-phr9"]}}
+{"finding": {"osv": "GO-2025-3488"}}`,
+		}),
+		Entry("empty finding.osv is ignored", testCase{
+			cveID:    "CVE-2025-22868",
+			expected: parser.ResultNotReachable,
+			input: `{"config": {"scanner_name": "govulncheck"}}
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868"]}}
+{"finding": {"osv": ""}}`,
+		}),
+		Entry("malformed JSON record stops parsing", testCase{
+			cveID:    "CVE-2025-22868",
+			expected: parser.ResultNotFound,
+			input: `{"osv": {"id": "BROKEN", "aliases": [INVALID]}}
+{"osv": {"id": "GO-2025-3488", "aliases": ["CVE-2025-22868"]}}`,
+		}),
+	)
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds tooling to detect CVE false positives from module-level scanners like Renovate.

Renovate flags CVEs at the Go **module** level, but the vulnerable **package/function** may not be compiled into kubemacpool. Go's official `govulncheck` [0] performs source-level call graph analysis and only reports CVEs where the vulnerable code is actually reachable.

This PR adds:
- `make govulncheck` — runs `govulncheck ./...` to scan all vulnerabilities at once
- `hack/check-cve.sh <CVE-ID>` — checks a specific CVE and reports whether it's a false positive

Example:
```
$ hack/check-cve.sh CVE-2025-22868
Scanning for CVE-2025-22868...
NOT AFFECTED: CVE-2025-22868 — false positive (vulnerable code is not reachable)
```

[0] https://go.dev/doc/security/vuln/

**Special notes for your reviewer**:

Tested across all stable branches (release-0.39 through release-0.45). All 12 open Renovate security PRs' CVEs were confirmed as false positives by govulncheck.

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local vulnerability scanning workflow with two commands: one to run scans and one to parse results.
  * Introduced a CVE-check script that accepts a `CVE-YYYY-NNNNN` input and reports whether it is **AFFECTED**, **NOT AFFECTED** (not reachable), or **NOT FOUND**.
* **Bug Fixes**
  * Improved result parsing to tolerate mixed scan output (non-JSON lines) and handle parsing edge cases more reliably.
* **Tests**
  * Added automated test coverage for CVE classification scenarios and parser robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->