### PR TITLE
CI Failure: pull-kubemacpool-unit-test / The unit test job failed because the Makefile attempts to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ KUSTOMIZE := GOFLAGS=-mod=mod $(GO) run sigs.k8s.io/kustomize/kustomize/v4@v4.5.
 CONTROLLER_GEN := GOFLAGS=-mod=mod $(GO) run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
 GOFMT := GOFLAGS=-mod=mod $(GO)fmt
 VET := GOFLAGS=-mod=mod $(GO) vet
-DEEPCOPY_GEN := GOFLAGS=-mod=mod $(GO) install k8s.io/code-generator/cmd/deepcopy-gen@latest
+DEEPCOPY_GEN := GOFLAGS=-mod=mod $(GO) install k8s.io/code-generator/cmd/deepcopy-gen@v0.34.1
 GO_VERSION = $(shell hack/go-version.sh)
 GOLANGCI_LINT_VERSION := v2.10.1
 GOLANGCI_LINT_BIN := $(BIN_DIR)/golangci-lint


### PR DESCRIPTION
Fixes #654

**What this PR does / why we need it**:

This PR fixes a CI failure in the `pull-kubemacpool-unit-test` job by pinning the `deepcopy-gen` tool version in the Makefile to match the version specified in `go.mod`.

The issue occurred because:
- The Makefile used `@latest` for installing `k8s.io/code-generator/cmd/deepcopy-gen`, which resolved to v0.36.2
- v0.36.2 requires Go 1.26+, but the project uses Go 1.25.12
- The `go.mod` pins `k8s.io/code-generator` to v0.34.1 (compatible with Go 1.25)
- This version mismatch triggered Go's automatic toolchain switch to Go 1.26.5, causing the CI job to fail

The fix pins `deepcopy-gen` to `v0.34.1` in the Makefile, ensuring consistency with the dependency version in `go.mod`.

**Special notes for your reviewer**:

This is a build configuration fix with no runtime code changes. The change ensures that the development tool version matches the pinned dependency version, preventing unexpected Go toolchain switches during CI builds.

**Release note**:
```release-note
NONE
```

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:439b5a3 -->