### PR TITLE
tests: Pin cirros image to tag v1.9.0

### DIFF
--- a/tests/tests.go
+++ b/tests/tests.go
@@ -671,7 +671,7 @@ func getVMCirros() *kubevirtv1.VirtualMachine {
 							Name: "containerdisk",
 							VolumeSource: kubevirtv1.VolumeSource{
 								ContainerDisk: &kubevirtv1.ContainerDiskSource{
-									Image: "quay.io/kubevirt/cirros-container-disk-demo:latest",
+									Image: "quay.io/kubevirt/cirros-container-disk-demo:v1.9.0",
 								},
 							},
 						},

--- a/tests/vmi.go
+++ b/tests/vmi.go
@@ -83,7 +83,7 @@ func NewVMI(namespace, name string, opts ...VMIOption) *kubevirtv1.VirtualMachin
 					Name: "containerdisk",
 					VolumeSource: kubevirtv1.VolumeSource{
 						ContainerDisk: &kubevirtv1.ContainerDiskSource{
-							Image: "quay.io/kubevirt/cirros-container-disk-demo:latest",
+							Image: "quay.io/kubevirt/cirros-container-disk-demo:v1.9.0",
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
quay.io/kubevirt/cirros-container-disk-demo:latest is no longer available. 
This PR pins to stable tag v1.9.0


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the default test virtual machine disk image to CirrOS version 1.9.0 for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->