### PR TITLE
Enable configuring TLS groups

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -153,18 +153,22 @@ func runCertManager() {
 func runKubemacpoolManager() {
 	var logType, metricsAddr string
 	var waitingTime int
-	var tlsMinVersion, tlsCiphers string
+	var tlsMinVersion, tlsCiphers, tlsGroups string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&logType, "v", "production", "Log type (debug/production).")
 	flag.IntVar(&waitingTime, names.WAIT_TIME_ARG, 600, "waiting time to release the mac if object was not created")
 	flag.StringVar(&tlsMinVersion, "tls-min-version", "VersionTLS13", "Minimum TLS version. "+
-		"Supported values are tls package constants names (e.g. VersionTLS13), please see "+
+		"Supported values are Go crypto/tls package constants names (e.g. VersionTLS13), please see "+
 		"https://pkg.go.dev/crypto/tls#pkg-constants.")
 	flag.StringVar(&tlsCiphers, "tls-cipher-suites", "", "Comma-separated list of TLS cipher suite names. "+
-		"Supported values are tls package constants names (e.g. TLS_AES_128_GCM_SHA256), please see "+
+		"Supported values are Go crypto/tls package constants names (e.g. TLS_AES_128_GCM_SHA256), please see "+
 		"https://pkg.go.dev/crypto/tls#pkg-constants. "+
 		"When 'tls-min-version' is 'VersionTLS13', cipher suites are selected by the runtime.")
+	flag.StringVar(&tlsGroups, "tls-group-preferences", "", "Comma-separated list of TLS group names (key exchange mechanism). "+
+		"Supported values are Go crypto/tls package constants names (e.g. CurveP256) "+
+		"please see https://pkg.go.dev/crypto/tls#CurveID`, "+
+		"When unset or given unknown values, TLS groups are selected by the runtime.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(logType != "production")))
@@ -195,7 +199,7 @@ func runKubemacpoolManager() {
 		os.Exit(1)
 	}
 
-	tlsConfig, err := kmptls.NewConfig(tlsMinVersion, tlsCiphers)
+	tlsConfig, err := kmptls.NewConfig(tlsMinVersion, tlsCiphers, tlsGroups)
 	if err != nil {
 		log.Error(err, "Failed to create TLS config")
 		os.Exit(1)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -235,6 +235,7 @@ func (k *KubeMacPoolManager) initRuntimeManager(isKubevirtInstalled bool) error 
 			TLSOpts: []func(*tls.Config){func(cfg *tls.Config) {
 				cfg.CipherSuites = k.tlsConfig.CipherSuites
 				cfg.MinVersion = k.tlsConfig.MinTLSVersion
+				cfg.CurvePreferences = k.tlsConfig.GroupPreferences
 			}},
 		},
 		Cache: cacheOptions,

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -7,24 +7,30 @@ import (
 )
 
 type Config struct {
-	CipherSuites  []uint16
-	MinTLSVersion uint16
+	CipherSuites     []uint16
+	MinTLSVersion    uint16
+	GroupPreferences []tls.CurveID
 }
 
-func NewConfig(minTLSVersion, cipherSuites, _ string) (*Config, error) {
+// NewConfig can be used for aggregating raw Go crypto TLS parameters.
+// The returned type can be used for overriding Go crypto/tls Config{} parameters.
+func NewConfig(minTLSVersion, cipherSuites, groups string) (*Config, error) {
 	minTLSVersionID, err := versionByName(minTLSVersion)
 	if err != nil {
 		return nil, err
 	}
 
 	cipherSuitesIDs := tlsCipherSuites(strings.Split(cipherSuites, ","))
+	tlsGroupIDs := tlsGroups(strings.Split(groups, ","))
 
 	return &Config{
-		MinTLSVersion: minTLSVersionID,
-		CipherSuites:  cipherSuitesIDs,
+		MinTLSVersion:    minTLSVersionID,
+		CipherSuites:     cipherSuitesIDs,
+		GroupPreferences: tlsGroupIDs,
 	}, nil
 }
 
+// versionByName converts Go crypto/tls contant names of TLS version to standard TLS version ID
 func versionByName(name string) (uint16, error) {
 	versions := map[string]uint16{
 		"VersionTLS10": tls.VersionTLS10,
@@ -51,6 +57,30 @@ func tlsCipherSuites(cipherSuitesNames []string) []uint16 {
 
 	var ids []uint16
 	for _, name := range cipherSuitesNames {
+		if id, ok := idByName[name]; ok {
+			ids = append(ids, id)
+		}
+	}
+
+	return ids
+}
+
+// tlsGroups translate comma-speared list of Go crypto/tls's TLS group constant names to
+// TLS curve IDs matching tls.Config.CurvePreferences.
+// Unknown groups are silently skipped, in case all groups are unknown TLS groups is
+// selected by the runtime.
+func tlsGroups(tlsGroupNames []string) []tls.CurveID {
+	idByName := map[string]tls.CurveID{
+		"CurveP256":          tls.CurveP256,
+		"CurveP384":          tls.CurveP384,
+		"CurveP521":          tls.CurveP521,
+		"X25519":             tls.X25519,
+		"X25519MLKEM768":     tls.X25519MLKEM768,
+		"SecP256r1MLKEM768":  tls.SecP256r1MLKEM768,
+		"SecP384r1MLKEM1024": tls.SecP384r1MLKEM1024,
+	}
+	var ids []tls.CurveID
+	for _, name := range tlsGroupNames {
 		if id, ok := idByName[name]; ok {
 			ids = append(ids, id)
 		}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -11,7 +11,7 @@ type Config struct {
 	MinTLSVersion uint16
 }
 
-func NewConfig(minTLSVersion, cipherSuites string) (*Config, error) {
+func NewConfig(minTLSVersion, cipherSuites, _ string) (*Config, error) {
 	minTLSVersionID, err := versionByName(minTLSVersion)
 	if err != nil {
 		return nil, err

--- a/pkg/tls/tls_suite_test.go
+++ b/pkg/tls/tls_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTls(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS Suite")
+}

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The KubeMacPool Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls_test
+
+import (
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kmptls "github.com/k8snetworkplumbingwg/kubemacpool/pkg/tls"
+)
+
+var _ = Describe("NewConfig", func() {
+	It("Should fail given unknown min TLS version", func() {
+		_, err := kmptls.NewConfig("VersionTLS99", "TLS_AES_128_GCM_SHA256", "X25519MLKEM768")
+		Expect(err).To(HaveOccurred())
+	})
+
+	DescribeTable("should return valid crypto package TLS parameters, given",
+		func(
+			minVersion, cipherSuites, groups string,
+			expectedCfg *kmptls.Config,
+		) {
+			cfg, err := kmptls.NewConfig(minVersion, cipherSuites, groups)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).To(Equal(expectedCfg))
+		},
+		Entry("TLS min version 1.0",
+			"VersionTLS10", "", "",
+			&kmptls.Config{MinTLSVersion: tls.VersionTLS10},
+		),
+		Entry("TLS min version 1.1",
+			"VersionTLS11", "", "",
+			&kmptls.Config{MinTLSVersion: tls.VersionTLS11},
+		),
+		Entry("TLS min version 1.2",
+			"VersionTLS12", "", "",
+			&kmptls.Config{MinTLSVersion: tls.VersionTLS12},
+		),
+		Entry("TLS min version 1.3",
+			"VersionTLS13", "", "",
+			&kmptls.Config{MinTLSVersion: tls.VersionTLS13},
+		),
+		Entry("unknown cipher-suite, should skip unknown cipher-suites",
+			"VersionTLS13",
+			"unkownCipherA,TLS_AES_128_GCM_SHA256,unkownCipherB,unkownCipherC",
+			"",
+			&kmptls.Config{
+				MinTLSVersion: tls.VersionTLS13,
+				CipherSuites:  []uint16{tls.TLS_AES_128_GCM_SHA256},
+			},
+		),
+		Entry("unknown groups, should skip unknown groups",
+			"VersionTLS13",
+			"TLS_AES_128_GCM_SHA256",
+			",unknownGroupA,X25519MLKEM768,unknownGroupB,unknownGroupC",
+			&kmptls.Config{
+				MinTLSVersion:    tls.VersionTLS13,
+				CipherSuites:     []uint16{tls.TLS_AES_128_GCM_SHA256},
+				GroupPreferences: []tls.CurveID{tls.X25519MLKEM768},
+			},
+		),
+		Entry("modern TLS settings",
+			"VersionTLS13",
+			"TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256",
+			"X25519MLKEM768,X25519,SecP256r1MLKEM768,SecP384r1MLKEM1024",
+			&kmptls.Config{
+				MinTLSVersion:    tls.VersionTLS13,
+				CipherSuites:     []uint16{tls.TLS_AES_128_GCM_SHA256, tls.TLS_AES_256_GCM_SHA384, tls.TLS_CHACHA20_POLY1305_SHA256},
+				GroupPreferences: []tls.CurveID{tls.X25519MLKEM768, tls.X25519, tls.SecP256r1MLKEM768, tls.SecP384r1MLKEM1024},
+			},
+		),
+	)
+})

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -57,6 +57,7 @@ func AddToManager(mgr manager.Manager, poolManager *pool_manager.PoolManager) er
 		TLSOpts: []func(*tls.Config){func(tlsConfig *tls.Config) {
 			tlsConfig.CipherSuites = cfg.CipherSuites
 			tlsConfig.MinVersion = cfg.MinTLSVersion
+			tlsConfig.CurvePreferences = cfg.GroupPreferences
 		}},
 	})
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

Enable configuring the project server endpoints TLS groups for better TLS security posture.

https://redhat.atlassian.net/browse/CNV-85326

**Special notes for your reviewer**:
The PR introduce new flag `tls-group-preferences` expecting comma-separated Go crypto/tls TLS groups constant names. Similar to TLS ciphers example.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
It is now possible to configure TLS groups according to the cluster TLS security profile, via flag `tls-group-preferences`
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added the `--tls-group-preferences` option for configuring preferred TLS key-exchange groups.
* Supports recognized Go TLS group names to customize secure connection negotiation.
* Applies selected TLS group preferences across supported metrics and webhook services.

## Bug Fixes

* Unknown TLS group names are safely ignored without preventing startup.
* Improved consistency of TLS settings across secure connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->