### PR TITLE
Bump go 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/k8snetworkplumbingwg/kubemacpool
 
-// allowed_go 1.25
-go 1.25.0
+// allowed_go 1.26
+go 1.26.0
 
-toolchain go1.25.12
+toolchain go1.26.6
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:
 This PR bumps go to 1.26

**Special notes for your reviewer**:
Along many improvements, newer Go version support additional TLS groups for post-quantum cryptography (PQC) readiness [1].
PQC readiness is crucial for our d/s product (Openshift).

[1] https://go.dev/doc/go1.26#:~:text=crypto/tls,post-quantum%20key%20exchanges

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
vendor: bump go to 1.26
```
